### PR TITLE
chore: company_collection_percentage, validations for shareable percents

### DIFF
--- a/lending/loan_management/doctype/loan_partner/loan_partner.js
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.js
@@ -29,3 +29,15 @@ frappe.ui.form.on("Loan Partner", {
 		frm.set_value("partner_loan_share_percentage", 100 - frm.doc.company_loan_share_percentage);
 	},
 });
+
+frappe.ui.form.on('Loan Partner Shareable', {
+	partner_collection_percentage: function(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		frappe.model.set_value(cdt, cdn, "company_collection_percentage", 100 - row.partner_collection_percentage);
+	},
+
+	company_collection_percentage: function(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		frappe.model.set_value(cdt, cdn, "partner_collection_percentage", 100 - row.company_collection_percentage);
+	},
+});

--- a/lending/loan_management/doctype/loan_partner/loan_partner.py
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.py
@@ -29,3 +29,19 @@ class LoanPartner(Document):
 		for field in fields:
 			if self.get(field) and (self.get(field) < 0 or self.get(field) > 100):
 				frappe.throw(_("{0} should be between 0 and 100").format(frappe.bold(frappe.unscrub(field))))
+
+		shareables_fields = [
+			"partner_collection_percentage",
+			"company_collection_percentage",
+			"partner_loan_amount_percentage",
+			"minimum_partner_loan_amount_percentage",
+		]
+
+		for shareable in self.shareables:
+			for field in shareables_fields:
+				if shareable.get(field) and (shareable.get(field) < 0 or shareable.get(field) > 100):
+					frappe.throw(
+						_("Row {0}: {1} should be between 0 and 100").format(
+							shareable.idx, frappe.bold(frappe.unscrub(field))
+						)
+					)

--- a/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
+++ b/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
@@ -9,6 +9,7 @@
   "shareable_type",
   "sharing_parameter",
   "partner_collection_percentage",
+  "company_collection_percentage",
   "partner_loan_amount_percentage",
   "minimum_partner_loan_amount_percentage"
  ],
@@ -28,7 +29,6 @@
   {
    "fieldname": "minimum_partner_loan_amount_percentage",
    "fieldtype": "Percent",
-   "in_list_view": 1,
    "label": "Minimum Partner Loan Amount Percentage"
   },
   {
@@ -45,13 +45,20 @@
    "in_list_view": 1,
    "label": "Sharing Parameter",
    "options": "\nCollection Percentage\nLoan Amount Percentage",
-   "reqd": 1
+   "reqd": 1,
+   "translatable": 1
+  },
+  {
+   "fieldname": "company_collection_percentage",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Company Collection Percentage"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-02 17:38:34.208157",
+ "modified": "2023-11-02 11:48:00.797758",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Shareable",


### PR DESCRIPTION
- added `company_collection_percentage` in loan partner shareables
- `partner_collection_percentage` and `company_collection_percentage` would be auto-calculated based on each other
- added validations for percentages in shareables