### PR TITLE
fix: loan refund gl entry

### DIFF
--- a/lending/loan_management/doctype/loan_refund/loan_refund.py
+++ b/lending/loan_management/doctype/loan_refund/loan_refund.py
@@ -119,8 +119,8 @@ class LoanRefund(AccountsController):
 					"remarks": _("Against Loan:") + self.loan,
 					"cost_center": self.cost_center,
 					"posting_date": getdate(self.posting_date),
-					"party_type": loan_details.applicant_type,
-					"party": loan_details.applicant,
+					"party_type": self.applicant_type,
+					"party": self.applicant,
 				}
 			)
 		)


### PR DESCRIPTION
Loan product does not have the attributes "applicant_type" and "applicant," while the loan refund does include these attributes.