### PR TITLE
fix: remove company filter from customer and member in applicant field

### DIFF
--- a/lending/public/js/loan_common.js
+++ b/lending/public/js/loan_common.js
@@ -23,19 +23,28 @@ lending.common = {
 				erpnext.hide_company();
 				frm.trigger("set_company_filter");
 			},
-
+			applicant_type: function(frm) {
+				frm.trigger("set_company_filter");
+			},
 			set_company_filter: function(frm) {
-				if (
-					["Loan Application", "Loan"].includes(frm.doc.doctype) &&
-					frm.doc.applicant_type === "Employee"
-				) {
-					frm.set_query("applicant", function() {
-						return {
-							"filters": {
-								"company": frm.doc.company
-							}
-						};
-					});
+				if (["Loan Application", "Loan"].includes(frm.doc.doctype)) {
+					if (frm.doc.applicant_type === "Employee") {
+						frm.set_query("applicant", function() {
+							return {
+								"filters": {
+									"company": frm.doc.company
+								}
+							};
+						});
+					} else {
+						frm.set_query("applicant", function() {
+							return {
+								"filters": {
+									"docstatus": 0
+								}
+							};
+						});
+					}
 				}
 			},
 


### PR DESCRIPTION
In Version 15

fixes: https://discuss.frappe.io/t/loan-error-when-selecting-applicant-type-customer/116863

**Before:**


https://github.com/frappe/lending/assets/141945075/532750ea-8597-4054-b919-6841dbbe0810

**After:**

- Solved the issue in both doctypes (Loan and Loan Application)
- We don't remove the line from the `setup_filters` because the first-time refresh time company filter does not work in Employee Applicant Type.
```
frm.trigger("set_company_filter");
```

https://github.com/frappe/lending/assets/141945075/17ea8b3f-dba9-476e-a243-fc016e0ee744

Thank You!