### PR TITLE
chore: fix fetch_if_empty for min_days_bw_disbursement_first_repayment

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -45,6 +45,7 @@ from lending.loan_management.doctype.process_loan_security_shortfall.process_loa
 
 class TestLoan(unittest.TestCase):
 	def setUp(self):
+		set_loan_settings_in_company()
 		create_loan_accounts()
 		simple_terms_loans = [
 			["Personal Loan", 500000, 8.4, "Monthly as per repayment start date"],
@@ -1057,6 +1058,7 @@ def create_loan_product(
 	repayment_schedule_type=None,
 	repayment_date_on=None,
 	days_past_due_threshold_for_npa=None,
+	min_days_bw_disbursement_first_repayment=None,
 ):
 
 	if not frappe.db.exists("Loan Product", product_code):
@@ -1087,6 +1089,9 @@ def create_loan_product(
 				"repayment_periods": repayment_periods,
 				"write_off_amount": 100,
 				"days_past_due_threshold_for_npa": days_past_due_threshold_for_npa,
+				"min_days_bw_disbursement_first_repayment": min_days_bw_disbursement_first_repayment,
+				"min_auto_closure_tolerance_amount": -100,
+				"max_auto_closure_tolerance_amount": 100,
 			}
 		)
 
@@ -1096,6 +1101,8 @@ def create_loan_product(
 				loan_product.repayment_date_on = repayment_date_on
 
 		loan_product.insert()
+
+		return loan_product
 
 
 def create_loan_security_type():
@@ -1340,3 +1347,11 @@ def create_demand_loan(applicant, loan_product, loan_application, posting_date=N
 	loan.save()
 
 	return loan
+
+
+def set_loan_settings_in_company(company=None):
+	if not company:
+		company = "_Test Company"
+	company = frappe.get_doc("Company", company)
+	company.min_days_bw_disbursement_first_repayment = "15"
+	company.save()

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1353,5 +1353,5 @@ def set_loan_settings_in_company(company=None):
 	if not company:
 		company = "_Test Company"
 	company = frappe.get_doc("Company", company)
-	company.min_days_bw_disbursement_first_repayment = "15"
+	company.min_days_bw_disbursement_first_repayment = 15
 	company.save()

--- a/lending/loan_management/doctype/loan_application/test_loan_application.py
+++ b/lending/loan_management/doctype/loan_application/test_loan_application.py
@@ -10,11 +10,13 @@ from erpnext.setup.doctype.employee.test_employee import make_employee
 from lending.loan_management.doctype.loan.test_loan import (
 	create_loan_accounts,
 	create_loan_product,
+	set_loan_settings_in_company,
 )
 
 
 class TestLoanApplication(unittest.TestCase):
 	def setUp(self):
+		set_loan_settings_in_company()
 		create_loan_accounts()
 		create_loan_product(
 			"Home Loan",

--- a/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -28,6 +28,7 @@ from lending.loan_management.doctype.loan.test_loan import (
 	create_loan_security_type,
 	create_repayment_entry,
 	make_loan_disbursement_entry,
+	set_loan_settings_in_company,
 )
 from lending.loan_management.doctype.loan_application.loan_application import create_pledge
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
@@ -42,6 +43,8 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 
 class TestLoanDisbursement(unittest.TestCase):
 	def setUp(self):
+		set_loan_settings_in_company()
+
 		create_loan_accounts()
 
 		create_loan_product(

--- a/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -15,6 +15,7 @@ from lending.loan_management.doctype.loan.test_loan import (
 	create_loan_security_price,
 	create_loan_security_type,
 	make_loan_disbursement_entry,
+	set_loan_settings_in_company,
 )
 from lending.loan_management.doctype.loan_application.loan_application import create_pledge
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
@@ -31,6 +32,8 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 
 class TestLoanInterestAccrual(unittest.TestCase):
 	def setUp(self):
+		set_loan_settings_in_company()
+
 		create_loan_accounts()
 
 		create_loan_product(

--- a/lending/loan_management/doctype/loan_product/loan_product.js
+++ b/lending/loan_management/doctype/loan_product/loan_product.js
@@ -2,6 +2,10 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Loan Product', {
+	setup(frm) {
+		frm.add_fetch("company", "min_days_bw_disbursement_first_repayment", "min_days_bw_disbursement_first_repayment");
+	},
+
 	onload: function(frm) {
 		$.each(["penalty_income_account", "interest_income_account"], function (i, field) {
 			frm.set_query(field, function () {

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -373,17 +373,16 @@
    "reqd": 1
   },
   {
-   "fetch_from": "company.min_days_bw_disbursement_first_repayment",
-   "fetch_if_empty": 1,
    "fieldname": "min_days_bw_disbursement_first_repayment",
    "fieldtype": "Int",
    "label": "Minimum days between Disbursement date and first Repayment date",
-   "non_negative": 1
+   "non_negative": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-12 12:12:02.553449",
+ "modified": "2023-10-12 13:35:48.346212",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_product/loan_product.py
+++ b/lending/loan_management/doctype/loan_product/loan_product.py
@@ -8,9 +8,22 @@ from frappe.model.document import Document
 
 
 class LoanProduct(Document):
+	def before_validate(self):
+		self.set_missing_values()
+
 	def validate(self):
 		self.validate_accounts()
 		self.validate_rates()
+
+	def set_missing_values(self):
+		company_min_days_bw_disbursement_first_repayment = frappe.get_cached_value(
+			"Company", self.company, "min_days_bw_disbursement_first_repayment"
+		)
+		if (
+			self.min_days_bw_disbursement_first_repayment is None
+			and company_min_days_bw_disbursement_first_repayment
+		):
+			self.min_days_bw_disbursement_first_repayment = company_min_days_bw_disbursement_first_repayment
 
 	def validate_accounts(self):
 		for fieldname in [


### PR DESCRIPTION
There's a framework bug (related to https://github.com/frappe/frappe/pull/22442) where if a int field with `fetch_from` and `fetch_if_empty` is intentionally set as 0, it still fetches the value from the parent doc. This affects the `min_days_bw_disbursement_first_repayment` field, so manually handling the fetching part in client and server side.