### PR TITLE
feat: Enforce approved loan applications

### DIFF
--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -28,7 +28,8 @@ frappe.ui.form.on('Loan', {
 		frm.set_query("loan_product", function () {
 			return {
 				"filters": {
-					"company": frm.doc.company
+					"company": frm.doc.company,
+					"allow_bypassing_application": 1
 				}
 			};
 		});

--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -71,6 +71,7 @@
    "fieldtype": "Select",
    "label": "Applicant Type",
    "options": "Employee\nMember\nCustomer",
+   "read_only_depends_on": "loan_application",
    "reqd": 1
   },
   {
@@ -79,6 +80,7 @@
    "in_standard_filter": 1,
    "label": "Applicant",
    "options": "applicant_type",
+   "read_only_depends_on": "loan_application",
    "reqd": 1
   },
   {
@@ -102,6 +104,7 @@
    "in_standard_filter": 1,
    "label": "Loan Product",
    "options": "Loan Product",
+   "read_only_depends_on": "loan_application",
    "reqd": 1
   },
   {
@@ -146,7 +149,8 @@
    "fieldtype": "Currency",
    "label": "Loan Amount",
    "non_negative": 1,
-   "options": "Company:company:default_currency"
+   "options": "Company:company:default_currency",
+   "read_only_depends_on": "loan_application"
   },
   {
    "fetch_from": "loan_product.rate_of_interest",
@@ -178,13 +182,15 @@
    "fieldname": "repayment_method",
    "fieldtype": "Select",
    "label": "Repayment Method",
-   "options": "\nRepay Fixed Amount per Period\nRepay Over Number of Periods"
+   "options": "\nRepay Fixed Amount per Period\nRepay Over Number of Periods",
+   "read_only_depends_on": "loan_application"
   },
   {
    "depends_on": "is_term_loan",
    "fieldname": "repayment_periods",
    "fieldtype": "Int",
-   "label": "Repayment Period in Months"
+   "label": "Repayment Period in Months",
+   "read_only_depends_on": "loan_application"
   },
   {
    "depends_on": "is_term_loan",
@@ -193,7 +199,8 @@
    "fieldname": "monthly_repayment_amount",
    "fieldtype": "Currency",
    "label": "Monthly Repayment Amount",
-   "options": "Company:company:default_currency"
+   "options": "Company:company:default_currency",
+   "read_only_depends_on": "loan_application"
   },
   {
    "collapsible": 1,
@@ -291,7 +298,8 @@
    "default": "0",
    "fieldname": "is_secured_loan",
    "fieldtype": "Check",
-   "label": "Is Secured Loan"
+   "label": "Is Secured Loan",
+   "read_only_depends_on": "loan_application"
   },
   {
    "default": "0",

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -17,6 +17,7 @@
   "company",
   "is_term_loan",
   "disabled",
+  "allow_bypassing_application",
   "repayment_schedule_type",
   "cyclic_day_of_the_month",
   "repayment_date_on",
@@ -80,6 +81,12 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_bypassing_application",
+   "fieldtype": "Check",
+   "label": "Allow bypassing application"
   },
   {
    "fieldname": "description",


### PR DESCRIPTION
There‘s no point in an application process if the approved loan can be substantially changed in its risk content without being approved anew.

The fix was surprisingly simple:

As proposed in #30, I’m rendering almost all fields in the Loan doctype as read_only if a loan application is attached. Any amendments may be made there.

If there‘s no application, then the fields remain editable. However this pertains only to particular Loan Types with the setting „Allow bypassing application.“ Other loan types may not be chosen manually, if not passed via application.

Fixes #30.