### PR TITLE
fix: fetch logic for repay_from_salary in loan_repayment

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.js
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.js
@@ -5,8 +5,12 @@ lending.common.setup_filters("Loan Repayment");
 
 frappe.ui.form.on('Loan Repayment', {
 	setup(frm) {
+		if (frappe.meta.has_field("Loan Repayment", "repay_from_salary")) {
+			frm.add_fetch("against_loan", "repay_from_salary", "repay_from_salary");
+		}
 		frm.ignore_doctypes_on_cancel_all = ["Process Loan Asset Classification"];
 	},
+
 	onload: function(frm) {
 		frm.set_query('against_loan', function() {
 			return {

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -275,6 +275,7 @@
     "label": "Accounting Details"
     },
     {
+    "depends_on": "eval:!doc.repay_from_salary",
     "fetch_from": "against_loan.payment_account",
     "fetch_if_empty": 1,
     "fieldname": "payment_account",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -145,6 +145,12 @@ class LoanRepayment(AccountsController):
 		if amounts.get("due_date"):
 			self.due_date = amounts.get("due_date")
 
+		if hasattr(self, "repay_from_salary") and hasattr(self, "payroll_payable_account"):
+			if self.repay_from_salary and not self.payroll_payable_account:
+				frappe.throw(_("Please set Payroll Payable Account in Loan Repayment"))
+			elif not self.repay_from_salary and self.payroll_payable_account:
+				self.repay_from_salary = 1
+
 	def check_future_entries(self):
 		future_repayment_date = frappe.db.get_value(
 			"Loan Repayment",


### PR DESCRIPTION
Currently checkboxes with `fetch_from` and `fetch_if_empty` set (like `repay_from_salary` check in `loan_repayment` doctype) don't work in the framework. We [tried](https://github.com/frappe/frappe/pull/22442) to fix it in the framework but we haven't come up with a solution which won't break lots of custom code. This PR fixes the issue until we come up with a long-term fix.