### PR TITLE
fix: post install patches

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -207,9 +207,33 @@ def make_property_setter_for_journal_entry():
 		)
 
 
+def get_post_install_patches():
+	return (
+		"rename_loan_type_to_loan_product",
+		"generate_loan_repayment_schedule",
+		"update_loan_types",
+		"make_loan_type_non_submittable",
+		"migrate_loan_type_to_loan_product",
+		"add_loan_product_code_and_rename_loan_name",
+		"update_penalty_interest_method_in_loan_products",
+	)
+
+
+def run_patches(patches):
+	frappe.flags.in_patch = True
+
+	try:
+		for patch in patches:
+			frappe.get_attr(f"lending.patches.v15_0.{patch}.execute")()
+	finally:
+		frappe.flags.in_patch = False
+
+
 def after_install():
 	create_custom_fields(LOAN_CUSTOM_FIELDS, ignore_validate=True)
 	make_property_setter_for_journal_entry()
+	print("\nRunning post-install patches to patch existing data...\n")
+	run_patches(get_post_install_patches())
 
 
 def before_uninstall():

--- a/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
+++ b/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
@@ -7,7 +7,7 @@ from frappe.model.utils.rename_field import rename_field
 
 def execute():
 	try:
-		rename_field("Loan Product", "loan_name", "product_name")
+		rename_field("Loan Product", "loan_name", "product_name", validate=False)
 
 	except Exception as e:
 		if e.args[0] != 1054:

--- a/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
+++ b/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py
@@ -6,12 +6,12 @@ from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	try:
-		rename_field("Loan Product", "loan_name", "product_name", validate=False)
+	loan_products_created = frappe.db.count("Loan Product")
 
-	except Exception as e:
-		if e.args[0] != 1054:
-			raise
+	if not loan_products_created:
+		return
+
+	rename_field("Loan Product", "loan_name", "product_name", validate=False)
 
 	for loan_product in frappe.db.get_all("Loan Product", fields=["name", "product_name"]):
 		frappe.db.set_value("Loan Product", loan_product.name, "product_code", loan_product.product_name)

--- a/lending/patches/v15_0/generate_loan_repayment_schedule.py
+++ b/lending/patches/v15_0/generate_loan_repayment_schedule.py
@@ -5,6 +5,11 @@ import frappe
 
 
 def execute():
+	loans_created = frappe.db.count("Loan")
+
+	if not loans_created:
+		return
+
 	loan_repayment_schedules_already_created = frappe.db.count("Loan Repayment Schedule")
 
 	if loan_repayment_schedules_already_created:

--- a/lending/patches/v15_0/generate_loan_repayment_schedule.py
+++ b/lending/patches/v15_0/generate_loan_repayment_schedule.py
@@ -5,7 +5,7 @@ import frappe
 
 
 def execute():
-	loan_repayment_schedules_already_created = frappe.db.count('Loan Repayment Schedule')
+	loan_repayment_schedules_already_created = frappe.db.count("Loan Repayment Schedule")
 
 	if loan_repayment_schedules_already_created:
 		return
@@ -21,7 +21,9 @@ def execute():
 		loan_repayment_schedule.posting_date = loan.posting_date
 		loan_repayment_schedule.status = get_status(loan.status)
 
-		repayment_schedules = frappe.db.get_all("Repayment Schedule", {"parent": loan.name}, "*", order_by='idx')
+		repayment_schedules = frappe.db.get_all(
+			"Repayment Schedule", {"parent": loan.name}, "*", order_by="idx"
+		)
 
 		for rs in repayment_schedules:
 			rs.parent = loan_repayment_schedule.name

--- a/lending/patches/v15_0/generate_loan_repayment_schedule.py
+++ b/lending/patches/v15_0/generate_loan_repayment_schedule.py
@@ -5,19 +5,30 @@ import frappe
 
 
 def execute():
