### PR TITLE
fix: DPD as 1 for as on date disbursement and Pre-payment

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -742,7 +742,12 @@ def update_days_past_due_in_loans(
 			)
 
 			dpd_date = posting_date
-			days_past_due = date_diff(getdate(dpd_date), getdate(demand_date)) + 1
+
+			if posting_date == add_days(getdate(), -1):
+				days_past_due = date_diff(getdate(dpd_date), getdate(demand_date)) + 1
+			else:
+				days_past_due = date_diff(getdate(dpd_date), getdate(demand_date))
+
 			if days_past_due < 0:
 				days_past_due = 0
 


### PR DESCRIPTION
Issue: https://support.frappe.io/helpdesk/tickets/26760

If the disbursement date matches the Loan Repayment (Pre Payment) date, the DPD is displayed as 1. To fix this, we ensure that when the disbursement date equals the Loan Repayment date, the DPD is set to 0