### PR TITLE
Fix loan repay from salary attribute

### DIFF
--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and contributors
-// For license information, please see license.txt
-
 lending.common.setup_filters("Loan");
 
 frappe.ui.form.on('Loan', {
@@ -245,7 +242,7 @@ frappe.ui.form.on('Loan', {
 					if (!r.exc && r.message) {
 
 						let loan_fields = ["loan_product", "loan_amount", "repayment_method",
-							"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan"]
+							"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan", "repay_from_salary"]
 
 						loan_fields.forEach(field => {
 							frm.set_value(field, r.message[field]);

--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -63,7 +63,8 @@
   "total_amount_paid",
   "is_npa",
   "manual_npa",
-  "amended_from"
+  "amended_from",
+  "repay_from_salary"
  ],
  "fields": [
   {
@@ -472,6 +473,12 @@
    "fieldtype": "Link",
    "label": "Loan Category",
    "options": "Loan Category"
+  },
+  {
+   "default": "0",
+   "fieldname": "repay_from_salary",
+   "fieldtype": "Check",
+   "label": "Repay From Salary"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -121,6 +121,9 @@ class Loan(AccountsController):
 				"Loan Product", self.loan_product, "rate_of_interest"
 			)
 
+		if not hasattr(self, 'repay_from_salary'):
+			self.repay_from_salary = 0
+
 	def check_sanctioned_amount_limit(self):
 		sanctioned_amount_limit = get_sanctioned_amount_limit(
 			self.applicant_type, self.applicant, self.company

--- a/lending/loan_management/doctype/loan/loan_dashboard.py
+++ b/lending/loan_management/doctype/loan/loan_dashboard.py
@@ -18,4 +18,12 @@ def get_data():
 			{"items": ["Loan Repayment", "Loan Interest Accrual", "Loan Write Off", "Loan Restructure"]},
 			{"items": ["Loan Security Unpledge", "Days Past Due Log", "Journal Entry", "Sales Invoice"]},
 		],
+		"custom_fields": [
+			{
+				"fieldname": "repay_from_salary",
+				"fieldtype": "Check",
+				"label": "Repay From Salary",
+				"default": "0"
+			}
+		]
 	}

--- a/lending/loan_management/doctype/loan/loan_list.js
+++ b/lending/loan_management/doctype/loan/loan_list.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
-// License: GNU General Public License v3. See license.txt
-
 frappe.listview_settings['Loan'] = {
 	get_indicator: function(doc) {
 		var status_color = {
@@ -13,4 +10,7 @@ frappe.listview_settings['Loan'] = {
 		};
 		return [__(doc.status), status_color[doc.status], "status,=,"+doc.status];
 	},
+	repay_from_salary: function(doc) {
+		return doc.repay_from_salary ? [__("Repay From Salary"), "green", "repay_from_salary,=,1"] : null;
+	}
 };

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.js
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.js
@@ -1,6 +1,3 @@
-// Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and contributors
-// For license information, please see license.txt
-
 lending.common.setup_filters("Loan Repayment");
 
 frappe.ui.form.on('Loan Repayment', {


### PR DESCRIPTION
Fixes #146

Add `repay_from_salary` attribute to Loan object in Loan Management module.

* **lending/loan_management/doctype/loan/loan.json**
  - Add `repay_from_salary` attribute to the fields list.
  - Set the `fieldtype` to "Check".
  - Set the `label` to "Repay From Salary".
  - Set the `default` to "0".

* **lending/loan_management/doctype/loan/loan.py**
  - Add the `repay_from_salary` attribute to the `Loan` class.
  - Update the `validate` method to handle the `repay_from_salary` attribute.
  - Update the `set_missing_fields` method to handle the `repay_from_salary` attribute.

* **lending/loan_management/doctype/loan/loan.js**
  - Add the `repay_from_salary` attribute to the `setup` method.
  - Update the `loan_application` method to handle the `repay_from_salary` attribute.

* **lending/loan_management/doctype/loan/loan_dashboard.py**
  - Add the `repay_from_salary` attribute to the `get_data` method.

* **lending/loan_management/doctype/loan/loan_list.js**
  - Add the `repay_from_salary` attribute to the `get_indicator` method.

* **lending/loan_management/doctype/loan_repayment/loan_repayment.js**
  - Add the `repay_from_salary` attribute to the `setup` method.

