### PR TITLE
feat: add loan product code, penalty_interest_method, broken_period_interest_charged, auto-closure fields

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -58,11 +58,16 @@ class TestLoan(unittest.TestCase):
 
 		for loan_product in simple_terms_loans:
 			create_loan_product(
-				loan_product[0], loan_product[1], loan_product[2], repayment_schedule_type=loan_product[3]
+				loan_product[0],
+				loan_product[0],
+				loan_product[1],
+				loan_product[2],
+				repayment_schedule_type=loan_product[3],
 			)
 
 		for loan_product in pro_rated_term_loans:
 			create_loan_product(
+				loan_product[0],
 				loan_product[0],
 				loan_product[1],
 				loan_product[2],
@@ -71,6 +76,7 @@ class TestLoan(unittest.TestCase):
 			)
 
 		create_loan_product(
+			"Stock Loan",
 			"Stock Loan",
 			2000000,
 			13.5,
@@ -87,6 +93,7 @@ class TestLoan(unittest.TestCase):
 		)
 
 		create_loan_product(
+			"Demand Loan",
 			"Demand Loan",
 			2000000,
 			13.5,
@@ -1027,7 +1034,8 @@ def create_account(account_name, parent_account, root_type, account_type, report
 
 
 def create_loan_product(
-	loan_name,
+	product_code,
+	product_name,
 	maximum_loan_amount,
 	rate_of_interest,
 	penalty_interest_rate=None,
@@ -1051,12 +1059,13 @@ def create_loan_product(
 	days_past_due_threshold_for_npa=None,
 ):
 
-	if not frappe.db.exists("Loan Product", loan_name):
+	if not frappe.db.exists("Loan Product", product_code):
 		loan_product = frappe.get_doc(
 			{
 				"doctype": "Loan Product",
 				"company": "_Test Company",
-				"loan_name": loan_name,
+				"product_code": product_code,
+				"product_name": product_name,
 				"is_term_loan": is_term_loan,
 				"repayment_schedule_type": "Monthly as per repayment start date",
 				"maximum_loan_amount": maximum_loan_amount,

--- a/lending/loan_management/doctype/loan_application/test_loan_application.py
+++ b/lending/loan_management/doctype/loan_application/test_loan_application.py
@@ -18,6 +18,7 @@ class TestLoanApplication(unittest.TestCase):
 		create_loan_accounts()
 		create_loan_product(
 			"Home Loan",
+			"Home Loan",
 			500000,
 			9.2,
 			0,

--- a/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -46,6 +46,7 @@ class TestLoanDisbursement(unittest.TestCase):
 
 		create_loan_product(
 			"Demand Loan",
+			"Demand Loan",
 			2000000,
 			13.5,
 			25,

--- a/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -35,6 +35,7 @@ class TestLoanInterestAccrual(unittest.TestCase):
 
 		create_loan_product(
 			"Demand Loan",
+			"Demand Loan",
 			2000000,
 			13.5,
 			25,
@@ -49,7 +50,8 @@ class TestLoanInterestAccrual(unittest.TestCase):
 		)
 
 		create_loan_product(
-			loan_name="Term Loan With DPD",
+			product_code="Term Loan With DPD",
+			product_name="Term Loan With DPD",
 			maximum_loan_amount=2000000,
 			rate_of_interest=10,
 			penalty_interest_rate=25,

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -1,17 +1,24 @@
 {
  "actions": [],
- "autoname": "field:loan_name",
+ "autoname": "field:product_code",
  "creation": "2019-08-29 18:08:38.159726",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "loan_name",
+  "product_code",
+  "product_name",
   "maximum_loan_amount",
   "rate_of_interest",
+  "penalty_interest_method",
   "penalty_interest_rate",
+  "penalty_interest_value_ptpd",
   "grace_period_in_days",
   "write_off_amount",
+  "broken_period_interest_charged",
+  "auto_close_with_security_deposit",
+  "min_auto_closure_tolerance_amount",
+  "max_auto_closure_tolerance_amount",
   "loan_partners",
   "column_break_2",
   "company",
@@ -49,14 +56,6 @@
   "amended_from"
  ],
  "fields": [
-  {
-   "fieldname": "loan_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Loan Name",
-   "reqd": 1,
-   "unique": 1
-  },
   {
    "fieldname": "maximum_loan_amount",
    "fieldtype": "Currency",
@@ -137,6 +136,7 @@
    "label": "Is Term Loan"
   },
   {
+   "depends_on": "eval:doc.penalty_interest_method == \"Rate\"",
    "description": "Penalty Interest Rate is levied on the pending interest amount on a daily basis in case of delayed repayment ",
    "fieldname": "penalty_interest_rate",
    "fieldtype": "Percent",
@@ -201,7 +201,8 @@
    "description": "Loans will be marked as NPA when the days past due count exceed this threshold",
    "fieldname": "days_past_due_threshold_for_npa",
    "fieldtype": "Int",
-   "label": "Days Past Due Threshold for NPA"
+   "label": "Days Past Due Threshold for NPA",
+   "non_negative": 1
   },
   {
    "fieldname": "loan_waiver_accounts_section",
@@ -302,20 +303,70 @@
    "depends_on": "eval:doc.repayment_schedule_type == \"Monthly as per cycle date\"",
    "description": "Day of every month on which the repayment date is considered",
    "fieldname": "cyclic_day_of_the_month",
-   "fieldtype": "Int",
+   "fieldtype": "Select",
    "label": "Cyclic Day Of the Month",
-   "mandatory_depends_on": "eval:doc.repayment_schedule_type == \"Monthly as per cycle date\""
+   "mandatory_depends_on": "eval:doc.repayment_schedule_type == \"Monthly as per cycle date\"",
+   "options": "\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31"
   },
   {
    "fieldname": "loan_partners",
    "fieldtype": "Table MultiSelect",
    "label": "Loan Partners",
    "options": "Loan Product Loan Partner"
+  },
+  {
+   "fieldname": "product_code",
+   "fieldtype": "Data",
+   "label": "Product Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "product_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Product Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "penalty_interest_method",
+   "fieldtype": "Select",
+   "label": "Penalty Interest Method",
+   "options": "Rate\nPTPD"
+  },
+  {
+   "depends_on": "eval:doc.penalty_interest_method == \"PTPD\"",
+   "description": "Per thousand per day penal amount which will be applied to the loan EMI proportionately to the EMI amount",
+   "fieldname": "penalty_interest_value_ptpd",
+   "fieldtype": "Currency",
+   "label": "Penalty Interest Value (PTPD)"
+  },
+  {
+   "default": "0",
+   "fieldname": "broken_period_interest_charged",
+   "fieldtype": "Check",
+   "label": "Broken Period Interest charged"
+  },
+  {
+   "default": "0",
+   "fieldname": "auto_close_with_security_deposit",
+   "fieldtype": "Check",
+   "label": "Auto-close with Security Deposit"
+  },
+  {
+   "fieldname": "min_auto_closure_tolerance_amount",
+   "fieldtype": "Currency",
+   "label": "Min Auto-closure Tolerance Amount"
+  },
+  {
+   "fieldname": "max_auto_closure_tolerance_amount",
+   "fieldtype": "Currency",
+   "label": "Max Auto-closure Tolerance Amount"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-03 00:33:47.168614",
+ "modified": "2023-10-09 10:57:20.676936",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -24,3 +24,5 @@ lending.patches.v15_0.update_loan_column_break_due_to_bpi
 lending.patches.v15_0.fix_typo_in_irac_provisioning_configuration
 lending.patches.v15_0.rename_loan_partner_charge_type
 lending.patches.v15_0.migrate_loan_type_to_loan_product
+lending.patches.v15_0.add_loan_product_code_and_rename_loan_name
+lending.patches.v15_0.update_penalty_interest_method_in_loan_products

--- a/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
+++ b/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	try:
+		rename_field("Loan Product", "loan_name", "product_name")
+
+	except Exception as e:
+		if e.args[0] != 1054:
+			raise
+
+	for loan_product in frappe.db.get_all("Loan Product", fields=["name", "product_name"]):
+		frappe.db.set_value("Loan Product", loan_product.name, "product_code", loan_product.product_name)

--- a/lending/patches/v15_0/update_penalty_interest_method_in_loan_products.py
+++ b/lending/patches/v15_0/update_penalty_interest_method_in_loan_products.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+
+def execute():
+	for loan_product in frappe.db.get_all("Loan Product", fields=["name"]):
+		frappe.db.set_value("Loan Product", loan_product.name, "penalty_interest_method", "Rate")


### PR DESCRIPTION
Added:
- "product_code"
- "product_name" (renamed from "loan_name")
-  "penalty_interest_method"
-  "penalty_interest_value_ptpd"
-  "broken_period_interest_charged"
-  "auto_close_with_security_deposit"
-  "min_auto_closure_tolerance_amount"
-  "max_auto_closure_tolerance_amount"
- 1-31 dropdown for "cyclic_day_of_the_month"