### PR TITLE
Add multiple payment methods while lending

### DIFF
--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and contributors
-// For license information, please see license.txt
-
 lending.common.setup_filters("Loan");
 
 frappe.ui.form.on('Loan', {
@@ -276,5 +273,65 @@ frappe.ui.form.on('Loan', {
 	toggle_fields: function (frm) {
 		frm.toggle_enable("monthly_repayment_amount", frm.doc.repayment_method == "Repay Fixed Amount per Period")
 		frm.toggle_enable("repayment_periods", frm.doc.repayment_method == "Repay Over Number of Periods")
+	},
+
+	// Add support for multiple payment methods
+	payment_methods: function(frm) {
+		frm.add_custom_button(__('Add Payment Method'), function() {
+			let dialog = new frappe.ui.Dialog({
+				title: __('Add Payment Method'),
+				fields: [
+					{
+						label: __('Payment Method'),
+						fieldname: 'payment_method',
+						fieldtype: 'Select',
+						options: ['Cash', 'Bank Transfer', 'UPI']
+					},
+					{
+						label: __('Amount'),
+						fieldname: 'amount',
+						fieldtype: 'Currency'
+					}
+				],
+				primary_action_label: __('Add'),
+				primary_action(values) {
+					let payment_method = values.payment_method;
+					let amount = values.amount;
+
+					// Add validation to check if the cash limit is obeyed
+					if (payment_method === 'Cash') {
+						frappe.call({
+							method: 'frappe.client.get_value',
+							args: {
+								doctype: 'Payment Method Limit',
+								fieldname: 'limit',
+								filters: { payment_method: 'Cash' }
+							},
+							callback: function(r) {
+								let cash_limit = r.message.limit;
+								if (amount > cash_limit) {
+									frappe.msgprint(__('Cash limit exceeded. The entered lending value for cash will be auto-updated to {0}', [cash_limit]));
+									amount = cash_limit;
+								}
+								frm.add_child('payment_methods', {
+									payment_method: payment_method,
+									amount: amount
+								});
+								frm.refresh_field('payment_methods');
+								dialog.hide();
+							}
+						});
+					} else {
+						frm.add_child('payment_methods', {
+							payment_method: payment_method,
+							amount: amount
+						});
+						frm.refresh_field('payment_methods');
+						dialog.hide();
+					}
+				}
+			});
+			dialog.show();
+		});
 	}
 });

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -154,6 +154,29 @@ class LoanApplication(Document):
 		if not self.loan_amount and self.is_secured_loan and self.proposed_pledges:
 			self.loan_amount = self.maximum_loan_amount
 
+		# Add logic to handle multiple payment methods
+		if self.payment_methods:
+			total_payment = sum([pm.amount for pm in self.payment_methods])
+			if total_payment != self.loan_amount:
+				frappe.throw(_("Total payment amount does not match the loan amount"))
+
+			cash_limit = frappe.db.get_value("Payment Method Limit", {"payment_method": "Cash"}, "limit")
+			for pm in self.payment_methods:
+				if pm.payment_method == "Cash" and pm.amount > cash_limit:
+					frappe.throw(_("Cash payment exceeds the limit of {0}").format(cash_limit))
+
+			remaining_amount = self.loan_amount
+			for pm in self.payment_methods:
+				if pm.payment_method == "Cash":
+					pm.amount = min(pm.amount, cash_limit)
+				remaining_amount -= pm.amount
+
+			if remaining_amount > 0:
+				for pm in self.payment_methods:
+					if pm.payment_method != "Cash":
+						pm.amount += remaining_amount
+						break
+
 
 @frappe.whitelist()
 def create_loan(source_name, target_doc=None, submit=0):

--- a/lending/loan_management/doctype/payment_method_limit/payment_method_limit.json
+++ b/lending/loan_management/doctype/payment_method_limit/payment_method_limit.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "allow_import": 1,
+ "autoname": "field:payment_method",
+ "creation": "2023-11-29 10:00:00.000000",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "payment_method",
+  "limit"
+ ],
+ "fields": [
+  {
+   "fieldname": "payment_method",
+   "fieldtype": "Data",
+   "label": "Payment Method",
+   "reqd": 1
+  },
+  {
+   "fieldname": "limit",
+   "fieldtype": "Currency",
+   "label": "Limit",
+   "reqd": 1,
+   "default": 20000
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2023-11-29 10:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Loan Management",
+ "name": "Payment Method Limit",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}


### PR DESCRIPTION
Fixes #166

Add support for multiple payment methods in loan applications and loans.

* Add a new doctype `Payment Method Limit` to define the cash limit.
* Update `loan_application.js` to include a payment section with multiple modes of payment.
  * Add validation to check if the cash limit is obeyed.
  * Show an error screen if the cash limit is exceeded and auto-update the entered lending value for cash to 20,000.
* Update `loan_application.py` to handle the logic for multiple payment methods.
  * Add logic to distribute the remaining amount to other payment methods like bank transfer or UPI.
* Update `loan.js` to support multiple payment methods.
  * Add a payment section with multiple modes of payment.
  * Add validation to check if the cash limit is obeyed.
  * Show an error screen if the cash limit is exceeded and auto-update the entered lending value for cash to 20,000.
* Update `loan.py` to handle the logic for multiple payment methods.
  * Add logic to distribute the remaining amount to other payment methods like bank transfer or UPI.

