### PR TITLE
fix: Unable to book loan

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -7,7 +7,16 @@ import json
 import frappe
 from frappe import _
 from frappe.query_builder import Order
-from frappe.utils import add_days, date_diff, flt, get_last_day, getdate, now_datetime, nowdate
+from frappe.utils import (
+	add_days,
+	cint,
+	date_diff,
+	flt,
+	get_last_day,
+	getdate,
+	now_datetime,
+	nowdate,
+)
 
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_payment_entry
@@ -64,7 +73,9 @@ class Loan(AccountsController):
 
 	def set_cyclic_date(self):
 		if self.repayment_schedule_type == "Monthly as per cycle date":
-			cycle_day = frappe.db.get_value("Loan Product", self.loan_product, "cyclic_day_of_the_month")
+			cycle_day = cint(
+				frappe.db.get_value("Loan Product", self.loan_product, "cyclic_day_of_the_month")
+			)
 			last_day_of_month = get_last_day(self.posting_date)
 			cyclic_date = add_days(last_day_of_month, cycle_day)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
11:06:33 web.1            |   File "apps/frappe/frappe/app.py", line 105, in application
11:06:33 web.1            |     response = frappe.api.handle()
11:06:33 web.1            |   File "apps/frappe/frappe/api.py", line 53, in handle
11:06:33 web.1            |     return _RESTAPIHandler(call, doctype, name).get_response()
11:06:33 web.1            |   File "apps/frappe/frappe/api.py", line 69, in get_response
11:06:33 web.1            |     return self.handle_method()
11:06:33 web.1            |   File "apps/frappe/frappe/api.py", line 79, in handle_method
11:06:33 web.1            |     return frappe.handler.handle()
11:06:33 web.1            |   File "apps/frappe/frappe/handler.py", line 48, in handle
11:06:33 web.1            |     data = execute_cmd(cmd)
11:06:33 web.1            |   File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
11:06:33 web.1            |     return frappe.call(method, **frappe.form_dict)
11:06:33 web.1            |   File "apps/frappe/frappe/__init__.py", line 1682, in call
11:06:33 web.1            |     return fn(*args, **newargs)
11:06:33 web.1            |   File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
11:06:33 web.1            |     return func(*args, **kwargs)
11:06:33 web.1            |   File "apps/frappe/frappe/desk/form/save.py", line 36, in savedocs
11:06:33 web.1            |     doc.save()
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 331, in save
11:06:33 web.1            |     return self._save(*args, **kwargs)
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 353, in _save
11:06:33 web.1            |     return self.insert()
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 284, in insert
11:06:33 web.1            |     self.run_before_save_methods()
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 1073, in run_before_save_methods
11:06:33 web.1            |     self.run_method("validate")
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 937, in run_method
11:06:33 web.1            |     out = Document.hook(fn)(self, *args, **kwargs)
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 1308, in composer
11:06:33 web.1            |     return composed(self, method, *args, **kwargs)
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 1290, in runner
11:06:33 web.1            |     add_to_return_value(self, fn(self, *args, **kwargs))
11:06:33 web.1            |   File "apps/frappe/frappe/model/document.py", line 934, in fn
11:06:33 web.1            |     return method_object(*args, **kwargs)
11:06:33 web.1            |   File "apps/lending/lending/loan_management/doctype/loan/loan.py", line 29, in validate
11:06:33 web.1            |     self.set_cyclic_date()
11:06:33 web.1            |   File "apps/lending/lending/loan_management/doctype/loan/loan.py", line 70, in set_cyclic_date
11:06:33 web.1            |     cyclic_date = add_days(last_day_of_month, cycle_day)
11:06:33 web.1            |   File "apps/frappe/frappe/utils/data.py", line 264, in add_days
11:06:33 web.1            |     return add_to_date(date, days=days)
11:06:33 web.1            |   File "apps/frappe/frappe/utils/data.py", line 250, in add_to_date
11:06:33 web.1            |     date = date + relativedelta(
11:06:33 web.1            |   File "env/lib/python3.10/site-packages/dateutil/relativedelta.py", line 179, in __init__
11:06:33 web.1            |     self.days = days + weeks * 7
11:06:33 web.1            | TypeError: can only concatenate str (not "int") to str
```