### PR TITLE
fix: Deadlock issues on posting loan repayment

### DIFF
--- a/lending/loan_management/doctype/loan_demand/loan_demand.json
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.json
@@ -52,8 +52,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Demand Type",
-   "options": "EMI\nPenalty\nNormal\nCharges\nBPI\nAdditional Interest",
-   "search_index": 1
+   "options": "EMI\nPenalty\nNormal\nCharges\nBPI\nAdditional Interest"
   },
   {
    "fieldname": "demand_amount",
@@ -69,8 +68,7 @@
    "no_copy": 1,
    "options": "Loan Demand",
    "print_hide": 1,
-   "read_only": 1,
-   "search_index": 1
+   "read_only": 1
   },
   {
    "fieldname": "loan",
@@ -116,8 +114,7 @@
    "fieldname": "applicant_type",
    "fieldtype": "Link",
    "label": "Applicant Type",
-   "options": "DocType",
-   "search_index": 1
+   "options": "DocType"
   },
   {
    "fetch_from": "loan.applicant",
@@ -137,8 +134,7 @@
    "fieldname": "demand_subtype",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Demand Subtype",
-   "search_index": 1
+   "label": "Demand Subtype"
   },
   {
    "fetch_from": "loan.company",
@@ -234,7 +230,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-26 21:19:21.444155",
+ "modified": "2025-01-29 14:12:33.665969",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Demand",


### PR DESCRIPTION
Resolved some deadlock issues while posting multiple parallel payments against single loans
- Converted multiple queries on loan doctype into single query
-  Removed unnecessary indexes from loan demand doctype