### PR TITLE
chore: better loan partner validations and some field changes

### DIFF
--- a/lending/loan_management/doctype/loan_partner/loan_partner.json
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.json
@@ -32,7 +32,6 @@
   "fldg_section",
   "fldg_trigger_dpd",
   "fldg_limit_calculation_component",
-  "fldg_total_percentage",
   "column_break_szii",
   "type_of_fldg_applicable",
   "fldg_fixed_deposit_percentage",
@@ -73,10 +72,10 @@
    "fieldname": "organization_type",
    "fieldtype": "Select",
    "label": "Organization Type",
-   "options": "\nCentralized\nDecentralized"
+   "options": "\nCentralized\nDecentralized",
+   "reqd": 1
   },
   {
-   "depends_on": "eval:!doc.__islocal",
    "fieldname": "section_break_mpap",
    "fieldtype": "Section Break",
    "label": "Organization"
@@ -97,6 +96,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "primary_address",
    "fieldtype": "Link",
    "label": "Primary Address",
@@ -192,11 +192,6 @@
    "mandatory_depends_on": "eval:doc.type_of_fldg_applicable == \"Corporate Guarantee only\" || doc.type_of_fldg_applicable == \"Both Fixed Deposit and Corporate Guarantee\""
   },
   {
-   "fieldname": "fldg_total_percentage",
-   "fieldtype": "Percent",
-   "label": "FLDG Total Percentage"
-  },
-  {
    "fieldname": "misc_section",
    "fieldtype": "Section Break",
    "label": "Misc"
@@ -240,7 +235,8 @@
    "fieldname": "partial_payment_mechanism",
    "fieldtype": "Select",
    "label": "Partial Payment Mechanism",
-   "options": "\nEMI Percentage wise sharing\nComponent wise sharing"
+   "options": "\nEMI Percentage wise sharing\nComponent wise sharing",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_xyxj",
@@ -253,7 +249,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-03 11:30:01.230498",
+ "modified": "2023-11-09 14:55:36.675654",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner",

--- a/lending/loan_management/doctype/loan_partner/loan_partner.py
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.py
@@ -30,12 +30,11 @@ class LoanPartner(Document):
 		fldg_fields_to_validate = []
 
 		if self.type_of_fldg_applicable == "Fixed Deposit only":
-			fldg_fields_to_validate = ["fldg_total_percentage", "fldg_fixed_deposit_percentage"]
+			fldg_fields_to_validate = ["fldg_fixed_deposit_percentage"]
 		elif self.type_of_fldg_applicable == "Corporate Guarantee only":
-			fldg_fields_to_validate = ["fldg_total_percentage", "fldg_corporate_guarantee_percentage"]
+			fldg_fields_to_validate = ["fldg_corporate_guarantee_percentage"]
 		elif self.type_of_fldg_applicable == "Both Fixed Deposit and Corporate Guarantee":
 			fldg_fields_to_validate = [
-				"fldg_total_percentage",
 				"fldg_fixed_deposit_percentage",
 				"fldg_corporate_guarantee_percentage",
 			]
@@ -53,11 +52,22 @@ class LoanPartner(Document):
 								shareable.idx, frappe.bold(frappe.unscrub(field))
 							)
 						)
-			elif shareable.sharing_parameter == "Loan Amount Percentage":
 				for field in ["partner_loan_amount_percentage", "minimum_partner_loan_amount_percentage"]:
