### PR TITLE
ci: test against proper erpnext version"

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -10,7 +10,13 @@ sudo apt install libcups2-dev redis-server mariadb-client-10.6
 
 pip install frappe-bench
 
-git clone https://github.com/frappe/frappe --branch "$BRANCH_TO_CLONE" --depth 1
+githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
+frappeuser=${FRAPPE_USER:-"frappe"}
+frappebranch=${FRAPPE_BRANCH:-$githubbranch}
+erpnextbranch=${ERPNEXT_BRANCH:-"develop"}
+paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
+
+git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site
@@ -40,8 +46,8 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app payments
-bench get-app https://github.com/frappe/erpnext --branch develop --resolve-deps
+bench get-app "https://github.com/${frappeuser}/payments" --branch "$paymentsbranch"
+bench get-app "https://github.com/${frappeuser}/erpnext" --branch "$erpnextbranch" --resolve-deps
 bench setup requirements --dev
 
 bench start &> bench_run_logs.txt &

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -13,7 +13,7 @@ pip install frappe-bench
 githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
 frappeuser=${FRAPPE_USER:-"frappe"}
 frappebranch=${FRAPPE_BRANCH:-$githubbranch}
-erpnextbranch=${ERPNEXT_BRANCH:-"develop"}
+erpnextbranch=${ERPNEXT_BRANCH:-$githubbranch}
 paymentsbranch=${PAYMENTS_BRANCH:-${githubbranch%"-hotfix"}}
 
 git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ on:
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"
-env:
-    LENDING_BRANCH: ${{ github.base_ref || github.ref_name }}
 
 concurrency:
   group: develop-${{ github.event.number }}
@@ -101,7 +99,8 @@ jobs:
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
-          BRANCH_TO_CLONE: ${{ env.LENDING_BRANCH }}
+          FRAPPE_USER: ${{ github.event.inputs.user }}
+          FRAPPE_BRANCH: ${{ github.event.inputs.branch }}
 
 
       - name: Run Tests


### PR DESCRIPTION
I think we don't want to test, say `version-15` branch against a not-yet rolled out `erpnext/develop`.

@deepeshgarg007 I think this is an important fix to the ci (please, only consider second commit - stacked onto https://github.com/frappe/lending/pull/200)