### PR TITLE
fix: adjust amount exceeding due limit to principal paid

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -399,9 +399,11 @@ class LoanRepayment(AccountsController):
 					interest_paid, updated_entries = self.allocate_interest_amount(
 						interest_paid, repayment_details
 					)
-					self.allocate_principal_amount_for_term_loans(
+					interest_paid, updated_entries = self.allocate_principal_amount_for_term_loans(
 						interest_paid, repayment_details, updated_entries
 					)
+				if interest_paid > 0:
+					self.principal_amount_paid += interest_paid
 			elif self.repayment_type in ("Principal Adjustment", "Principal Capitalization"):
 				self.allocate_principal_amount_for_term_loans(interest_paid, repayment_details, {})
 			elif self.repayment_type in (


### PR DESCRIPTION
When creating a loan repayment entry, adjust the amount paid over the due limit to the principal payable.