-					if not shareable.get(field) or shareable.get(field) < 1 or shareable.get(field) > 99:
-						frappe.throw(
-							_("Row {0}: {1} should be between 1 and 99").format(
-								shareable.idx, frappe.bold(frappe.unscrub(field))
-							)
+					if shareable.get(field):
+						shareable.set(field, 0)
+			elif shareable.sharing_parameter == "Loan Amount Percentage":
+				if not shareable.get("partner_loan_amount_percentage") or shareable.get("partner_loan_amount_percentage") < 1 or shareable.get("partner_loan_amount_percentage") > 99:
+					frappe.throw(
+						_("Row {0}: {1} should be between 1 and 99").format(
+							shareable.idx, frappe.bold(frappe.unscrub("partner_loan_amount_percentage"))
 						)
+					)
+				if shareable.get("minimum_partner_loan_amount_percentage") and (shareable.get("minimum_partner_loan_amount_percentage") < 1 or shareable.get("minimum_partner_loan_amount_percentage") > 99):
+					frappe.throw(
+						_("Row {0}: {1} should be between 1 and 99").format(
+							shareable.idx, frappe.bold(frappe.unscrub("minimum_partner_loan_amount_percentage"))
+						)
+					)
+				for field in ["partner_collection_percentage", "company_collection_percentage"]:
+					if shareable.get(field):
+						shareable.set(field, 0)

--- a/lending/loan_management/doctype/loan_partner/loan_partner.py
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.py
@@ -56,13 +56,20 @@ class LoanPartner(Document):
 					if shareable.get(field):
 						shareable.set(field, 0)
 			elif shareable.sharing_parameter == "Loan Amount Percentage":
-				if not shareable.get("partner_loan_amount_percentage") or shareable.get("partner_loan_amount_percentage") < 1 or shareable.get("partner_loan_amount_percentage") > 99:
+				if (
+					not shareable.get("partner_loan_amount_percentage")
+					or shareable.get("partner_loan_amount_percentage") < 1
+					or shareable.get("partner_loan_amount_percentage") > 99
+				):
 					frappe.throw(
 						_("Row {0}: {1} should be between 1 and 99").format(
 							shareable.idx, frappe.bold(frappe.unscrub("partner_loan_amount_percentage"))
 						)
 					)
-				if shareable.get("minimum_partner_loan_amount_percentage") and (shareable.get("minimum_partner_loan_amount_percentage") < 1 or shareable.get("minimum_partner_loan_amount_percentage") > 99):
+				if shareable.get("minimum_partner_loan_amount_percentage") and (
+					shareable.get("minimum_partner_loan_amount_percentage") < 1
+					or shareable.get("minimum_partner_loan_amount_percentage") > 99
+				):
 					frappe.throw(
 						_("Row {0}: {1} should be between 1 and 99").format(
 							shareable.idx, frappe.bold(frappe.unscrub("minimum_partner_loan_amount_percentage"))

--- a/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
+++ b/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
@@ -18,17 +18,20 @@
    "fieldname": "partner_collection_percentage",
    "fieldtype": "Percent",
    "in_list_view": 1,
-   "label": "Partner Collection Percentage"
+   "label": "Partner Collection Percentage",
+   "mandatory_depends_on": "eval:doc.sharing_parameter == \"Collection Percentage\""
   },
   {
    "fieldname": "partner_loan_amount_percentage",
    "fieldtype": "Percent",
    "in_list_view": 1,
-   "label": "Partner Loan Amount Percentage"
+   "label": "Partner Loan Amount Percentage",
+   "mandatory_depends_on": "eval:doc.sharing_parameter == \"Loan Amount Percentage\""
   },
   {
    "fieldname": "minimum_partner_loan_amount_percentage",
    "fieldtype": "Percent",
+   "in_list_view": 1,
    "label": "Minimum Partner Loan Amount Percentage"
   },
   {
@@ -51,14 +54,14 @@
   {
    "fieldname": "company_collection_percentage",
    "fieldtype": "Percent",
-   "in_list_view": 1,
-   "label": "Company Collection Percentage"
+   "label": "Company Collection Percentage",
+   "mandatory_depends_on": "eval:doc.sharing_parameter == \"Collection Percentage\""
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-02 11:48:00.797758",
+ "modified": "2023-11-09 17:13:25.366680",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Shareable",


### PR DESCRIPTION
- better validations for loan partner shareables
- removed unnecessary `fldg_total_percentage`
- show `organization_type` before doc save (rest of address details are shown after doc save)
- make `partial_payment_mechanism` mandatory