### PR TITLE
fix: validation for loan restructure date

### DIFF
--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -44,7 +44,7 @@ class LoanRestructure(AccountsController):
 
 	def validate_restructure_date(self):
 		max_due_date = frappe.db.get_value(
-			"Loan Interest Accrual", {"loan": self.loan}, "max(posting_date)"
+			"Loan Interest Accrual", {"loan": self.loan, "docstatus": 1}, "max(posting_date)"
 		)
 		if max_due_date and getdate(self.restructure_date) < getdate(max_due_date):
 			frappe.throw(_("Restructure Date cannot be before last due date {0}").format(max_due_date))


### PR DESCRIPTION
Issue:
When processing a loan repayment, the system was fetching the posting_date from a cancelled "Loan Interest Accrual" entry.

Fix:
Added a filter for docstatus = 1 in the query to ensure only submitted entries are considered