### PR TITLE
chore: rename loan partner charge type and remove custom fields on uninstall

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -161,3 +161,33 @@ def make_property_setter_for_journal_entry():
 def after_install():
 	create_custom_fields(LOAN_CUSTOM_FIELDS, ignore_validate=True)
 	make_property_setter_for_journal_entry()
+
+
+def before_uninstall():
+	delete_custom_fields(LOAN_CUSTOM_FIELDS)
+
+
+def delete_custom_fields(custom_fields):
+	"""
+	:param custom_fields: a dict like `{'Customer': [{fieldname: 'test', ...}]}`
+	"""
+
+	for doctypes, fields in custom_fields.items():
+		if isinstance(fields, dict):
+			# only one field
+			fields = [fields]
+
+		if isinstance(doctypes, str):
+			# only one doctype
+			doctypes = (doctypes,)
+
+		for doctype in doctypes:
+			frappe.db.delete(
+				"Custom Field",
+				{
+					"fieldname": ("in", [field["fieldname"] for field in fields]),
+					"dt": doctype,
+				},
+			)
+
+			frappe.clear_cache(doctype=doctype)

--- a/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
+++ b/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
@@ -6,7 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "charge_type",
+  "shareable_type",
   "sharing_parameter",
   "partner_ratio",
   "company_ratio",
@@ -14,13 +14,6 @@
   "minimum_partner_percentage"
  ],
  "fields": [
-  {
-   "fieldname": "charge_type",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Charge Type",
-   "options": "Item"
-  },
   {
    "fieldname": "sharing_parameter",
    "fieldtype": "Select",
@@ -54,12 +47,19 @@
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Minimum Partner Percentage"
+  },
+  {
+   "fieldname": "shareable_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Shareable Type",
+   "options": "Item"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-22 11:28:49.162023",
+ "modified": "2023-09-26 14:49:38.075304",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Shareable",

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -21,3 +21,4 @@ lending.patches.v15_0.create_custom_field_for_interest_day_count_convention
 lending.patches.v15_0.create_custom_field_for_bpi
 lending.patches.v15_0.update_loan_column_break_due_to_bpi
 lending.patches.v15_0.fix_typo_in_irac_provisioning_configuration
+lending.patches.v15_0.rename_loan_partner_charge_type

--- a/lending/patches/v15_0/rename_loan_partner_charge_type.py
+++ b/lending/patches/v15_0/rename_loan_partner_charge_type.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	try:
+		rename_field("Loan Partner Shareable", "charge_type", "shareable_type")
+
+	except Exception as e:
+		if e.args[0] != 1054:
+			raise


### PR DESCRIPTION
- remove custom fields on uninstall
- rename loan partner charge type to shareable type