### PR TITLE
fix: close employee loan on write off

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,8 +4,9 @@ set -e
 
 cd ~ || exit
 
-sudo apt-get update
-sudo apt-get -y install redis-server libcups2-dev -qq
+sudo apt update
+sudo apt remove mysql-server mysql-client
+sudo apt install libcups2-dev redis-server mariadb-client-10.6
 
 pip install frappe-bench
 
@@ -15,15 +16,14 @@ bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frapp
 mkdir ~/frappe-bench/sites/test_site
 cp -r "${GITHUB_WORKSPACE}/.github/helper/site_config.json" ~/frappe-bench/sites/test_site/
 
-mysql --host 127.0.0.1 --port 3306 -u root -e "SET GLOBAL character_set_server = 'utf8mb4'"
-mysql --host 127.0.0.1 --port 3306 -u root -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
-mysql --host 127.0.0.1 --port 3306 -u root -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
-mysql --host 127.0.0.1 --port 3306 -u root -e "CREATE DATABASE test_frappe"
-mysql --host 127.0.0.1 --port 3306 -u root -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
 
-mysql --host 127.0.0.1 --port 3306 -u root -e "UPDATE mysql.user SET Password=PASSWORD('travis') WHERE User='root'"
-mysql --host 127.0.0.1 --port 3306 -u root -e "FLUSH PRIVILEGES"
+mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "FLUSH PRIVILEGES"
 
 install_whktml() {
     wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz

--- a/.github/helper/site_config.json
+++ b/.github/helper/site_config.json
@@ -9,7 +9,7 @@
     "mail_password": "test",
     "admin_password": "admin",
     "root_login": "root",
-    "root_password": "travis",
+    "root_password": "root",
     "host_name": "http://test_site:8000",
     "install_apps": ["payments", "erpnext"],
     "throttle_user_limit": 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: 'root'
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Clone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
     strategy:
       fail-fast: false
 
-    name: Server
+    name: Python Unit Tests
 
     services:
       mysql:
-        image: mariadb:10.3
+        image: mariadb:10.6
         env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: YES
+          MARIADB_ROOT_PASSWORD: 'root'
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -383,11 +383,6 @@ def close_unsecured_term_loan(loan):
 		frappe.throw(_("Cannot close this loan until full repayment"))
 
 
-def close_loan(loan, total_amount_paid):
-	frappe.db.set_value("Loan", loan, "total_amount_paid", total_amount_paid)
-	frappe.db.set_value("Loan", loan, "status", "Closed")
-
-
 @frappe.whitelist()
 def make_loan_disbursement(loan, company, applicant_type, applicant, pending_amount=0, as_dict=0):
 	disbursement_entry = frappe.new_doc("Loan Disbursement")

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1170,8 +1170,12 @@ def get_amounts(amounts, against_loan, posting_date, with_loan_details=False):
 		)
 		unaccrued_interest += pending_days * per_day_interest
 
+	written_off_amount = flt(against_loan_doc.written_off_amount, precision)
+
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
-	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
+	amounts["payable_principal_amount"] = flt(
+		max(payable_principal_amount - written_off_amount, 0), precision
+	)
 	amounts["interest_amount"] = flt(total_pending_interest, precision)
 	amounts["penalty_amount"] = flt(penalty_amount + pending_penalty_amount, precision)
 	amounts["payable_amount"] = flt(
@@ -1179,7 +1183,7 @@ def get_amounts(amounts, against_loan, posting_date, with_loan_details=False):
 	)
 	amounts["pending_accrual_entries"] = pending_accrual_entries
 	amounts["unaccrued_interest"] = flt(unaccrued_interest, precision)
-	amounts["written_off_amount"] = flt(against_loan_doc.written_off_amount, precision)
+	amounts["written_off_amount"] = written_off_amount
 
 	if final_due_date:
 		amounts["due_date"] = final_due_date

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1170,12 +1170,8 @@ def get_amounts(amounts, against_loan, posting_date, with_loan_details=False):
 		)
 		unaccrued_interest += pending_days * per_day_interest
 
-	written_off_amount = flt(against_loan_doc.written_off_amount, precision)
-
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
-	amounts["payable_principal_amount"] = flt(
-		max(payable_principal_amount - written_off_amount, 0), precision
-	)
+	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
 	amounts["interest_amount"] = flt(total_pending_interest, precision)
 	amounts["penalty_amount"] = flt(penalty_amount + pending_penalty_amount, precision)
 	amounts["payable_amount"] = flt(
@@ -1183,7 +1179,7 @@ def get_amounts(amounts, against_loan, posting_date, with_loan_details=False):
 	)
 	amounts["pending_accrual_entries"] = pending_accrual_entries
 	amounts["unaccrued_interest"] = flt(unaccrued_interest, precision)
-	amounts["written_off_amount"] = written_off_amount
+	amounts["written_off_amount"] = flt(against_loan_doc.written_off_amount, precision)
 
 	if final_due_date:
 		amounts["due_date"] = final_due_date

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -53,11 +53,13 @@ class LoanWriteOff(AccountsController):
 	def on_submit(self):
 		self.update_outstanding_amount()
 		self.make_gl_entries()
+		self.close_employee_loan()
 
 	def on_cancel(self):
 		self.update_outstanding_amount(cancel=1)
 		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry"]
 		self.make_gl_entries(cancel=1)
+		self.close_employee_loan(cancel=1)
 
 	def update_outstanding_amount(self, cancel=0):
 		written_off_amount = frappe.db.get_value("Loan", self.loan, "written_off_amount")
@@ -108,3 +110,39 @@ class LoanWriteOff(AccountsController):
 		)
 
 		make_gl_entries(gl_entries, cancel=cancel, merge_entries=False)
+
+	def close_employee_loan(self, cancel=0):
+		if not frappe.db.has_column("Loan", "repay_from_salary"):
+			return
+
+		loan = frappe.get_value(
+			"Loan",
+			self.loan,
+			[
+				"total_payment",
+				"total_principal_paid",
+				"loan_amount",
+				"total_interest_payable",
+				"written_off_amount",
+				"disbursed_amount",
+				"status",
+				"is_secured_loan",
+				"repay_from_salary",
+				"name",
+			],
+			as_dict=1,
+		)
+
+		if loan.is_secured_loan or not loan.repay_from_salary:
+			return
+
+		if not cancel:
+			pending_principal_amount = get_pending_principal_amount(loan)
+
+			precision = cint(frappe.db.get_default("currency_precision")) or 2
+
+			if flt(pending_principal_amount, precision) <= 0:
+				frappe.db.set_value("Loan", loan.name, "status", "Closed")
+				frappe.msgprint(_("Loan {0} closed").format(loan.name))
+		else:
+			frappe.db.set_value("Loan", loan.loan, "status", "Disbursed")


### PR DESCRIPTION
A user did a write off for a loan but when he runs the payroll through Frappe HR, the system still fetches the loan which had been written off. The reason was that the loan wasn't closed after write off. Now, the loan would be closed after a write off if there's no pending principal amount.