### PR TITLE
chore: Streamline a few property names in 'Loan' and 'Loan Application‘

### DIFF
--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -52,7 +52,7 @@
     "interest_income_account",
     "penalty_income_account",
     "section_break_17",
-    "total_payment",
+    "total_amount_payable",
     "total_principal_paid",
     "written_off_amount",
     "refund_amount",
@@ -189,7 +189,7 @@
     },
     {
     "depends_on": "is_term_loan",
-    "fetch_from": "loan_application.repayment_amount",
+    "fetch_from": "loan_application.monthly_repayment_amount",
     "fetch_if_empty": 1,
     "fieldname": "monthly_repayment_amount",
     "fieldtype": "Currency",
@@ -249,9 +249,9 @@
     },
     {
     "default": "0",
-    "fieldname": "total_payment",
+    "fieldname": "total_amount_payable",
     "fieldtype": "Currency",
-    "label": "Total Payable Amount",
+    "label": "Total Amount Payable",
     "no_copy": 1,
     "options": "Company:company:default_currency",
     "read_only": 1

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -129,7 +129,7 @@ class TestLoan(unittest.TestCase):
 
 		self.assertEqual(loan_repayment_schedule.monthly_repayment_amount, 15052)
 		self.assertEqual(flt(loan.total_interest_payable, 0), 21034)
-		self.assertEqual(flt(loan.total_payment, 0), 301034)
+		self.assertEqual(flt(loan.total_amount_payable, 0), 301034)
 		self.assertEqual(len(schedule), 20)
 
 		for idx, principal_amount, interest_amount, balance_loan_amount in [
@@ -151,7 +151,7 @@ class TestLoan(unittest.TestCase):
 
 		self.assertEqual(len(loan_repayment_schedule.repayment_schedule), 22)
 		self.assertEqual(flt(loan.total_interest_payable, 0), 22712)
-		self.assertEqual(flt(loan.total_payment, 0), 302712)
+		self.assertEqual(flt(loan.total_amount_payable, 0), 302712)
 
 	def test_loan_with_security(self):
 		pledge = [

--- a/lending/loan_management/doctype/loan_application/loan_application.js
+++ b/lending/loan_management/doctype/loan_application/loan_application.js
@@ -23,16 +23,16 @@ frappe.ui.form.on('Loan Application', {
 		});
 	},
 	repayment_method: function(frm) {
-		frm.doc.repayment_amount = frm.doc.repayment_periods = "";
+		frm.doc.monthly_repayment_amount = frm.doc.repayment_periods = "";
 		frm.trigger("toggle_fields");
 		frm.trigger("toggle_required");
 	},
 	toggle_fields: function(frm) {
-		frm.toggle_enable("repayment_amount", frm.doc.repayment_method=="Repay Fixed Amount per Period")
+		frm.toggle_enable("monthly_repayment_amount", frm.doc.repayment_method=="Repay Fixed Amount per Period")
 		frm.toggle_enable("repayment_periods", frm.doc.repayment_method=="Repay Over Number of Periods")
 	},
 	toggle_required: function(frm){
-		frm.toggle_reqd("repayment_amount", cint(frm.doc.repayment_method=='Repay Fixed Amount per Period'))
+		frm.toggle_reqd("monthly_repayment_amount", cint(frm.doc.repayment_method=='Repay Fixed Amount per Period'))
 		frm.toggle_reqd("repayment_periods", cint(frm.doc.repayment_method=='Repay Over Number of Periods'))
 	},
 	add_toolbar_buttons: function(frm) {

--- a/lending/loan_management/doctype/loan_application/loan_application.json
+++ b/lending/loan_management/doctype/loan_application/loan_application.json
@@ -26,11 +26,11 @@
   "maximum_loan_amount",
   "repayment_info",
   "repayment_method",
-  "total_payable_amount",
+  "total_amount_payable",
   "column_break_11",
   "repayment_periods",
-  "repayment_amount",
-  "total_payable_interest",
+  "monthly_repayment_amount",
+  "total_interest_payable",
   "amended_from"
  ],
  "fields": [
@@ -138,9 +138,9 @@
   },
   {
    "depends_on": "is_term_loan",
-   "fieldname": "total_payable_interest",
+   "fieldname": "total_interest_payable",
    "fieldtype": "Currency",
-   "label": "Total Payable Interest",
+   "label": "Total Interest Payable",
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -150,7 +150,7 @@
   },
   {
    "depends_on": "repayment_method",
-   "fieldname": "repayment_amount",
+   "fieldname": "monthly_repayment_amount",
    "fieldtype": "Currency",
    "label": "Monthly Repayment Amount",
    "options": "Company:company:default_currency"
@@ -162,9 +162,9 @@
    "label": "Repayment Period in Months"
   },
   {
-   "fieldname": "total_payable_amount",
+   "fieldname": "total_amount_payable",
    "fieldtype": "Currency",
-   "label": "Total Payable Amount",
+   "label": "Total Amount Payable",
    "options": "Company:company:default_currency",
    "read_only": 1
   },

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -106,7 +106,7 @@ class LoanApplication(Document):
 
 		if self.is_term_loan:
 			if self.repayment_method == "Repay Over Number of Periods":
-				self.repayment_amount = get_monthly_repayment_amount(
+				self.monthly_repayment_amount = get_monthly_repayment_amount(
 					self.loan_amount, self.rate_of_interest, self.repayment_periods
 				)
 
@@ -114,31 +114,31 @@ class LoanApplication(Document):
 				monthly_interest_rate = flt(self.rate_of_interest) / (12 * 100)
 				if monthly_interest_rate:
 					min_repayment_amount = self.loan_amount * monthly_interest_rate
-					if self.repayment_amount - min_repayment_amount <= 0:
+					if self.monthly_repayment_amount - min_repayment_amount <= 0:
 						frappe.throw(_("Repayment Amount must be greater than " + str(flt(min_repayment_amount, 2))))
 					self.repayment_periods = math.ceil(
-						(math.log(self.repayment_amount) - math.log(self.repayment_amount - min_repayment_amount))
+						(math.log(self.monthly_repayment_amount) - math.log(self.monthly_repayment_amount - min_repayment_amount))
 						/ (math.log(1 + monthly_interest_rate))
 					)
 				else:
-					self.repayment_periods = self.loan_amount / self.repayment_amount
+					self.repayment_periods = self.loan_amount / self.monthly_repayment_amount
 
 			self.calculate_payable_amount()
 		else:
-			self.total_payable_amount = self.loan_amount
+			self.total_amount_payable = self.loan_amount
 
 	def calculate_payable_amount(self):
 		balance_amount = self.loan_amount
-		self.total_payable_amount = 0
-		self.total_payable_interest = 0
+		self.total_amount_payable = 0
+		self.total_interest_payable = 0
 
 		while balance_amount > 0:
 			interest_amount = rounded(balance_amount * flt(self.rate_of_interest) / (12 * 100))
-			balance_amount = rounded(balance_amount + interest_amount - self.repayment_amount)
+			balance_amount = rounded(balance_amount + interest_amount - self.monthly_repayment_amount)
 
-			self.total_payable_interest += interest_amount
+			self.total_interest_payable += interest_amount
 
-		self.total_payable_amount = self.loan_amount + self.total_payable_interest
+		self.total_amount_payable = self.loan_amount + self.total_interest_payable
 
 	def set_loan_amount(self):
 		if self.is_secured_loan and not self.proposed_pledges:

--- a/lending/loan_management/doctype/loan_application/test_loan_application.py
+++ b/lending/loan_management/doctype/loan_application/test_loan_application.py
@@ -49,14 +49,14 @@ class TestLoanApplication(unittest.TestCase):
 	def test_loan_totals(self):
 		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
 
-		self.assertEqual(loan_application.total_payable_interest, 18599)
-		self.assertEqual(loan_application.total_payable_amount, 268599)
-		self.assertEqual(loan_application.repayment_amount, 14923)
+		self.assertEqual(loan_application.total_interest_payable, 18599)
+		self.assertEqual(loan_application.total_amount_payable, 268599)
+		self.assertEqual(loan_application.monthly_repayment_amount, 14923)
 
 		loan_application.repayment_periods = 24
 		loan_application.save()
 		loan_application.reload()
 
-		self.assertEqual(loan_application.total_payable_interest, 24657)
-		self.assertEqual(loan_application.total_payable_amount, 274657)
-		self.assertEqual(loan_application.repayment_amount, 11445)
+		self.assertEqual(loan_application.total_interest_payable, 24657)
+		self.assertEqual(loan_application.total_amount_payable, 274657)
+		self.assertEqual(loan_application.monthly_repayment_amount, 11445)

--- a/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.py
+++ b/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.py
@@ -61,7 +61,7 @@ class LoanBalanceAdjustment(AccountsController):
 				"loan_amount",
 				"credit_adjustment_amount",
 				"debit_adjustment_amount",
-				"total_payment",
+				"total_amount_payable",
 				"total_principal_paid",
 				"total_interest_payable",
 				"status",

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -176,7 +176,7 @@ def make_accrual_interest_entry_for_demand_loans(
 			"Loan",
 			fields=[
 				"name",
-				"total_payment",
+				"total_amount_payable",
 				"total_amount_paid",
 				"debit_adjustment_amount",
 				"credit_adjustment_amount",
@@ -257,7 +257,7 @@ def get_term_loans(date, term_loan=None, loan_type=None):
 		.on(loan_repayment_schedule.parent == loan_schedule.name)
 		.select(
 			loan.name,
-			loan.total_payment,
+			loan.total_amount_payable,
 			loan.total_amount_paid,
 			loan.loan_account,
 			loan.interest_income_account,

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -223,7 +223,7 @@ class LoanRepayment(AccountsController):
 				"total_principal_paid",
 				"status",
 				"is_secured_loan",
-				"total_payment",
+				"total_amount_payable",
 				"debit_adjustment_amount",
 				"credit_adjustment_amount",
 				"refund_amount",
@@ -278,7 +278,7 @@ class LoanRepayment(AccountsController):
 				"total_principal_paid",
 				"status",
 				"is_secured_loan",
-				"total_payment",
+				"total_amount_payable",
 				"loan_amount",
 				"disbursed_amount",
 				"total_interest_payable",
@@ -991,7 +991,7 @@ def regenerate_repayment_schedule(loan, cancel=0):
 		else:
 			accrued_entries += 1
 			if last_repayment_amount is None:
-				last_repayment_amount = term.total_payment
+				last_repayment_amount = term.total_amount_payable
 			if last_balance_amount is None:
 				last_balance_amount = term.balance_loan_amount
 
@@ -1023,14 +1023,14 @@ def regenerate_repayment_schedule(loan, cancel=0):
 			principal_amount += balance_amount
 			balance_amount = 0.0
 
-		total_payment = principal_amount + interest_amount
+		total_amount_payable = principal_amount + interest_amount
 		loan_doc.append(
 			"repayment_schedule",
 			{
 				"payment_date": payment_date,
 				"principal_amount": principal_amount,
 				"interest_amount": interest_amount,
-				"total_payment": total_payment,
+				"total_amount_payable": total_amount_payable,
 				"balance_loan_amount": balance_amount,
 			},
 		)
@@ -1043,7 +1043,7 @@ def regenerate_repayment_schedule(loan, cancel=0):
 def get_pending_principal_amount(loan):
 	if loan.status in ("Disbursed", "Closed") or loan.disbursed_amount >= loan.loan_amount:
 		pending_principal_amount = (
-			flt(loan.total_payment)
+			flt(loan.total_amount_payable)
 			+ flt(loan.debit_adjustment_amount)
 			- flt(loan.credit_adjustment_amount)
 			- flt(loan.total_principal_paid)

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -42,7 +42,7 @@ class LoanRepaymentSchedule(Document):
 		carry_forward_interest = self.adjusted_interest
 
 		while balance_amount > 0:
-			interest_amount, principal_amount, balance_amount, total_payment, days = self.get_amounts(
+			interest_amount, principal_amount, balance_amount, total_amount_payable, days = self.get_amounts(
 				payment_date,
 				balance_amount,
 				schedule_type_details.repayment_schedule_type,
@@ -59,7 +59,7 @@ class LoanRepaymentSchedule(Document):
 				payment_date = next_payment_date
 
 			self.add_repayment_schedule_row(
-				payment_date, principal_amount, interest_amount, total_payment, balance_amount, days
+				payment_date, principal_amount, interest_amount, total_amount_payable, balance_amount, days
 			)
 
 			if (
@@ -68,7 +68,7 @@ class LoanRepaymentSchedule(Document):
 			):
 				self.get("repayment_schedule")[-1].principal_amount += balance_amount
 				self.get("repayment_schedule")[-1].balance_loan_amount = 0
-				self.get("repayment_schedule")[-1].total_payment = (
+				self.get("repayment_schedule")[-1].total_amount_payable = (
 					self.get("repayment_schedule")[-1].interest_amount
 					+ self.get("repayment_schedule")[-1].principal_amount
 				)
@@ -136,12 +136,12 @@ class LoanRepaymentSchedule(Document):
 		if carry_forward_interest:
 			interest_amount += carry_forward_interest
 
-		total_payment = principal_amount + interest_amount
+		total_amount_payable = principal_amount + interest_amount
 
-		return interest_amount, principal_amount, balance_amount, total_payment, days
+		return interest_amount, principal_amount, balance_amount, total_amount_payable, days
 
 	def add_repayment_schedule_row(
-		self, payment_date, principal_amount, interest_amount, total_payment, balance_loan_amount, days
+		self, payment_date, principal_amount, interest_amount, total_amount_payable, balance_loan_amount, days
 	):
 		self.append(
 			"repayment_schedule",
@@ -150,7 +150,7 @@ class LoanRepaymentSchedule(Document):
 				"payment_date": payment_date,
 				"principal_amount": principal_amount,
 				"interest_amount": interest_amount,
-				"total_payment": total_payment,
+				"total_amount_payable": total_amount_payable,
 				"balance_loan_amount": balance_loan_amount,
 			},
 		)

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -576,7 +576,7 @@ class LoanRestructure(AccountsController):
 			schedule.insert()
 
 	def update_totals(self, cancel=0):
-		total_payment = 0
+		total_amount_payable = 0
 		total_interest_payable = 0
 
 		if not cancel:
@@ -587,7 +587,7 @@ class LoanRestructure(AccountsController):
 		schedule = frappe.get_doc("Loan Repayment Schedule", filters)
 
 		for data in schedule.repayment_schedule:
-			total_payment += data.total_payment
+			total_amount_payable += data.total_amount_payable
 			total_interest_payable += data.interest_amount
 
 		total_principal_paid = 0
@@ -608,7 +608,7 @@ class LoanRestructure(AccountsController):
 				"loan_amount": loan_amount,
 				"rate_of_interest": self.new_rate_of_interest,
 				"monthly_repayment_amount": monthly_repayment_amount,
-				"total_payment": total_payment,
+				"total_amount_payable": total_amount_payable,
 				"total_interest_payable": total_interest_payable,
 				"total_principal_paid": total_principal_paid,
 				"total_amount_paid": total_amount_paid,

--- a/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
+++ b/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
@@ -79,7 +79,7 @@ def check_for_ltv_shortfall(process_loan_security_shortfall):
 			"name",
 			"loan_amount",
 			"total_principal_paid",
-			"total_payment",
+			"total_amount_payable",
 			"total_interest_payable",
 			"disbursed_amount",
 			"status",
@@ -98,7 +98,7 @@ def check_for_ltv_shortfall(process_loan_security_shortfall):
 	for loan in loans:
 		if loan.status == "Disbursed":
 			outstanding_amount = (
-				flt(loan.total_payment) - flt(loan.total_interest_payable) - flt(loan.total_principal_paid)
+				flt(loan.total_amount_payable) - flt(loan.total_interest_payable) - flt(loan.total_principal_paid)
 			)
 		else:
 			outstanding_amount = (

--- a/lending/loan_management/doctype/loan_security_unpledge/loan_security_unpledge.py
+++ b/lending/loan_management/doctype/loan_security_unpledge/loan_security_unpledge.py
@@ -56,7 +56,7 @@ class LoanSecurityUnpledge(Document):
 			"Loan",
 			self.loan,
 			[
-				"total_payment",
+				"total_amount_payable",
 				"debit_adjustment_amount",
 				"credit_adjustment_amount",
 				"refund_amount",

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.js
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.js
@@ -23,10 +23,10 @@ frappe.ui.form.on('Loan Write Off', {
 	},
 	show_pending_principal_amount: function(frm) {
 		if (frm.doc.loan && frm.doc.docstatus === 0) {
-			frappe.db.get_value('Loan', frm.doc.loan, ['total_payment', 'total_interest_payable',
+			frappe.db.get_value('Loan', frm.doc.loan, ['total_amount_payable', 'total_interest_payable',
 				'total_principal_paid', 'written_off_amount'], function(values) {
 				frm.set_df_property('write_off_amount', 'description',
-					"Pending principal amount is " + cstr(flt(values.total_payment - values.total_interest_payable
+					"Pending principal amount is " + cstr(flt(values.total_amount_payable - values.total_interest_payable
 						- values.total_principal_paid - values.written_off_amount, 2)));
 				frm.refresh_field('write_off_amount');
 			});

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -31,7 +31,7 @@ class LoanWriteOff(AccountsController):
 			"Loan",
 			self.loan,
 			[
-				"total_payment",
+				"total_amount_payable",
 				"debit_adjustment_amount",
 				"credit_adjustment_amount",
 				"refund_amount",

--- a/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.py
+++ b/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.py
@@ -132,14 +132,14 @@ def get_outstanding_pos(branch, company, delinquent=0):
 		"Loan",
 		filters,
 		[
-			"sum(total_payment) as total_payment",
+			"sum(total_amount_payable) as total_amount_payable",
 			"sum(total_principal_paid) as total_principal_paid",
 			"sum(total_interest_payable) as total_interest_payable",
 		],
 		as_dict=1,
 	)
 
-	return flt(pos.total_payment) - flt(pos.total_principal_paid) - flt(pos.total_interest_payable)
+	return flt(pos.total_amount_payable) - flt(pos.total_principal_paid) - flt(pos.total_interest_payable)
 
 
 def get_utilized_limit(branch, company, delinquent=0):

--- a/lending/loan_management/doctype/repayment_schedule/repayment_schedule.json
+++ b/lending/loan_management/doctype/repayment_schedule/repayment_schedule.json
@@ -9,7 +9,7 @@
     "number_of_days",
     "principal_amount",
     "interest_amount",
-    "total_payment",
+    "total_amount_payable",
     "balance_loan_amount",
     "is_accrued"
 ],
@@ -43,10 +43,10 @@
     },
     {
     "columns": 2,
-    "fieldname": "total_payment",
+    "fieldname": "total_amount_payable",
     "fieldtype": "Currency",
     "in_list_view": 1,
-    "label": "Total Payment",
+    "label": "Total Amount Payable",
     "options": "Company:company:default_currency",
     "read_only": 1
     },

--- a/lending/loan_management/report/loan_interest_report/loan_interest_report.py
+++ b/lending/loan_management/report/loan_interest_report/loan_interest_report.py
@@ -164,7 +164,7 @@ def get_active_loan_details(filters):
 			"loan_type",
 			"disbursed_amount",
 			"rate_of_interest",
-			"total_payment",
+			"total_amount_payable",
 			"total_principal_paid",
 			"total_interest_payable",
 			"written_off_amount",
@@ -185,12 +185,12 @@ def get_active_loan_details(filters):
 	currency = erpnext.get_company_currency(filters.get("company"))
 
 	for loan in loan_details:
-		total_payment = loan.total_payment if loan.status == "Disbursed" else loan.disbursed_amount
+		total_amount_payable = loan.total_amount_payable if loan.status == "Disbursed" else loan.disbursed_amount
 
 		loan.update(
 			{
 				"sanctioned_amount": flt(sanctioned_amount_map.get(loan.applicant_name)),
-				"principal_outstanding": flt(total_payment)
+				"principal_outstanding": flt(total_amount_payable)
 				- flt(loan.total_principal_paid)
 				- flt(loan.total_interest_payable)
 				- flt(loan.written_off_amount),


### PR DESCRIPTION
I thought this would fix #24, but it doesn‘t.

Nevertheless I didn’t want to throw away the commit and still think it‘d make quite a lot of sense to streamline a few property names in the Loan and Loan Application doctypes and settle with:

- `total_amount_payable`
- `total_interest_payable`
- `monthly_repayment_amount`

I think I caught all occurences. Still needs a patch though.
Feel free to review and propose better names or propose a few more properties to be streamlined! 