### PR TITLE
fix: cancel disbursement with gl cancel

### DIFF
--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -573,8 +573,7 @@ class LoanDisbursement(AccountsController):
 		else:
 			bank_account = self.disbursement_account
 
-		if not cancel:
-			self.add_gl_entry(gle_map, self.loan_account, bank_account, self.disbursed_amount, remarks)
+		self.add_gl_entry(gle_map, self.loan_account, bank_account, self.disbursed_amount, remarks)
 
 		if self.withhold_security_deposit:
 			security_deposit_account = frappe.db.get_value(


### PR DESCRIPTION
**Issue:**
- When canceling a Loan Disbursement, the associated GL Entries were not being canceled correctly. This caused discrepancies in the accounting records, as the GL entries remained active even though the disbursement was reversed. 

![image](https://github.com/user-attachments/assets/31d82ac2-619a-4b85-b152-fd76fb015ccf)

![image](https://github.com/user-attachments/assets/2ba0f3d1-0070-41c3-ad28-21dcfa40c1f1)



**Fix:**
- Remove the `if not cancel` condition. when a Loan Disbursement is canceled, the related GL entries are also canceled. The logic now creates a reverse entry or marks the original entry as canceled, based on the state of the disbursement.

![image](https://github.com/user-attachments/assets/bdba3740-9c52-4158-9b29-fd4fdd185da0)

![image](https://github.com/user-attachments/assets/affbc7d9-9bcb-4ac2-9db8-251dc3918618)
