### PR TITLE
fix: closed status in loan disbursement

### DIFF
--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
@@ -46,6 +46,7 @@
   "disbursement_references_section",
   "reference_date",
   "days_past_due",
+  "status",
   "column_break_17",
   "reference_number",
   "amended_from"
@@ -343,12 +344,22 @@
    "fieldtype": "Currency",
    "label": "Principal Amount Paid",
    "options": "Company:company:default_currency"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "\nDraft\nSubmitted\nCancelled\nClosed",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-12 16:56:42.962589",
+ "modified": "2024-12-31 15:56:14.127955",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Disbursement",

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
@@ -359,7 +359,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-31 22:51:42.962589",
+ "modified": "2025-01-01 11:56:14.127955",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Disbursement",

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -42,6 +42,7 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 
 class LoanDisbursement(AccountsController):
 	def validate(self):
+		self.set_status()
 		self.set_missing_values()
 		self.validate_disbursal_amount()
 		if self.repayment_schedule_type == "Line of Credit":
@@ -126,6 +127,14 @@ class LoanDisbursement(AccountsController):
 		self.create_loan_limit_change_log()
 		self.withheld_security_deposit()
 		self.make_gl_entries()
+
+	def set_status(self):
+		if self.docstatus == 0:
+			self.status = "Draft"
+		elif self.docstatus == 1:
+			self.db_set("status", "Submitted")
+		elif self.docstatus == 2:
+			self.db_set("status", "Cancelled")
 
 	def add_bpi_difference_entry(self, gle_map):
 		if flt(self.bpi_amount_difference) > 0:
@@ -247,6 +256,7 @@ class LoanDisbursement(AccountsController):
 
 		self.make_gl_entries(cancel=1)
 		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry"]