-	frappe.reload_doc("loan_management", "doctype", "loan_repayment_schedule")
+	loan_repayment_schedules_already_created = frappe.db.count('Loan Repayment Schedule')
+
+	if loan_repayment_schedules_already_created:
+		return
 
 	for loan in frappe.get_all("Loan", filters={"is_term_loan": 1}):
 		loan = frappe.get_cached_doc("Loan", loan.name)
 		loan_repayment_schedule = frappe.new_doc("Loan Repayment Schedule")
 		loan_repayment_schedule.flags.ignore_validate = True
 		loan_repayment_schedule.loan = loan.name
-		loan_repayment_schedule.loan_type = loan.loan_type
+		loan_repayment_schedule.loan_product = loan.loan_type
 		loan_repayment_schedule.loan_amount = loan.loan_amount
 		loan_repayment_schedule.monthly_repayment_amount = loan.monthly_repayment_amount
 		loan_repayment_schedule.posting_date = loan.posting_date
-		loan_repayment_schedule.set("repayment_schedule", loan.repayment_schedule)
 		loan_repayment_schedule.status = get_status(loan.status)
+
+		repayment_schedules = frappe.db.get_all("Repayment Schedule", {"parent": loan.name}, "*", order_by='idx')
+
+		for rs in repayment_schedules:
+			rs.parent = loan_repayment_schedule.name
+			rs.parenttype = "Loan Repayment Schedule"
+
+		loan_repayment_schedule.set("repayment_schedule", repayment_schedules)
+
 		loan_repayment_schedule.submit()
 
 

--- a/lending/patches/v15_0/make_loan_type_non_submittable.py
+++ b/lending/patches/v15_0/make_loan_type_non_submittable.py
@@ -5,5 +5,10 @@ import frappe
 
 
 def execute():
+	loan_products_created = frappe.db.count("Loan Product")
+
+	if not loan_products_created:
+		return
+
 	lt = frappe.qb.DocType("Loan Product")
 	frappe.qb.update(lt).set(lt.docstatus, 0).run()

--- a/lending/patches/v15_0/migrate_loan_type_to_loan_product.py
+++ b/lending/patches/v15_0/migrate_loan_type_to_loan_product.py
@@ -1,22 +1,30 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
+import frappe
 from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
 	try:
