### PR TITLE
fix: update company loan tab insert_after

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -18,7 +18,7 @@ LOAN_CUSTOM_FIELDS = {
 			"fieldname": "loan_tab",
 			"fieldtype": "Tab Break",
 			"label": "Loan",
-			"insert_after": "expenses_included_in_valuation",
+			"insert_after": "default_in_transit_warehouse",
 		},
 		{
 			"fieldname": "loan_settings",

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -9,7 +9,7 @@ lending.patches.v15_0.rename_loan_type_to_loan_product
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 lending.patches.v15_0.update_loan_types
-lending.patches.v15_0.create_custom_fields #9
+lending.patches.v15_0.create_custom_fields #10
 lending.patches.v15_0.create_custom_field_for_irac_provisioning_configuration
 lending.patches.v15_0.update_loan_asset_classification_ranges
 lending.patches.v15_0.generate_loan_classifications_from_loan_asset_classification_ranges


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/37632 removed the `expenses_included_in_valuation` field hence updating `loan_tab`'s `insert_after`