### PR TITLE
fix: Remove UOM and allow renaming for loan product

### DIFF
--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "field:product_code",
  "creation": "2019-08-29 18:08:38.159726",
  "doctype": "DocType",
@@ -450,7 +451,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-25 11:18:12.517166",
+ "modified": "2025-01-06 16:38:24.416251",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_security_price/loan_security_price.json
+++ b/lending/loan_management/doctype/loan_security_price/loan_security_price.json
@@ -9,8 +9,6 @@
   "loan_security",
   "loan_security_name",
   "loan_security_type",
-  "column_break_2",
-  "uom",
   "section_break_4",
   "loan_security_price",
   "section_break_6",
@@ -26,18 +24,6 @@
    "label": "Loan Security",
    "options": "Loan Security",
    "reqd": 1
-  },
-  {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fetch_from": "loan_security.unit_of_measure",
-   "fieldname": "uom",
-   "fieldtype": "Link",
-   "label": "UOM",
-   "options": "UOM",
-   "read_only": 1
   },
   {
    "fieldname": "section_break_4",
@@ -91,7 +77,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-01-17 07:41:49.598086",
+ "modified": "2025-01-06 13:11:25.399176",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Price",
@@ -125,5 +111,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
1. Removed an unnecessary field (UOM) for Loan Security Price
2. Enabled renaming of the Loan Product DocType