### PR TITLE
fix: Repayment amount validation

### DIFF
--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -42,9 +42,9 @@ class LoanApplication(Document):
 			frappe.throw(_("Please enter Repayment Periods"))
 
 		if self.repayment_method == "Repay Fixed Amount per Period":
-			if not self.monthly_repayment_amount:
+			if not self.repayment_amount:
 				frappe.throw(_("Please enter repayment Amount"))
-			if self.monthly_repayment_amount > self.loan_amount:
+			if self.repayment_amount > self.loan_amount:
 				frappe.throw(_("Monthly Repayment Amount cannot be greater than Loan Amount"))
 
 	def validate_loan_type(self):


### PR DESCRIPTION
In the Loan Application doctype, unlike the other ones, the annuity field is named “repayment_amount.“

The following validation routine:

```
if not self.monthly_repayment_amount:
    frappe.throw(_("Please enter repayment Amount"))
if self.monthly_repayment_amount > self.loan_amount:
    frappe.throw(_("Monthly Repayment Amount cannot be greater than Loan Amount"))
```

therefore can‘t work:
![IMG_1557](https://github.com/frappe/lending/assets/46800703/59aef525-63ac-40dd-9214-7fe00b82515a)