+		self.set_status()
 
 	def set_missing_values(self):
 		if not self.disbursement_date:

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement_list.js
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement_list.js
@@ -1,12 +1,12 @@
-// Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
+// Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-frappe.listview_settings['Loan Repayment Schedule'] = {
+frappe.listview_settings['Loan Disbursement'] = {
 	get_indicator: function(doc) {
-		let status_color = {
+		var status_color = {
 			"Draft": "red",
-			"Active": "green",
-			"Restructured": "orange",
+			"Submitted": "blue",
+			"Cancelled": "red",
 			"Closed": "green"
 		};
 		return [__(doc.status), status_color[doc.status], "status,=,"+doc.status];

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -921,6 +921,9 @@ class LoanRepayment(AccountsController):
 					query = query.set(loan.status, "Disbursed")
 					self.update_repayment_schedule_status(cancel=1)
 
+			if self.repayment_schedule_type == "Line of Credit" and self.loan_disbursement:
+				self.update_repayment_schedule_status(cancel=1)
+
 			if flt(self.excess_amount) > 0:
 				query = query.set(loan.excess_amount_paid, loan.excess_amount_paid - self.excess_amount)
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -837,13 +837,14 @@ class LoanRepayment(AccountsController):
 
 		if self.loan_disbursement:
 			filters["loan_disbursement"] = self.loan_disbursement
+			if cancel:
+				frappe.db.set_value("Loan Disbursement", self.loan_disbursement, "status", "Submitted")
+			if status == "Closed":
+				frappe.db.set_value("Loan Disbursement", self.loan_disbursement, "status", status)
 
 		repayment_schedule = frappe.get_value("Loan Repayment Schedule", filters, "name")
 		if repayment_schedule:
 			frappe.db.set_value("Loan Repayment Schedule", repayment_schedule, "status", status)
-
-		if self.loan_disbursement and status == "Closed":
-			frappe.db.set_value("Loan Disbursement", self.loan_disbursement, "status", status)
 
 	def auto_close_loan(self):
 		auto_close = False

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -842,6 +842,9 @@ class LoanRepayment(AccountsController):
 		if repayment_schedule:
 			frappe.db.set_value("Loan Repayment Schedule", repayment_schedule, "status", status)
 
+		if self.loan_disbursement and status == "Closed":
+			frappe.db.set_value("Loan Disbursement", self.loan_disbursement, "status", status)
+
 	def auto_close_loan(self):
 		auto_close = False
 

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -36,3 +36,4 @@ lending.patches.v15_0.update_loan_product_accounts
 lending.patches.v15_0.create_accounting_dimensions_for_loan_doctypes
 lending.patches.v15_0.update_maturity_date
 lending.patches.v15_0.loan_repayment_schedule_status_patch
+lending.patches.v15_0.loan_disbursement_status_patch

--- a/lending/patches/v15_0/loan_disbursement_status_patch.py
+++ b/lending/patches/v15_0/loan_disbursement_status_patch.py
@@ -1,0 +1,25 @@
+import frappe
+
+loan_dis = frappe.db.get_all(
+	"Loan Disbursement",
+	filters={"status": ["!=", "Closed"]},
+	fields=["name", "docstatus"],
+)
+for ld in loan_dis:
+	if ld.docstatus == 0:
+		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Draft", update_modified=False)
+	elif ld.docstatus == 1:
+		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Submitted", update_modified=False)
+	elif ld.docstatus == 2:
+		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Cancelled", update_modified=False)
+
+loan_repay_sche = frappe.db.get_all(
+	"Loan Repayment Schedule",
+	filters={"status": "Closed"},
+	fields=["loan_disbursement"],
+)
+for lrs in loan_repay_sche:
+	if lrs.loan_disbursement:
+		frappe.db.set_value(
+			"Loan Disbursement", lrs.loan_disbursement, "status", "Closed", update_modified=False
+		)

--- a/lending/patches/v15_0/loan_disbursement_status_patch.py
+++ b/lending/patches/v15_0/loan_disbursement_status_patch.py
@@ -1,25 +1,35 @@
 import frappe
 
-loan_dis = frappe.db.get_all(
-	"Loan Disbursement",
-	filters={"status": ["!=", "Closed"]},
-	fields=["name", "docstatus"],
+frappe.db.sql(
+	"""
+	UPDATE `tabLoan Disbursement`
+	SET status = 'Draft'
+	WHERE docstatus = 0
+"""
 )
-for ld in loan_dis:
-	if ld.docstatus == 0:
-		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Draft", update_modified=False)
-	elif ld.docstatus == 1:
-		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Submitted", update_modified=False)
-	elif ld.docstatus == 2:
-		frappe.db.set_value("Loan Disbursement", ld.name, "status", "Cancelled", update_modified=False)
 
-loan_repay_sche = frappe.db.get_all(
-	"Loan Repayment Schedule",
-	filters={"status": "Closed"},
-	fields=["loan_disbursement"],
+frappe.db.sql(
+	"""
+	UPDATE `tabLoan Disbursement`
+	SET status = 'Submitted'
+	WHERE docstatus = 1
+"""
 )
-for lrs in loan_repay_sche:
-	if lrs.loan_disbursement:
-		frappe.db.set_value(
-			"Loan Disbursement", lrs.loan_disbursement, "status", "Closed", update_modified=False
-		)
+
+frappe.db.sql(
+	"""
+	UPDATE `tabLoan Disbursement`
+	SET status = 'Cancelled'
+	WHERE docstatus = 2
+"""
+)
+
+frappe.db.sql(
+	"""
+	UPDATE `tabLoan Disbursement` ld
+	INNER JOIN `tabLoan Repayment Schedule` lrs
+	ON ld.name = lrs.loan_disbursement
+	SET ld.status = 'Closed'
+	WHERE lrs.status = 'Closed'
+"""
+)


### PR DESCRIPTION
First, add a status field in the loan disbursement. When the loan repayment schedule is closed, the loan disbursement should also be automatically marked as closed.