### PR TITLE
fix: bugs with creating loan with fixed amount repayment

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -98,7 +98,7 @@ class Loan(AccountsController):
 		self.available_limit_amount = self.maximum_limit_amount
 
 	def validate_repayment_terms(self):
-		if self.is_term_loan and self.repayment_schedule_type != "Line of Credit":
+		if self.is_term_loan and self.repayment_schedule_type != "Line of Credit" and self.repayment_method == "Repay Over Number of Periods":
 			if not self.repayment_periods:
 				frappe.throw(_("Repayment periods is mandatory for term loans"))
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -626,7 +626,6 @@ class LoanRepayment(AccountsController):
 			[
 				"interest_receivable_account",
 				"penalty_receivable_account",
-				"suspense_interest_receivable",
 				"suspense_interest_income",
 				"interest_income_account",
 				"interest_waiver_account",

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -230,7 +230,7 @@ class LoanRepaymentSchedule(Document):
 		carry_forward_interest = self.adjusted_interest
 		moratorium_interest = 0
 
-		if not self.restructure_type:
+		if not self.restructure_type and self.repayment_method != "Repay Fixed Amount per Period":
 			monthly_repayment_amount = get_monthly_repayment_amount(
 				balance_amount, rate_of_interest, self.repayment_periods, self.repayment_frequency
 			)

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -154,7 +154,7 @@ class LoanRestructure(AccountsController):
 
 		for charge in frappe.get_all(
 			"Loan Charges",
-			filters={"parent": self.loan_product, "event": "Restructure"},
+			filters={"parent": self.loan_product},
 			fields=["charge_type", "charge_based_on", "amount", "percentage"],
 		):
 			if charge.charge_based_on == "Percentage":


### PR DESCRIPTION
Fix:
 -  Issue with creating loan with `Fixed amount over period` was throwing error with `repayment period` mandatory.
 - Missing column error in Loan Repayment(`suspense_interest_receivable`) and Loan Charges (`event`).