### PR TITLE
chore: loan partner and IRAC provisioning configuration updates

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -124,7 +124,7 @@ LOAN_CUSTOM_FIELDS = {
 			"fieldname": "loan_details_tab",
 			"label": "Loan Details",
 			"fieldtype": "Tab Break",
-			"insert_after": "primary_address",
+			"insert_after": "email_id",
 		},
 		{
 			"fieldname": "is_npa",

--- a/lending/loan_management/doctype/loan_classification_range/loan_classification_range.json
+++ b/lending/loan_management/doctype/loan_classification_range/loan_classification_range.json
@@ -13,7 +13,7 @@
  ],
  "fields": [
   {
-   "columns": 2,
+   "columns": 3,
    "fieldname": "classification_code",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -37,7 +37,7 @@
    "label": "Min DPD Range"
   },
   {
-   "columns": 3,
+   "columns": 2,
    "fieldname": "max_dpd_range",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -47,7 +47,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-13 21:41:03.820275",
+ "modified": "2023-11-01 23:33:52.633698",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Classification Range",

--- a/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.json
+++ b/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.json
@@ -10,39 +10,23 @@
   "classification_code",
   "classification_name",
   "security_type",
-  "min_dpd_range",
-  "max_dpd_range",
   "provision_rate"
  ],
  "fields": [
   {
-   "columns": 1,
+   "columns": 2,
    "fieldname": "provision_rate",
    "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Provision Rate"
   },
   {
-   "columns": 2,
+   "columns": 3,
    "fieldname": "classification_code",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Classification Code",
    "options": "Loan Classification"
-  },
-  {
-   "columns": 1,
-   "fieldname": "min_dpd_range",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Min DPD Range"
-  },
-  {
-   "columns": 1,
-   "fieldname": "max_dpd_range",
-   "fieldtype": "Int",
-   "in_list_view": 1,
-   "label": "Max DPD Range"
   },
   {
    "columns": 3,
@@ -65,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-26 11:44:17.642540",
+ "modified": "2023-11-01 23:33:15.840425",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan IRAC Provisioning Configuration",

--- a/lending/loan_management/doctype/loan_partner/loan_partner.js
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.js
@@ -20,4 +20,12 @@ frappe.ui.form.on("Loan Partner", {
 			frappe.contacts.clear_address_and_contact(frm);
         }
     },
+
+	partner_loan_share_percentage: function(frm) {
+		frm.set_value("company_loan_share_percentage", 100 - frm.doc.partner_loan_share_percentage);
+	},
+
+	company_loan_share_percentage: function(frm) {
+		frm.set_value("partner_loan_share_percentage", 100 - frm.doc.company_loan_share_percentage);
+	},
 });

--- a/lending/loan_management/doctype/loan_partner/loan_partner.json
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:partner_name",
+ "autoname": "field:partner_code",
  "beta": 1,
  "creation": "2023-09-18 19:55:37.996068",
  "default_view": "List",
@@ -10,16 +10,17 @@
  "engine": "InnoDB",
  "field_order": [
   "details_section",
+  "partner_code",
   "partner_name",
-  "effective_date",
   "partner_loan_share_percentage",
   "partner_base_interest_rate",
-  "incremental_interest_applicable",
+  "effective_date",
   "column_break_yfag",
   "repayment_schedule_type",
   "company_loan_share_percentage",
   "company_base_interest_rate",
   "interest_increment_percentage",
+  "incremental_interest_applicable",
   "section_break_mpap",
   "column_break_gpwj",
   "organization_type",
@@ -31,14 +32,20 @@
   "fldg_section",
   "fldg_trigger_dpd",
   "fldg_total_percentage",
-  "fldg_fd_or_cg_applicable",
+  "type_of_fldg_applicable",
   "column_break_szii",
   "fldg_limit_calculation_component",
   "fldg_fixed_deposit_percentage",
   "fldg_corporate_guarantee_percentage",
   "misc_section",
   "servicer_fee",
-  "column_break_wujj"
+  "column_break_wujj",
+  "restructure_of_loans_applicable",
+  "column_break_xyxj",
+  "waiving_of_charges_applicable",
+  "section_break_scge",
+  "partial_payment_mechanism",
+  "column_break_xlvh"
  ],
  "fields": [
   {
@@ -140,11 +147,9 @@
    "label": "Incremental Interest Applicable"
   },
   {
-   "depends_on": "incremental_interest_applicable",
    "fieldname": "company_base_interest_rate",
    "fieldtype": "Percent",
-   "label": "Company Base Interest Rate",
-   "mandatory_depends_on": "incremental_interest_applicable"
+   "label": "Company Base Interest Rate"
   },
   {
    "depends_on": "incremental_interest_applicable",
@@ -174,29 +179,23 @@
    "options": "\nDisbursement\nPOS\nPOS & Interest Accrued"
   },
   {
-   "depends_on": "fldg_fd_or_cg_applicable",
+   "depends_on": "eval:doc.type_of_fldg_applicable == \"Fixed Deposit only\" || doc.type_of_fldg_applicable == \"Both Fixed Deposit and Corporate Guarantee\"",
    "fieldname": "fldg_fixed_deposit_percentage",
    "fieldtype": "Percent",
    "label": "FLDG Fixed Deposit Percentage",
-   "mandatory_depends_on": "fldg_fd_or_cg_applicable"
+   "mandatory_depends_on": "eval:doc.type_of_fldg_applicable == \"Fixed Deposit only\" || doc.type_of_fldg_applicable == \"Both Fixed Deposit and Corporate Guarantee\""
   },
   {
-   "depends_on": "fldg_fd_or_cg_applicable",
+   "depends_on": "eval:doc.type_of_fldg_applicable == \"Corporate Guarantee only\" || doc.type_of_fldg_applicable == \"Both Fixed Deposit and Corporate Guarantee\"",
    "fieldname": "fldg_corporate_guarantee_percentage",
    "fieldtype": "Percent",
    "label": "FLDG Corporate Guarantee Percentage",
-   "mandatory_depends_on": "fldg_fd_or_cg_applicable"
+   "mandatory_depends_on": "eval:doc.type_of_fldg_applicable == \"Corporate Guarantee only\" || doc.type_of_fldg_applicable == \"Both Fixed Deposit and Corporate Guarantee\""
   },
   {
    "fieldname": "fldg_total_percentage",
    "fieldtype": "Percent",
    "label": "FLDG Total Percentage"
-  },
-  {
-   "default": "0",
-   "fieldname": "fldg_fd_or_cg_applicable",
-   "fieldtype": "Check",
-   "label": "FLDG Fixed Deposit/Corporate Guarantee Applicable"
   },
   {
    "fieldname": "misc_section",
@@ -212,11 +211,54 @@
   {
    "fieldname": "column_break_wujj",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "partner_code",
+   "fieldtype": "Data",
+   "label": "Partner Code",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "type_of_fldg_applicable",
+   "fieldtype": "Select",
+   "label": "Type of FLDG Applicable",
+   "options": "\nFixed Deposit only\nCorporate Guarantee only\nBoth Fixed Deposit and Corporate Guarantee"
+  },
+  {
+   "default": "0",
+   "fieldname": "waiving_of_charges_applicable",
+   "fieldtype": "Check",
+   "label": "Waiving of Charges applicable"
+  },
+  {
+   "default": "0",
+   "fieldname": "restructure_of_loans_applicable",
+   "fieldtype": "Check",
+   "label": "Restructure of Loans applicable"
+  },
+  {
+   "fieldname": "partial_payment_mechanism",
+   "fieldtype": "Select",
+   "label": "Partial Payment Mechanism",
+   "options": "\nEMI Percentage wise sharing\nComponent wise sharing"
+  },
+  {
+   "fieldname": "column_break_xyxj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_scge",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_xlvh",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-02 14:27:55.348088",
+ "modified": "2023-11-01 22:14:06.548223",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner",

--- a/lending/loan_management/doctype/loan_partner/loan_partner.py
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import frappe
+from frappe import _
 from frappe.contacts.address_and_contact import load_address_and_contact
-
-# import frappe
 from frappe.model.document import Document
 
 
@@ -11,3 +11,21 @@ class LoanPartner(Document):
 	def onload(self):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)
+
+	def validate(self):
+		self.validate_percentage_and_interest_fields()
+
+	def validate_percentage_and_interest_fields(self):
+		fields = [
+			"partner_loan_share_percentage",
+			"company_loan_share_percentage",
+			"partner_base_interest_rate",
+			"company_base_interest_rate",
+			"fldg_total_percentage",
+			"fldg_fixed_deposit_percentage",
+			"fldg_corporate_guarantee_percentage",
+		]
+
+		for field in fields:
+			if self.get(field) and (self.get(field) < 0 or self.get(field) > 100):
+				frappe.throw(_("{0} should be between 0 and 100").format(frappe.bold(frappe.unscrub(field))))

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -9,7 +9,7 @@ lending.patches.v15_0.rename_loan_type_to_loan_product
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 lending.patches.v15_0.update_loan_types
-lending.patches.v15_0.create_custom_fields #10
+lending.patches.v15_0.create_custom_fields #11
 lending.patches.v15_0.create_custom_field_for_irac_provisioning_configuration
 lending.patches.v15_0.update_loan_asset_classification_ranges
 lending.patches.v15_0.generate_loan_classifications_from_loan_asset_classification_ranges


### PR DESCRIPTION
- Fixed the `insert_after` of the Loan tab in Customer doctype
- Removed unnecessary min and max DPD ranges from Loan IRAC Provisioning Configuration
- `company_loan_share_percentage` / `partner_loan_share_percentage` in Loan Partner would be auto-calculated
- Added validations for percent and rate fields in Loan Partner
- Added some more fields like Restructure of Loans applicable, Waiving of Charges applicable, etc., in Loan Partner (business logic coming soon)