### PR TITLE
fix: Pull fields from Loan Application into Loan

### DIFF
--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -16,6 +16,7 @@ frappe.ui.form.on('Loan', {
 	},
 	onload: function (frm) {
 		frm.trigger("loan_application")
+
 		// Ignore Loan Security Assignment on cancel of loan
 		frm.ignore_doctypes_on_cancel_all = ["Loan Security Assignment", "Loan Repayment Schedule", "Sales Invoice",
 			"Loan Transfer", "Journal Entry"];
@@ -251,7 +252,6 @@ frappe.ui.form.on('Loan', {
 					"loan_application": frm.doc.loan_application
 				},
 				callback: function (r) {
-					console.log(r.exc)
 					if (!r.exc && r.message) {
 						loan_application_fields.forEach(field => {
 							frm.set_df_property(field, 'read_only', 1);
@@ -259,9 +259,7 @@ frappe.ui.form.on('Loan', {
 						});
 						if (frm.doc.is_secured_loan) {
 							$.each(r.message.proposed_pledges, function(i, d) {
-								console.log(r)
 								let row = frm.add_child("securities");
-								console.log(row)
 								row.loan_security = d.loan_security;
 								row.qty = d.qty;
 								row.loan_security_price = d.loan_security_price;

--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -3,6 +3,9 @@
 
 lending.common.setup_filters("Loan");
 
+const loan_application_fields = ["loan_product", "loan_amount", "repayment_method",
+	"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan", "applicant", "applicant_type", "maximum_loan_amount"]
+
 frappe.ui.form.on('Loan', {
 	setup: function(frm) {
 		frm.make_methods = {
@@ -12,6 +15,7 @@ frappe.ui.form.on('Loan', {
 		}
 	},
 	onload: function (frm) {
+		frm.trigger("loan_application")
 		// Ignore Loan Security Assignment on cancel of loan
 		frm.ignore_doctypes_on_cancel_all = ["Loan Security Assignment", "Loan Repayment Schedule", "Sales Invoice",
 			"Loan Transfer", "Journal Entry"];
@@ -247,19 +251,17 @@ frappe.ui.form.on('Loan', {
 					"loan_application": frm.doc.loan_application
 				},
 				callback: function (r) {
+					console.log(r.exc)
 					if (!r.exc && r.message) {
-
-						let loan_fields = ["loan_product", "loan_amount", "repayment_method",
-							"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan", "applicant", "applicant_type", "maximum_loan_amount"]
-
-						loan_fields.forEach(field => {
+						loan_application_fields.forEach(field => {
+							frm.set_df_property(field, 'read_only', 1);
 							frm.set_value(field, r.message[field]);
-							frm.set_df_property(field, 'read_only', 1)
 						});
-
 						if (frm.doc.is_secured_loan) {
 							$.each(r.message.proposed_pledges, function(i, d) {
+								console.log(r)
 								let row = frm.add_child("securities");
+								console.log(row)
 								row.loan_security = d.loan_security;
 								row.qty = d.qty;
 								row.loan_security_price = d.loan_security_price;
@@ -271,6 +273,11 @@ frappe.ui.form.on('Loan', {
 						}
 					}
 				}
+			});
+		}
+		else {
+			loan_application_fields.forEach(field => {
+				frm.set_df_property(field, 'read_only', 0);
 			});
 		}
 	},

--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -250,10 +250,11 @@ frappe.ui.form.on('Loan', {
 					if (!r.exc && r.message) {
 
 						let loan_fields = ["loan_product", "loan_amount", "repayment_method",
-							"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan"]
+							"monthly_repayment_amount", "repayment_periods", "rate_of_interest", "is_secured_loan", "applicant", "applicant_type", "maximum_loan_amount"]
 
 						loan_fields.forEach(field => {
 							frm.set_value(field, r.message[field]);
+							frm.set_df_property(field, 'read_only', 1)
 						});
 
 						if (frm.doc.is_secured_loan) {

--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -709,7 +709,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-08 20:27:32.009472",
+ "modified": "2025-02-14 13:00:14.179337",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -287,7 +287,7 @@ class Loan(AccountsController):
 
 	def link_loan_security_assignment(self):
 		if self.is_secured_loan and self.loan_application:
-			lsa, maximum_loan_value = frappe.db.get_value(
+			lsa_details = frappe.db.get_value(
 				"Loan Security Assignment",
 				{
 					"loan_application": self.loan_application,
@@ -297,7 +297,8 @@ class Loan(AccountsController):
 				["name", "maximum_loan_value"],
 			)
 
-			if lsa:
+			if lsa_details:
+				lsa, maximum_loan_value = lsa_details
 				frappe.db.set_value(
 					"Loan Security Assignment",
 					lsa,


### PR DESCRIPTION
All the fields set in Loan Application are now imported if Loan Application is set in Loan

Reolves #24 and #30 