### PR TITLE
chore: add loan partners in loan product

### DIFF
--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -12,6 +12,7 @@
   "penalty_interest_rate",
   "grace_period_in_days",
   "write_off_amount",
+  "loan_partners",
   "column_break_2",
   "company",
   "is_term_loan",
@@ -304,11 +305,17 @@
    "fieldtype": "Int",
    "label": "Cyclic Day Of the Month",
    "mandatory_depends_on": "eval:doc.repayment_schedule_type == \"Monthly as per cycle date\""
+  },
+  {
+   "fieldname": "loan_partners",
+   "fieldtype": "Table MultiSelect",
+   "label": "Loan Partners",
+   "options": "Loan Product Loan Partner"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-22 11:51:37.789220",
+ "modified": "2023-10-03 00:33:47.168614",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.json
+++ b/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-10-03 00:33:27.497599",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "loan_partner"
+ ],
+ "fields": [
+  {
+   "fieldname": "loan_partner",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Loan Partner",
+   "options": "Loan Partner",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-10-03 00:33:27.497599",
+ "modified_by": "Administrator",
+ "module": "Loan Management",
+ "name": "Loan Product Loan Partner",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.py
+++ b/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class LoanProductLoanPartner(Document):
+	pass


### PR DESCRIPTION
Letting users add the list of loan partners for each loan product so that the system can validate and control (in the future) which partners can be tagged to loans belonging to the respective product.