-		rename_field("Loan", "loan_type", "loan_product")
-		rename_field("Loan Application", "loan_type", "loan_product")
-		rename_field("Loan Disbursement", "loan_type", "loan_product")
-		rename_field("Loan Interest Accrual", "loan_type", "loan_product")
-		rename_field("Loan IRAC Provisioning Configuration", "loan_type", "loan_product")
-		rename_field("Loan Repayment", "loan_type", "loan_product")
-		rename_field("Loan Repayment Schedule", "loan_type", "loan_product")
-		rename_field("Loan Restructure", "loan_type", "loan_product")
-		rename_field("Process Loan Classification", "loan_type", "loan_product")
-		rename_field("Process Loan Interest Accrual", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan", "loan_type"):
+			rename_field("Loan", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Application", "loan_type"):
+			rename_field("Loan Application", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Disbursement", "loan_type"):
+			rename_field("Loan Disbursement", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Interest Accrual", "loan_type"):
+			rename_field("Loan Interest Accrual", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Repayment", "loan_type"):
+			rename_field("Loan Repayment", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Repayment Schedule", "loan_type"):
+			rename_field("Loan Repayment Schedule", "loan_type", "loan_product")
+		if frappe.db.has_column("Loan Restructure", "loan_type"):
+			rename_field("Loan Restructure", "loan_type", "loan_product")
+		if frappe.db.has_column("Process Loan Classification", "loan_type"):
+			rename_field("Process Loan Classification", "loan_type", "loan_product")
+		if frappe.db.has_column("Process Loan Interest Accrual", "loan_type"):
+			rename_field("Process Loan Interest Accrual", "loan_type", "loan_product")
 
 	except Exception as e:
 		if e.args[0] != 1054:

--- a/lending/patches/v15_0/rename_loan_type_to_loan_product.py
+++ b/lending/patches/v15_0/rename_loan_type_to_loan_product.py
@@ -3,7 +3,6 @@
 
 
 import frappe
-
 from frappe.model.rename_doc import rename_doc
 
 

--- a/lending/patches/v15_0/rename_loan_type_to_loan_product.py
+++ b/lending/patches/v15_0/rename_loan_type_to_loan_product.py
@@ -4,8 +4,19 @@
 
 import frappe
 
+from frappe.model.rename_doc import rename_doc
+
 
 def execute():
-	if frappe.db.table_exists("Loan Type") and not frappe.db.table_exists("Loan Product"):
-		frappe.rename_doc("DocType", "Loan Type", "Loan Product", force=True)
-		frappe.reload_doc("loan_management", "doctype", "loan_product")
+	if frappe.db.table_exists("Loan Type"):
+		frappe.db.sql_ddl("DROP TABLE `tabLoan Product`")
+
+		rename_doc(
+			doctype="DocType",
+			old="Loan Type",
+			new="Loan Product",
+			force=True,
+			validate=False,
+		)
+
+		frappe.reload_doc("loan_management", "doctype", "loan_product", force=True)

--- a/lending/patches/v15_0/update_loan_types.py
+++ b/lending/patches/v15_0/update_loan_types.py
@@ -5,7 +5,9 @@ import frappe
 
 
 def execute():
-	accounts_already_updated = frappe.db.get_value('Loan Product', {'disabled': 0}, "interest_receivable_account")
+	accounts_already_updated = frappe.db.get_value(
+		"Loan Product", {"disabled": 0}, "interest_receivable_account"
+	)
 
 	if accounts_already_updated:
 		return

--- a/lending/patches/v15_0/update_loan_types.py
+++ b/lending/patches/v15_0/update_loan_types.py
@@ -5,6 +5,11 @@ import frappe
 
 
 def execute():
+	accounts_already_updated = frappe.db.get_value('Loan Product', {'disabled': 0}, "interest_receivable_account")
+
+	if accounts_already_updated:
+		return
+
 	for loan_product in frappe.db.get_all(
 		"Loan Product", fields=["name", "payment_account", "loan_account", "interest_income_account"]
 	):
@@ -13,7 +18,6 @@ def execute():
 			loan_product.name,
 			{
 				"interest_receivable_account": loan_product.loan_account,
-				"charges_receivable_account": loan_product.loan_account,
 				"penalty_receivable_account": loan_product.loan_account,
 				"suspense_interest_receivable": loan_product.loan_account,
 				"suspense_interest_income": loan_product.interest_income_account,

--- a/lending/patches/v15_0/update_loan_types.py
+++ b/lending/patches/v15_0/update_loan_types.py
@@ -5,6 +5,11 @@ import frappe
 
 
 def execute():
+	loan_products_created = frappe.db.count("Loan Product")
+
+	if not loan_products_created:
+		return
+
 	accounts_already_updated = frappe.db.get_value(
 		"Loan Product", {"disabled": 0}, "interest_receivable_account"
 	)

--- a/lending/patches/v15_0/update_penalty_interest_method_in_loan_products.py
+++ b/lending/patches/v15_0/update_penalty_interest_method_in_loan_products.py
@@ -5,5 +5,10 @@ import frappe
 
 
 def execute():
+	loan_products_created = frappe.db.count("Loan Product")
+
+	if not loan_products_created:
+		return
+
 	for loan_product in frappe.db.get_all("Loan Product", fields=["name"]):
 		frappe.db.set_value("Loan Product", loan_product.name, "penalty_interest_method", "Rate")


### PR DESCRIPTION
If a site is created from a backup, patches updating some data should also run post installation to avoid leaving data in an inconsistent state during v14 -> v15 migration. So fixing that by running required patches post installation and also made the patches fail-safe.

Depends on: https://github.com/frappe/frappe/pull/23248.