### PR TITLE
Fix: Proper Placement of Loan tab in Company DocType

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -194,9 +194,7 @@ def make_property_setter_for_journal_entry():
 			property_setter_doc.value += "\n" + "Loan Interest Accrual"
 			property_setter_doc.save()
 	else:
-		options = (
-			frappe.get_meta("Journal Entry Account").get_field("reference_type").options
-		)
+		options = frappe.get_meta("Journal Entry Account").get_field("reference_type").options
 		options += "\n" + "Loan Interest Accrual"
 
 		make_property_setter(

--- a/lending/install.py
+++ b/lending/install.py
@@ -18,7 +18,7 @@ LOAN_CUSTOM_FIELDS = {
 			"fieldname": "loan_tab",
 			"fieldtype": "Tab Break",
 			"label": "Loan",
-			"insert_after": "default_in_transit_warehouse",
+			"insert_after": "default_operating_cost_account",
 		},
 		{
 			"fieldname": "loan_settings",
@@ -194,7 +194,9 @@ def make_property_setter_for_journal_entry():
 			property_setter_doc.value += "\n" + "Loan Interest Accrual"
 			property_setter_doc.save()
 	else:
-		options = frappe.get_meta("Journal Entry Account").get_field("reference_type").options
+		options = (
+			frappe.get_meta("Journal Entry Account").get_field("reference_type").options
+		)
 		options += "\n" + "Loan Interest Accrual"
 
 		make_property_setter(


### PR DESCRIPTION
Custom Loan tab is added to Company DocType. However, it is misplaced causing the fields in **Stock and Manufacturing** tab be split and attached to the Loan tab.

The placement is done in _after_install_ hook pointing to _lending.install_ file.

The _insert_after_ key value should be the last field in **Stock and Manufacturing** which is '_ default_operating_cost_account_'

This will put back the **Stock and Manufacturing** fields back into there proper place.

Screenshot after running:
from lending.install import after_install
afteer_install()

![CleanShot 2025-01-16 at 07 55 07@2x](https://github.com/user-attachments/assets/dd5e17d3-08a1-469a-aec0-e141aefd0f10)
