### PR TITLE
feat: loan product specific charge income accounts

### DIFF
--- a/lending/loan_management/doctype/loan_charges/loan_charges.json
+++ b/lending/loan_management/doctype/loan_charges/loan_charges.json
@@ -10,10 +10,12 @@
   "event",
   "charge_based_on",
   "amount",
-  "percentage"
+  "percentage",
+  "income_account"
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "charge_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -21,6 +23,7 @@
    "options": "Item"
   },
   {
+   "columns": 2,
    "fieldname": "event",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -28,6 +31,7 @@
    "options": "Disbursement\nRepayment\nRestructure"
   },
   {
+   "columns": 2,
    "fieldname": "charge_based_on",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -35,22 +39,32 @@
    "options": "Percentage\nFixed Amount"
   },
   {
+   "columns": 1,
    "fieldname": "amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Amount"
   },
   {
+   "columns": 1,
    "fieldname": "percentage",
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Percentage"
+  },
+  {
+   "columns": 2,
+   "fieldname": "income_account",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Income Account",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-05-09 10:27:46.934165",
+ "modified": "2023-10-05 09:56:43.428965",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Charges",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -83,13 +83,24 @@ class LoanRepayment(AccountsController):
 			as_dict=1,
 		)
 
+		charges_waiver_item_income_account = frappe.db.get_value(
+			"Loan Charges",
+			{"charge_type": item_details.charges_waiver_item, "parent": self.loan_product},
+			"income_account",
+		)
+
 		for invoice in self.get("pending_charges"):
 			if invoice.sales_invoice:
 				si = frappe.new_doc("Sales Invoice")
 				si.customer = self.applicant
 				si.append(
 					"items",
-					{"item_code": item_details.charges_waiver_item, "qty": -1, "rate": invoice.allocated_amount},
+					{
+						"item_code": item_details.charges_waiver_item,
+						"qty": -1,
+						"rate": invoice.allocated_amount,
+						"income_account": charges_waiver_item_income_account,
+					},
 				)
 				si.set_missing_values()
 				si.is_return = 1

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -340,9 +340,8 @@ class LoanRestructure(AccountsController):
 			for charge in frappe.get_all(
 				"Loan Charges",
 				filters={"parent": self.loan_product, "event": "Restructure"},
-				fields=["charge_type", "charge_based_on", "amount", "percentage"],
+				fields=["charge_type", "charge_based_on", "amount", "percentage", "income_account"],
 			):
-
 				si.append(
 					"items",
 					{
@@ -351,6 +350,7 @@ class LoanRestructure(AccountsController):
 						"rate": charge.amount
 						if charge.charge_based_on == "Fixed Amount"
 						else flt(self.new_loan_amount) * flt(charge.percentage) / 100,
+						"income_account": charge.income_account,
 					},
 				)
 


### PR DESCRIPTION
Adding an `income_account` field in the charges table in `Loan Product` so that users can loan product specific income accounts for charges.