### PR TITLE
Repayment schedule rewrite (exact monthly repayments for repay over fixed number of periods) + optional rounding off of repayment amount in repayment schedule

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1951,6 +1951,7 @@ def create_loan_product(
 	charges_receivable_account="Charges Receivable - _TC",
 	suspense_interest_income="Suspense Income Account - _TC",
 	interest_waiver_account="Interest Waiver Account - _TC",
+	write_off_account="Write Off Account - _TC",
 	repayment_method=None,
 	repayment_periods=None,
 	repayment_schedule_type="Monthly as per repayment start date",
@@ -1998,6 +1999,7 @@ def create_loan_product(
 	loan_product_doc.interest_waiver_account = interest_waiver_account
 	loan_product_doc.interest_accrued_account = interest_accrued_account
 	loan_product_doc.penalty_accrued_account = penalty_accrued_account
+	loan_product_doc.write_off_account = write_off_account
 	loan_product_doc.broken_period_interest_recovery_account = broken_period_interest_recovery_account
 	loan_product_doc.additional_interest_income = additional_interest_income
 	loan_product_doc.additional_interest_accrued = additional_interest_accrued

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -18,6 +18,9 @@ from lending.loan_management.doctype.loan.loan import (
 from lending.loan_management.doctype.loan_repayment_schedule.loan_repayment_schedule import (
 	get_monthly_repayment_amount,
 )
+from lending.loan_management.doctype.loan_repayment_schedule.utils import (
+	get_ceil_monthly_repayment,
+)
 from lending.loan_management.doctype.loan_security_price.loan_security_price import (
 	get_loan_security_price,
 )
@@ -115,8 +118,13 @@ class LoanApplication(Document):
 
 		if self.is_term_loan:
 			if self.repayment_method == "Repay Over Number of Periods":
+				ceil_monthly_repayment = get_ceil_monthly_repayment(loan_product=self.loan_product)
 				self.repayment_amount = get_monthly_repayment_amount(
-					self.loan_amount, self.rate_of_interest, self.repayment_periods, "Monthly"
+					self.loan_amount,
+					self.rate_of_interest,
+					self.repayment_periods,
+					"Monthly",
+					ceil_monthly_repayment=ceil_monthly_repayment,
 				)
 
 			if self.repayment_method == "Repay Fixed Amount per Period":

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -19,6 +19,7 @@ from lending.loan_management.doctype.loan_repayment_schedule.loan_repayment_sche
 	get_monthly_repayment_amount,
 )
 from lending.loan_management.doctype.loan_repayment_schedule.utils import (
+	add_single_month,
 	get_ceil_monthly_repayment,
 )
 from lending.loan_management.doctype.loan_security_price.loan_security_price import (
@@ -119,12 +120,18 @@ class LoanApplication(Document):
 		if self.is_term_loan:
 			if self.repayment_method == "Repay Over Number of Periods":
 				ceil_monthly_repayment = get_ceil_monthly_repayment(loan_product=self.loan_product)
+				interest_day_count_convention = frappe.get_cached_value(
+					"Company", self.company, "interest_day_count_convention"
+				)
 				self.repayment_amount = get_monthly_repayment_amount(
 					self.loan_amount,
 					self.rate_of_interest,
 					self.repayment_periods,
 					"Monthly",
 					ceil_monthly_repayment=ceil_monthly_repayment,
+					interest_day_count_convention=interest_day_count_convention,
+					disbursement_date=self.posting_date,
+					repayment_start_date=add_single_month(self.posting_date),
 				)
 
 			if self.repayment_method == "Repay Fixed Amount per Period":

--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -308,7 +308,6 @@ def make_loan_demand_for_demand_loans(
 	loan=None,
 	process_loan_demand=None,
 ):
-	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	filters = {
 		"docstatus": 1,
 		"status": ("in", ("Disbursed", "Partially Disbursed", "Active")),

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -10,9 +10,9 @@ from frappe.utils import (
 	cint,
 	date_diff,
 	flt,
-	get_datetime,
 	get_first_day,
 	get_first_day_of_week,
+	get_last_day,
 	getdate,
 	nowdate,
 )
@@ -264,11 +264,11 @@ def calculate_accrual_amount_for_loans(
 		pending_principal_amount = get_pending_principal_amount(loan)
 
 		payable_interest = get_interest_amount(
-			no_of_days,
 			principal_amount=pending_principal_amount,
 			rate_of_interest=loan.rate_of_interest,
 			company=loan.company,
-			posting_date=posting_date,
+			from_date=last_accrual_date,
+			to_date=posting_date,
 		)
 
 		if payable_interest > 0:
@@ -394,11 +394,11 @@ def is_posting_date_accrual_day(loan_accrual_frequency, posting_date):
 def get_interest_for_term(company, rate_of_interest, pending_principal_amount, from_date, to_date):
 	no_of_days = date_diff(to_date, from_date) + 1
 	payable_interest = get_interest_amount(
-		no_of_days,
-		principal_amount=pending_principal_amount,
-		rate_of_interest=rate_of_interest,
-		company=company,
-		posting_date=to_date,
+		pending_principal_amount,
+		rate_of_interest,
+		company,
+		from_date=from_date,
+		to_date=add_days(to_date, 1),
 	)
 
 	return payable_interest
@@ -557,10 +557,11 @@ def calculate_penal_interest_for_loans(
 			else:
 				from_date = add_days(last_accrual_date, 1)
 
-			no_of_days = date_diff(posting_date, from_date)
+			# no_of_days = date_diff(posting_date, from_date)
 
-			penal_interest_amount = flt(demand.pending_amount) * penal_interest_rate * no_of_days / 36500
-
+			penal_interest_amount = get_interest_amount(
+				demand.pending_amount, penal_interest_amount, loan.company, from_date, posting_date
+			)
 			if flt(penal_interest_amount, precision) > 0:
 				total_penal_interest += penal_interest_amount
 
@@ -578,10 +579,9 @@ def calculate_penal_interest_for_loans(
 				if not principal_amount:
 					continue
 
-				per_day_interest = get_per_day_interest(
-					principal_amount, loan.rate_of_interest, loan.company, posting_date
+				additional_interest_amount = get_interest_amount(
+					principal_amount, loan.rate_of_interest, loan.company, from_date, posting_date
 				)
-				additional_interest = flt(per_day_interest * no_of_days, precision)
 
 				if not is_future_accrual:
 					if flt(penal_interest_amount, precision) > 0:
@@ -596,7 +596,7 @@ def calculate_penal_interest_for_loans(
 							"Penal Interest",
 							penal_interest_rate,
 							loan_demand=demand.name,
-							additional_interest=additional_interest,
+							additional_interest=additional_interest_amount,
 							accrual_date=accrual_date,
 							loan_repayment_schedule_detail=demand.repayment_schedule_detail,
 						)
@@ -872,49 +872,73 @@ def days_in_year(year):
 	return days
 
 
-def get_per_day_interest(
-	principal_amount, rate_of_interest, company, posting_date=None, interest_day_count_convention=None
-):
-	if not posting_date:
-		posting_date = getdate()
-
-	if not interest_day_count_convention:
-		interest_day_count_convention = frappe.get_cached_value(
-			"Company", company, "interest_day_count_convention"
-		)
-
-	if interest_day_count_convention == "Actual/365" or interest_day_count_convention == "30/365":
-		year_divisor = 365
-	elif interest_day_count_convention == "30/360" or interest_day_count_convention == "Actual/360":
-		year_divisor = 360
-	else:
-		# Default is Actual/Actual
-		year_divisor = days_in_year(get_datetime(posting_date).year)
-
-	return flt((principal_amount * rate_of_interest) / (year_divisor * 100))
-
-
 def get_interest_amount(
-	no_of_days,
-	principal_amount=None,
-	rate_of_interest=None,
-	company=None,
-	posting_date=None,
-	interest_per_day=None,
+	principal_amount,
+	rate_of_interest,
+	company,
+	from_date,
+	to_date,
 ):
 	interest_day_count_convention = frappe.get_cached_value(
 		"Company", company, "interest_day_count_convention"
 	)
 
-	if not interest_per_day:
-		interest_per_day = get_per_day_interest(
-			principal_amount, rate_of_interest, company, posting_date, interest_day_count_convention
-		)
+	interest_for_duration = rate_of_interest / 100
+	if interest_day_count_convention == "Actual/Actual":
+		year_a = getdate(from_date)
+		year_b = getdate(to_date)
+		if days_in_year(year_a) != days_in_year(year_b):
+			first_year_interest_rate = date_diff(getdate(f"31-12-{year_a}"), from_date) / days_in_year(
+				year_a
+			)
+			second_year_interest_rate = date_diff(to_date, getdate(f"31-12-{year_a}")) / days_in_year(
+				year_b
+			)
+			interest_for_duration *= first_year_interest_rate + second_year_interest_rate
+		else:
+			interest_for_duration *= date_diff(getdate(to_date, from_date)) / days_in_year(year_a)
+	else:
+		if interest_day_count_convention.startswith("Actual"):
+			interest_for_duration *= date_diff(getdate(to_date, from_date))
+		elif interest_day_count_convention.startswith("30"):
+			# complex logic; don't even try
+			# tldr; treats all months as 30 days long
+			no_of_months = 0
+			cur_date = from_date
+			while True:
+				if add_single_month(cur_date) <= to_date:
+					no_of_months += 1
+					cur_date = add_single_month(cur_date)
+				elif cur_date <= to_date:
+					last_day_of_cur_date = get_last_day(cur_date)
+					last_day_of_to_date = get_last_day(to_date)
+					if last_day_of_cur_date == last_day_of_to_date:
+						no_of_months += date_diff(to_date, cur_date) / get_days_in_month(cur_date)
+					else:
+						no_of_months += date_diff(last_day_of_cur_date, cur_date) / get_days_in_month(cur_date)
+						no_of_months += date_diff(to_date, last_day_of_cur_date) / get_days_in_month(to_date)
+					break
+				else:
+					break
+		interest_for_duration *= no_of_months * 30
 
-	if interest_day_count_convention == "30/365" or interest_day_count_convention == "30/360":
-		no_of_days = 30
+		if interest_day_count_convention.endswith("360"):
+			interest_for_duration /= 360
+		if interest_day_count_convention.endswith("365"):
+			interest_for_duration /= 365
 
-	return interest_per_day * no_of_days
+	return interest_for_duration * principal_amount
+
+
+def get_days_in_month(date):
+	return date_diff(get_last_day(date), get_first_day(date)) + 1
+
+
+def add_single_month(date):
+	if getdate(date) == get_last_day(date):
+		return get_last_day(add_months(date, 1))
+	else:
+		return add_months(date, 1)
 
 
 def reverse_loan_interest_accruals(

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -266,9 +266,9 @@ def calculate_accrual_amount_for_loans(
 		payable_interest = get_interest_amount(
 			principal_amount=pending_principal_amount,
 			rate_of_interest=loan.rate_of_interest,
-			company=loan.company,
 			from_date=last_accrual_date,
 			to_date=posting_date,
+			company=loan.company,
 		)
 
 		if payable_interest > 0:
@@ -394,11 +394,11 @@ def is_posting_date_accrual_day(loan_accrual_frequency, posting_date):
 def get_interest_for_term(company, rate_of_interest, pending_principal_amount, from_date, to_date):
 	no_of_days = date_diff(to_date, from_date) + 1
 	payable_interest = get_interest_amount(
-		pending_principal_amount,
-		rate_of_interest,
-		company,
+		principal_amount=pending_principal_amount,
+		rate_of_interest=rate_of_interest,
 		from_date=from_date,
 		to_date=add_days(to_date, 1),
+		company=company,
 	)
 
 	return payable_interest
@@ -560,7 +560,11 @@ def calculate_penal_interest_for_loans(
 			# no_of_days = date_diff(posting_date, from_date)
 
 			penal_interest_amount = get_interest_amount(
-				demand.pending_amount, penal_interest_amount, loan.company, from_date, posting_date
+				principal_amount=demand.pending_amount,
+				rate_of_interest=penal_interest_amount,
+				from_date=from_date,
+				to_date=posting_date,
+				company=loan.company,
 			)
 			if flt(penal_interest_amount, precision) > 0:
 				total_penal_interest += penal_interest_amount
@@ -580,7 +584,11 @@ def calculate_penal_interest_for_loans(
 					continue
 
 				additional_interest_amount = get_interest_amount(
-					principal_amount, loan.rate_of_interest, loan.company, from_date, posting_date
+					principal_amount=principal_amount,
+					rate_of_interest=loan.rate_of_interest,
+					from_date=from_date,
+					to_date=posting_date,
+					company=loan.company,
 				)
 
 				if not is_future_accrual:
@@ -875,13 +883,15 @@ def days_in_year(year):
 def get_interest_amount(
 	principal_amount,
 	rate_of_interest,
-	company,
 	from_date,
 	to_date,
+	company=None,
+	interest_day_count_convention=None,
 ):
-	interest_day_count_convention = frappe.get_cached_value(
-		"Company", company, "interest_day_count_convention"
-	)
+	if not interest_day_count_convention:
+		interest_day_count_convention = frappe.get_cached_value(
+			"Company", company, "interest_day_count_convention"
+		)
 
 	interest_for_duration = rate_of_interest / 100
 	if interest_day_count_convention == "Actual/Actual":

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -516,7 +516,7 @@
    "label": "Accounting"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "ceil_monthly_repayment",
    "fieldtype": "Check",
    "label": "Ceil Monthly Repayment"
@@ -524,7 +524,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-14 16:13:11.987363",
+ "modified": "2025-02-14 17:27:05.719913",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -22,6 +22,7 @@
   "is_term_loan",
   "validate_normal_repayment",
   "disabled",
+  "ceil_monthly_repayment",
   "limits_section",
   "min_days_bw_disbursement_first_repayment",
   "excess_amount_acceptance_limit",
@@ -513,11 +514,17 @@
    "fieldname": "accounting_tab",
    "fieldtype": "Tab Break",
    "label": "Accounting"
+  },
+  {
+   "default": "0",
+   "fieldname": "ceil_monthly_repayment",
+   "fieldtype": "Check",
+   "label": "Ceil Monthly Repayment"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-09 16:16:25.371953",
+ "modified": "2025-02-14 16:13:11.987363",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -812,7 +812,6 @@ class LoanRepayment(AccountsController):
 
 		elif self.repayment_type == "Full Settlement":
 			if self.repayment_schedule_type != "Line of Credit":
-				print("ininininin")
 				query = query.set(loan.status, "Settled")
 				query = query.set(loan.settlement_date, self.posting_date)
 			self.update_repayment_schedule_status()

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -783,16 +783,21 @@ class LoanRepayment(AccountsController):
 					query = query.set(loan.settlement_date, self.posting_date)
 				self.update_repayment_schedule_status()
 
-		elif self.auto_close_loan() and self.repayment_type in (
-			"Normal Repayment",
-			"Pre Payment",
-			"Advance Payment",
-			"Security Deposit Adjustment",
-			"Loan Closure",
-			"Principal Adjustment",
-			"Penalty Waiver",
-			"Interest Waiver",
-			"Charges Waiver",
+		elif (
+			self.auto_close_loan()
+			and self.repayment_type
+			in (
+				"Normal Repayment",
+				"Pre Payment",
+				"Advance Payment",
+				"Security Deposit Adjustment",
+				"Loan Closure",
+				"Principal Adjustment",
+				"Penalty Waiver",
+				"Interest Waiver",
+				"Charges Waiver",
+			)
+			and not self.is_write_off_waiver
 		):
 			if self.repayment_schedule_type != "Line of Credit":
 				query = query.set(loan.status, "Closed")

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -146,7 +146,10 @@ class LoanRepayment(AccountsController):
 		update_installment_counts(self.against_loan, loan_disbursement=self.loan_disbursement)
 
 		if self.repayment_type == "Full Settlement":
-			frappe.enqueue(self.post_write_off_settlements, enqueue_after_commit=True)
+			if not frappe.flags.in_test:
+				frappe.enqueue(self.post_write_off_settlements, enqueue_after_commit=True)
+			else:
+				self.post_write_off_settlements()
 
 		update_loan_securities_values(self.against_loan, self.principal_amount_paid, self.doctype)
 		self.create_loan_limit_change_log()
@@ -809,6 +812,7 @@ class LoanRepayment(AccountsController):
 
 		elif self.repayment_type == "Full Settlement":
 			if self.repayment_schedule_type != "Line of Credit":
+				print("ininininin")
 				query = query.set(loan.status, "Settled")
 				query = query.set(loan.settlement_date, self.posting_date)
 			self.update_repayment_schedule_status()

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
@@ -18,6 +18,7 @@
   "repayment_frequency",
   "repayment_start_date",
   "maturity_date",
+  "ceil_monthly_repayment",
   "repayment_schedule_section",
   "repayment_schedule",
   "term_details_section",
@@ -376,12 +377,19 @@
    "fieldname": "co_lending_tab",
    "fieldtype": "Tab Break",
    "label": "Co Lending"
+  },
+  {
+   "default": "0",
+   "fieldname": "ceil_monthly_repayment",
+   "fieldtype": "Check",
+   "label": "Ceil Monthly Repayment",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-09 16:31:11.170120",
+ "modified": "2025-02-14 16:34:47.294351",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Schedule",

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -29,6 +29,7 @@ from lending.loan_management.doctype.loan_repayment_schedule.utils import (
 
 class LoanRepaymentSchedule(Document):
 	def validate(self):
+		self.set_ceil_monthly_repayment()
 		self.set_repayment_period()
 		self.set_repayment_start_date()
 		self.validate_repayment_method()
@@ -36,7 +37,6 @@ class LoanRepaymentSchedule(Document):
 		self.make_co_lender_schedule()
 		self.reset_index()
 		self.set_maturity_date()
-		self.set_ceil_monthly_repayment()
 
 	def reset_index(self):
 		for idx, row in enumerate(self.get("repayment_schedule"), start=1):

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -21,6 +21,7 @@ from lending.loan_management.doctype.loan_demand.loan_demand import create_loan_
 from lending.loan_management.doctype.loan_repayment_schedule.utils import (
 	add_single_month,
 	get_amounts,
+	get_ceil_monthly_repayment,
 	get_loan_partner_details,
 	get_monthly_repayment_amount,
 	set_demand,
@@ -46,24 +47,7 @@ class LoanRepaymentSchedule(Document):
 		self.maturity_date = self.get("repayment_schedule")[-1].payment_date
 
 	def set_ceil_monthly_repayment(self):
-		# The below query fetches the flag from Loan Product directly.
-		# I think this is easier and more straightforward than creating
-		# a chain of docs with redundant values
-		# (Loan Product -> Loan -> Loan Repayment)
-
-		loan_product_doc = frappe.query_builder.DocType("Loan Product")
-		loan_doc = frappe.query_builder.DocType("Loan")
-
-		loan_query = (
-			frappe.qb.from_(loan_doc).where(loan_doc.name == self.loan).select(loan_doc.loan_product)
-		)
-		query = (
-			frappe.qb.from_(loan_product_doc)
-			.where(loan_product_doc.name == loan_query)
-			.select(loan_product_doc.ceil_monthly_repayment)
-		)
-		ceil_monthly_repayment = query.run()[0][0]
-		self.ceil_monthly_repayment = ceil_monthly_repayment
+		self.ceil_monthly_repayment = get_ceil_monthly_repayment(loan=self.loan)
 
 	def on_submit(self):
 		self.make_demand_for_advance_payment()

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -36,6 +36,7 @@ class LoanRepaymentSchedule(Document):
 		self.make_co_lender_schedule()
 		self.reset_index()
 		self.set_maturity_date()
+		self.set_ceil_monthly_repayment()
 
 	def reset_index(self):
 		for idx, row in enumerate(self.get("repayment_schedule"), start=1):
@@ -43,6 +44,26 @@ class LoanRepaymentSchedule(Document):
 
 	def set_maturity_date(self):
 		self.maturity_date = self.get("repayment_schedule")[-1].payment_date
+
+	def set_ceil_monthly_repayment(self):
+		# The below query fetches the flag from Loan Product directly.
+		# I think this is easier and more straightforward than creating
+		# a chain of docs with redundant values
+		# (Loan Product -> Loan -> Loan Repayment)
+
+		loan_product_doc = frappe.query_builder.DocType("Loan Product")
+		loan_doc = frappe.query_builder.DocType("Loan")
+
+		loan_query = (
+			frappe.qb.from_(loan_doc).where(loan_doc.name == self.loan).select(loan_doc.loan_product)
+		)
+		query = (
+			frappe.qb.from_(loan_product_doc)
+			.where(loan_product_doc.name == loan_query)
+			.select(loan_product_doc.ceil_monthly_repayment)
+		)
+		ceil_monthly_repayment = query.run()[0][0]
+		self.ceil_monthly_repayment = ceil_monthly_repayment
 
 	def on_submit(self):
 		self.make_demand_for_advance_payment()
@@ -281,7 +302,11 @@ class LoanRepaymentSchedule(Document):
 
 		if not self.restructure_type and self.repayment_method != "Repay Fixed Amount per Period":
 			monthly_repayment_amount = get_monthly_repayment_amount(
-				balance_amount, rate_of_interest, self.repayment_periods, self.repayment_frequency
+				balance_amount,
+				rate_of_interest,
+				self.repayment_periods,
+				self.repayment_frequency,
+				ceil_monthly_repayment=self.ceil_monthly_repayment,
 			)
 		else:
 			monthly_repayment_amount = self.monthly_repayment_amount
@@ -318,7 +343,11 @@ class LoanRepaymentSchedule(Document):
 					):
 						balance_amount = self.loan_amount + moratorium_interest
 						monthly_repayment_amount = get_monthly_repayment_amount(
-							balance_amount, rate_of_interest, self.repayment_periods, self.repayment_frequency
+							balance_amount,
+							rate_of_interest,
+							self.repayment_periods,
+							self.repayment_frequency,
+							self.ceil_monthly_repayment,
 						)
 						moratorium_interest = 0
 
@@ -574,6 +603,7 @@ class LoanRepaymentSchedule(Document):
 							self.rate_of_interest,
 							self.repayment_periods,
 							self.repayment_frequency,
+							ceil_monthly_repayment=self.ceil_monthly_repayment,
 						)
 						return (
 							previous_interest_amount,
@@ -661,6 +691,7 @@ class LoanRepaymentSchedule(Document):
 						self.rate_of_interest,
 						self.repayment_periods - completed_tenure,
 						self.repayment_frequency,
+						ceil_monthly_repayment=self.ceil_monthly_repayment,
 					)
 
 				if self.restructure_type == "Pre Payment" and self.repayment_frequency != "One Time":

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -280,10 +280,14 @@ class LoanRepaymentSchedule(Document):
 		partner_schedule_type=None,
 	):
 		payment_date = self.repayment_start_date
+		prev_payment_date = self.posting_date
 		carry_forward_interest = self.adjusted_interest
 		moratorium_interest = 0
 		row = 0
 
+		interest_day_count_convention = frappe.get_cached_value(
+			"Company", self.company, "interest_day_count_convention"
+		)
 		if not self.restructure_type and self.repayment_method != "Repay Fixed Amount per Period":
 			monthly_repayment_amount = get_monthly_repayment_amount(
 				balance_amount,
@@ -291,6 +295,9 @@ class LoanRepaymentSchedule(Document):
 				self.repayment_periods,
 				self.repayment_frequency,
 				ceil_monthly_repayment=self.ceil_monthly_repayment,
+				interest_day_count_convention=interest_day_count_convention,
+				disbursement_date=self.posting_date,
+				repayment_start_date=self.repayment_start_date,
 			)
 		else:
 			monthly_repayment_amount = self.monthly_repayment_amount
@@ -332,6 +339,9 @@ class LoanRepaymentSchedule(Document):
 							self.repayment_periods,
 							self.repayment_frequency,
 							ceil_monthly_repayment=self.ceil_monthly_repayment,
+							interest_day_count_convention=interest_day_count_convention,
+							disbursement_date=self.posting_date,
+							repayment_start_date=self.repayment_start_date,
 						)
 						moratorium_interest = 0
 
@@ -339,6 +349,7 @@ class LoanRepaymentSchedule(Document):
 
 			payment_days, months = self.get_days_and_months(
 				payment_date,
+				prev_payment_date,
 				additional_days,
 				balance_amount,
 				rate_of_interest,
@@ -365,6 +376,7 @@ class LoanRepaymentSchedule(Document):
 				additional_principal_amount,
 				pending_prev_days,
 			)
+			prev_payment_date = payment_date
 
 			if (
 				schedule_field == "colender_schedule"
@@ -582,12 +594,18 @@ class LoanRepaymentSchedule(Document):
 						and getdate(self.posting_date) <= getdate(self.moratorium_end_date)
 						and self.restructure_type
 					):
+						interest_day_count_convention = frappe.get_cached_value(
+							"Company", self.company, "interest_day_count_convention"
+						)
 						self.monthly_repayment_amount = get_monthly_repayment_amount(
 							self.current_principal_amount,
 							self.rate_of_interest,
 							self.repayment_periods,
 							self.repayment_frequency,
 							ceil_monthly_repayment=self.ceil_monthly_repayment,
+							interest_day_count_convention=interest_day_count_convention,
+							disbursement_date=self.posting_date,
+							repayment_start_date=self.repayment_start_date,
 						)
 						return (
 							previous_interest_amount,
@@ -676,6 +694,9 @@ class LoanRepaymentSchedule(Document):
 						self.repayment_periods - completed_tenure,
 						self.repayment_frequency,
 						ceil_monthly_repayment=self.ceil_monthly_repayment,
+						interest_day_count_convention=interest_day_count_convention,
+						disbursement_date=self.posting_date,
+						repayment_start_date=self.repayment_start_date,
 					)
 
 				if self.restructure_type == "Pre Payment" and self.repayment_frequency != "One Time":
@@ -755,6 +776,7 @@ class LoanRepaymentSchedule(Document):
 	def get_days_and_months(
 		self,
 		payment_date,
+		prev_payment_date,
 		additional_days,
 		balance_amount,
 		rate_of_interest,
@@ -774,7 +796,8 @@ class LoanRepaymentSchedule(Document):
 				"Monthly as per repayment start date",
 				"Pro-rated calendar months",
 			):
-				days = date_diff(payment_date, add_months(payment_date, -1))
+				days = date_diff(payment_date, prev_payment_date)
+				print(days, "meow")
 				if (
 					additional_days < 0
 					or (additional_days > 0 and self.moratorium_tenure and not self.restructure_type)

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -18,8 +18,10 @@ from frappe.utils import (
 
 from lending.loan_management.doctype.loan.loan import get_cyclic_date
 from lending.loan_management.doctype.loan_demand.loan_demand import create_loan_demand
-from lending.loan_management.doctype.loan_repayment_schedule.utils import (
+from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
 	add_single_month,
+)
+from lending.loan_management.doctype.loan_repayment_schedule.utils import (
 	get_amounts,
 	get_ceil_monthly_repayment,
 	get_loan_partner_details,

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -347,7 +347,7 @@ class LoanRepaymentSchedule(Document):
 							rate_of_interest,
 							self.repayment_periods,
 							self.repayment_frequency,
-							self.ceil_monthly_repayment,
+							ceil_monthly_repayment=self.ceil_monthly_repayment,
 						)
 						moratorium_interest = 0
 

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -11,18 +11,24 @@ def add_single_month(date):
 		return add_months(date, 1)
 
 
-def get_monthly_repayment_amount(loan_amount, rate_of_interest, repayment_periods, frequency):
+def get_monthly_repayment_amount(
+	loan_amount, rate_of_interest, repayment_periods, frequency, ceil_monthly_repayment=False
+):
 	if frequency == "One Time":
 		repayment_periods = 1
 
 	if rate_of_interest:
 		monthly_interest_rate = flt(rate_of_interest) / (get_frequency(frequency) * 100)
-		monthly_repayment_amount = math.ceil(
-			(loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods)
-			/ ((1 + monthly_interest_rate) ** repayment_periods - 1)
-		)
+		monthly_repayment_amount = (
+			loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
+		) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
 	else:
 		monthly_repayment_amount = math.ceil(flt(loan_amount) / repayment_periods)
+
+	if ceil_monthly_repayment:
+		monthly_repayment_amount = math.ceil(monthly_repayment_amount)
+	else:
+		monthly_repayment_amount = flt(monthly_repayment_amount)
 	return monthly_repayment_amount
 
 

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -1,7 +1,11 @@
 import math
 
 import frappe
-from frappe.utils import add_months, cint, flt, get_last_day, getdate
+from frappe.utils import add_months, cint, date_diff, flt, get_last_day, getdate
+
+from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
+	days_in_year,
+)
 
 
 def add_single_month(date):
@@ -12,16 +16,44 @@ def add_single_month(date):
 
 
 def get_monthly_repayment_amount(
-	loan_amount, rate_of_interest, repayment_periods, frequency, ceil_monthly_repayment=False
+	loan_amount,
+	rate_of_interest,
+	repayment_periods,
+	frequency,
+	ceil_monthly_repayment=False,
+	disbursement_date=None,
+	repayment_start_date=None,
+	interest_day_count_convention=False,
 ):
 	if frequency == "One Time":
 		repayment_periods = 1
 
 	if rate_of_interest:
 		monthly_interest_rate = flt(rate_of_interest) / (get_frequency(frequency) * 100)
-		monthly_repayment_amount = (
-			loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
-		) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
+		if frequency == "Monthly":
+			if interest_day_count_convention.startswith("30"):
+				if interest_day_count_convention.endswith("365"):
+					monthly_interest_rate = flt(rate_of_interest) * 30 / 365
+				elif interest_day_count_convention.endswith("360"):
+					monthly_interest_rate = flt(rate_of_interest) * 30 / 360
+
+				monthly_repayment_amount = (
+					loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
+				) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
+			elif interest_day_count_convention.startswith("Actual"):
+				monthly_repayment_amount = binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
+					principal=loan_amount,
+					repayment_periods=repayment_periods,
+					rate_of_interest=rate_of_interest,
+					disbursement_date=disbursement_date,
+					repayment_start_date=repayment_start_date,
+					interest_day_count_convention=interest_day_count_convention,
+				)
+		else:
+
+			monthly_repayment_amount = (
+				loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
+			) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
 	else:
 		monthly_repayment_amount = math.ceil(flt(loan_amount) / repayment_periods)
 
@@ -141,3 +173,107 @@ def get_ceil_monthly_repayment(loan=None, loan_product=None):
 		query = query.where(loan_product_doc.name == loan_product)
 	ceil_monthly_repayment = query.run()[0][0]
 	return ceil_monthly_repayment
+
+
+def binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
+	principal,
+	repayment_periods,
+	rate_of_interest,
+	disbursement_date,
+	repayment_start_date,
+	interest_day_count_convention,
+):
+	precision = cint(frappe.db.get_default("currency_precision")) or 2
+	l = 0
+	h = principal**2  # just to be safe
+	while True:
+		print(l, h)
+		x = (l + h) / 2
+		remaining_principal = repayment_simulator_for_fixed_number_of_periods(
+			x,
+			principal,
+			repayment_periods,
+			rate_of_interest,
+			disbursement_date,
+			repayment_start_date,
+			interest_day_count_convention,
+		)
+		if abs(remaining_principal) < 0.0001:
+			repayment_simulator_for_fixed_number_of_periods(
+				x,
+				principal,
+				repayment_periods,
+				rate_of_interest,
+				disbursement_date,
+				repayment_start_date,
+				interest_day_count_convention,
+				prnt=True,
+			)
+			print(x)
+			break
+		if remaining_principal < 0:
+			h = x
+		else:
+			l = x
+	return x
+
+
+def repayment_simulator_for_fixed_number_of_periods(
+	monthly_repayment_amount,
+	principal,
+	repayment_periods,
+	rate_of_interest,
+	disbursement_date,
+	repayment_start_date,
+	interest_day_count_convention,
+	prnt=False,
+):
+	prev_date = disbursement_date
+	current_date = repayment_start_date
+	for _ in range(repayment_periods):
+
+		# separate interest for each month based on the number of days
+		# Assuming this function is only use for 'Actual/...' day count interests
+		if interest_day_count_convention.startswith("Actual"):
+			monthly_interest_rate = rate_of_interest / 100
+			if interest_day_count_convention == ("Actual/Actual"):
+				year_a = getdate(prev_date).year
+				year_b = getdate(current_date).year
+				if days_in_year(year_a) == days_in_year(year_b):
+					monthly_interest_rate *= date_diff(current_date, prev_date) / days_in_year(year_a)
+				else:
+					first_year_interest_rate = date_diff(getdate(f"31-12-{year_a}"), prev_date) / days_in_year(
+						year_a
+					)
+					second_year_interest_rate = date_diff(
+						current_date, getdate(f"31-12-{year_a}")
+					) / days_in_year(year_b)
+					# first_year_interest_rate = date_diff(getdate(f'1-1-{year_b}'), prev_date)
+					# second_year_interest_rate = date_diff(current_date, getdate(f'1-1-{year_b}'))
+					print(first_year_interest_rate, second_year_interest_rate)
+
+					monthly_interest_rate *= first_year_interest_rate + second_year_interest_rate
+			else:
+				monthly_interest_rate *= frappe.utils.date_diff(current_date, prev_date) / 365
+		elif interest_day_count_convention.startswith("30"):
+			monthly_interest_rate = rate_of_interest * 30
+
+		if interest_day_count_convention.endswith("365"):
+			monthly_interest_rate /= 365
+		elif interest_day_count_convention.endswith("360"):
+			monthly_interest_rate /= 360
+
+		interest_amount = principal * monthly_interest_rate
+		principal -= monthly_repayment_amount - interest_amount
+		if prnt:
+			print(
+				current_date,
+				monthly_repayment_amount - interest_amount,
+				interest_amount,
+				monthly_repayment_amount,
+				principal,
+				frappe.utils.date_diff(current_date, prev_date),
+			)
+		prev_date = current_date
+		current_date = add_months(current_date, 1)
+	return principal

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -1,18 +1,11 @@
 import math
 
 import frappe
-from frappe.utils import add_months, cint, date_diff, flt, get_last_day, getdate
+from frappe.utils import add_months, cint, date_diff, flt, getdate
 
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
 	days_in_year,
 )
-
-
-def add_single_month(date):
-	if getdate(date) == get_last_day(date):
-		return get_last_day(add_months(date, 1))
-	else:
-		return add_months(date, 1)
 
 
 def get_monthly_repayment_amount(
@@ -250,11 +243,11 @@ def repayment_simulator_for_fixed_number_of_periods(
 					) / days_in_year(year_b)
 					# first_year_interest_rate = date_diff(getdate(f'1-1-{year_b}'), prev_date)
 					# second_year_interest_rate = date_diff(current_date, getdate(f'1-1-{year_b}'))
-					print(first_year_interest_rate, second_year_interest_rate)
 
 					monthly_interest_rate *= first_year_interest_rate + second_year_interest_rate
 			else:
-				monthly_interest_rate *= frappe.utils.date_diff(current_date, prev_date) / 365
+				monthly_interest_rate *= date_diff(current_date, prev_date)
+
 		elif interest_day_count_convention.startswith("30"):
 			monthly_interest_rate = rate_of_interest * 30
 

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -122,3 +122,22 @@ def get_loan_partner_details(loan_partner):
 	)
 
 	return loan_partner_details
+
+
+def get_ceil_monthly_repayment(loan=None, loan_product=None):
+	# The below query fetches the flag from Loan Product directly.
+	# I think this is easier and more straightforward than creating
+	# a chain of docs with redundant values
+	# (Loan Product -> Loan -> Loan Repayment)
+
+	loan_product_doc = frappe.query_builder.DocType("Loan Product")
+	loan_doc = frappe.query_builder.DocType("Loan")
+
+	query = frappe.qb.from_(loan_product_doc).select(loan_product_doc.ceil_monthly_repayment)
+	if loan:
+		loan_query = frappe.qb.from_(loan_doc).where(loan_doc.name == loan).select(loan_doc.loan_product)
+		query = query.where(loan_product_doc.name == loan_query)
+	if loan_product:
+		query = query.where(loan_product_doc.name == loan_product)
+	ceil_monthly_repayment = query.run()[0][0]
+	return ceil_monthly_repayment

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -1,14 +1,12 @@
-import math
-
 import frappe
-from frappe.utils import add_months, cint, date_diff, flt, getdate
+from frappe.utils import add_months, cint, flt
 
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
-	days_in_year,
+	get_interest_amount,
 )
 
 
-def get_monthly_repayment_amount(
+def get_monthly_repayment_schedule(
 	loan_amount,
 	rate_of_interest,
 	repayment_periods,
@@ -21,40 +19,17 @@ def get_monthly_repayment_amount(
 	if frequency == "One Time":
 		repayment_periods = 1
 
-	if rate_of_interest:
-		monthly_interest_rate = flt(rate_of_interest) / (get_frequency(frequency) * 100)
-		if frequency == "Monthly":
-			if interest_day_count_convention.startswith("30"):
-				if interest_day_count_convention.endswith("365"):
-					monthly_interest_rate = flt(rate_of_interest) * 30 / 365
-				elif interest_day_count_convention.endswith("360"):
-					monthly_interest_rate = flt(rate_of_interest) * 30 / 360
+	monthly_repayment_schedule = binary_search_monthly_repayment_schedule_for_fixed_number_of_periods(
+		principal=loan_amount,
+		repayment_periods=repayment_periods,
+		rate_of_interest=rate_of_interest,
+		disbursement_date=disbursement_date,
+		repayment_start_date=repayment_start_date,
+		interest_day_count_convention=interest_day_count_convention,
+		ceil_monthly_repayment=ceil_monthly_repayment,
+	)
 
-				monthly_repayment_amount = (
-					loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
-				) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
-			elif interest_day_count_convention.startswith("Actual"):
-				monthly_repayment_amount = binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
-					principal=loan_amount,
-					repayment_periods=repayment_periods,
-					rate_of_interest=rate_of_interest,
-					disbursement_date=disbursement_date,
-					repayment_start_date=repayment_start_date,
-					interest_day_count_convention=interest_day_count_convention,
-				)
-		else:
-
-			monthly_repayment_amount = (
-				loan_amount * monthly_interest_rate * (1 + monthly_interest_rate) ** repayment_periods
-			) / ((1 + monthly_interest_rate) ** repayment_periods - 1)
-	else:
-		monthly_repayment_amount = math.ceil(flt(loan_amount) / repayment_periods)
-
-	if ceil_monthly_repayment:
-		monthly_repayment_amount = math.ceil(monthly_repayment_amount)
-	else:
-		monthly_repayment_amount = flt(monthly_repayment_amount)
-	return monthly_repayment_amount
+	return monthly_repayment_schedule
 
 
 def get_frequency(frequency):
@@ -168,21 +143,21 @@ def get_ceil_monthly_repayment(loan=None, loan_product=None):
 	return ceil_monthly_repayment
 
 
-def binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
+def binary_search_monthly_repayment_schedule_for_fixed_number_of_periods(
 	principal,
 	repayment_periods,
 	rate_of_interest,
 	disbursement_date,
 	repayment_start_date,
 	interest_day_count_convention,
+	ceil_monthly_repayment=False,
 ):
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	l = 0
 	h = principal**2  # just to be safe
-	while True:
-		print(l, h)
+	for i in range(300):
 		x = (l + h) / 2
-		remaining_principal = repayment_simulator_for_fixed_number_of_periods(
+		remaining_principal = repayment_simulator(
 			x,
 			principal,
 			repayment_periods,
@@ -190,9 +165,10 @@ def binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
 			disbursement_date,
 			repayment_start_date,
 			interest_day_count_convention,
+			ceil_monthly_repayment,
 		)
 		if abs(remaining_principal) < 0.0001:
-			repayment_simulator_for_fixed_number_of_periods(
+			_, schedule = repayment_simulator(
 				x,
 				principal,
 				repayment_periods,
@@ -200,73 +176,63 @@ def binary_search_monthly_repayment_amount_for_fixed_number_of_periods(
 				disbursement_date,
 				repayment_start_date,
 				interest_day_count_convention,
-				prnt=True,
+				generate_schedule=True,
 			)
-			print(x)
-			break
+			return x, schedule
 		if remaining_principal < 0:
 			h = x
 		else:
 			l = x
-	return x
+	frappe.throw("There was an error finding the monthly repayment amount (binary search stuck)")
 
 
-def repayment_simulator_for_fixed_number_of_periods(
+def repayment_simulator(
 	monthly_repayment_amount,
 	principal,
-	repayment_periods,
+	repayment_method,
 	rate_of_interest,
 	disbursement_date,
 	repayment_start_date,
 	interest_day_count_convention,
-	prnt=False,
+	repayment_periods=None,
+	generate_schedule=False,
 ):
+	# list initialisation takes up resources
+	if generate_schedule:
+		schedule = []
 	prev_date = disbursement_date
 	current_date = repayment_start_date
-	for _ in range(repayment_periods):
+	i = 0
+	repay_over_number_of_periods = repayment_method == "Repay Over Number of Periods"
+	while True:
+		i += 1
+		interest_amount = get_interest_amount(
+			principal_amount=principal,
+			rate_of_interest=rate_of_interest,
+			from_date=prev_date,
+			to_date=current_date,
+			interest_day_count_convention=interest_day_count_convention,
+		)
 
-		# separate interest for each month based on the number of days
-		# Assuming this function is only use for 'Actual/...' day count interests
-		if interest_day_count_convention.startswith("Actual"):
-			monthly_interest_rate = rate_of_interest / 100
-			if interest_day_count_convention == ("Actual/Actual"):
-				year_a = getdate(prev_date).year
-				year_b = getdate(current_date).year
-				if days_in_year(year_a) == days_in_year(year_b):
-					monthly_interest_rate *= date_diff(current_date, prev_date) / days_in_year(year_a)
-				else:
-					first_year_interest_rate = date_diff(getdate(f"31-12-{year_a}"), prev_date) / days_in_year(
-						year_a
-					)
-					second_year_interest_rate = date_diff(
-						current_date, getdate(f"31-12-{year_a}")
-					) / days_in_year(year_b)
-					# first_year_interest_rate = date_diff(getdate(f'1-1-{year_b}'), prev_date)
-					# second_year_interest_rate = date_diff(current_date, getdate(f'1-1-{year_b}'))
-
-					monthly_interest_rate *= first_year_interest_rate + second_year_interest_rate
-			else:
-				monthly_interest_rate *= date_diff(current_date, prev_date)
-
-		elif interest_day_count_convention.startswith("30"):
-			monthly_interest_rate = rate_of_interest * 30
-
-		if interest_day_count_convention.endswith("365"):
-			monthly_interest_rate /= 365
-		elif interest_day_count_convention.endswith("360"):
-			monthly_interest_rate /= 360
-
-		interest_amount = principal * monthly_interest_rate
 		principal -= monthly_repayment_amount - interest_amount
-		if prnt:
-			print(
-				current_date,
-				monthly_repayment_amount - interest_amount,
-				interest_amount,
-				monthly_repayment_amount,
-				principal,
-				frappe.utils.date_diff(current_date, prev_date),
+
+		if generate_schedule:
+			schedule.append(
+				frappe._dict(
+					{
+						"principal_amount": principal,
+						"posting_date": current_date,
+						"interest_amount": interest_amount,
+					}
+				)
 			)
+
+		if repay_over_number_of_periods:
+			if i == repayment_periods:
+				break
 		prev_date = current_date
 		current_date = add_months(current_date, 1)
+
+	if generate_schedule:
+		return principal, schedule
 	return principal

--- a/lending/loan_management/doctype/loan_repayment_schedule/utils.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/utils.py
@@ -1,35 +1,11 @@
+from math import ceil
+
 import frappe
-from frappe.utils import add_months, cint, flt
+from frappe.utils import add_days, add_months, add_years, cint, flt, get_last_day
 
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
 	get_interest_amount,
 )
-
-
-def get_monthly_repayment_schedule(
-	loan_amount,
-	rate_of_interest,
-	repayment_periods,
-	frequency,
-	ceil_monthly_repayment=False,
-	disbursement_date=None,
-	repayment_start_date=None,
-	interest_day_count_convention=False,
-):
-	if frequency == "One Time":
-		repayment_periods = 1
-
-	monthly_repayment_schedule = binary_search_monthly_repayment_schedule_for_fixed_number_of_periods(
-		principal=loan_amount,
-		repayment_periods=repayment_periods,
-		rate_of_interest=rate_of_interest,
-		disbursement_date=disbursement_date,
-		repayment_start_date=repayment_start_date,
-		interest_day_count_convention=interest_day_count_convention,
-		ceil_monthly_repayment=ceil_monthly_repayment,
-	)
-
-	return monthly_repayment_schedule
 
 
 def get_frequency(frequency):
@@ -143,40 +119,51 @@ def get_ceil_monthly_repayment(loan=None, loan_product=None):
 	return ceil_monthly_repayment
 
 
-def binary_search_monthly_repayment_schedule_for_fixed_number_of_periods(
+def get_repayment_schedule(
 	principal,
-	repayment_periods,
 	rate_of_interest,
+	repayment_method,
+	frequency,
 	disbursement_date,
 	repayment_start_date,
 	interest_day_count_convention,
 	ceil_monthly_repayment=False,
+	repayment_periods=-1,
 ):
+	if frequency == "One Time":
+		repayment_periods = 1
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	l = 0
 	h = principal**2  # just to be safe
-	for i in range(300):
+	for _ in range(300):
 		x = (l + h) / 2
 		remaining_principal = repayment_simulator(
-			x,
-			principal,
-			repayment_periods,
-			rate_of_interest,
-			disbursement_date,
-			repayment_start_date,
-			interest_day_count_convention,
-			ceil_monthly_repayment,
+			monthly_repayment_amount=x,
+			principal=principal,
+			rate_of_interest=rate_of_interest,
+			repayment_method=repayment_method,
+			frequency=frequency,
+			disbursement_date=disbursement_date,
+			repayment_start_date=repayment_start_date,
+			interest_day_count_convention=interest_day_count_convention,
+			ceil_monthly_repayment=ceil_monthly_repayment,
+			repayment_periods=repayment_periods,
+			precision=precision,
 		)
-		if abs(remaining_principal) < 0.0001:
+		if flt(remaining_principal, precision):
 			_, schedule = repayment_simulator(
-				x,
-				principal,
-				repayment_periods,
-				rate_of_interest,
-				disbursement_date,
-				repayment_start_date,
-				interest_day_count_convention,
+				monthly_repayment_amount=x,
+				principal=principal,
+				rate_of_interest=rate_of_interest,
+				frequency=frequency,
+				repayment_method=repayment_method,
+				disbursement_date=disbursement_date,
+				repayment_start_date=repayment_start_date,
+				interest_day_count_convention=interest_day_count_convention,
+				repayment_periods=repayment_periods,
+				ceil_monthly_repayment=ceil_monthly_repayment,
 				generate_schedule=True,
+				precision=precision,
 			)
 			return x, schedule
 		if remaining_principal < 0:
@@ -190,22 +177,25 @@ def repayment_simulator(
 	monthly_repayment_amount,
 	principal,
 	repayment_method,
+	frequency,
 	rate_of_interest,
 	disbursement_date,
 	repayment_start_date,
 	interest_day_count_convention,
-	repayment_periods=None,
+	repayment_periods=-1,
+	ceil_monthly_repayment=False,
 	generate_schedule=False,
+	precision=2,
 ):
 	# list initialisation takes up resources
 	if generate_schedule:
 		schedule = []
+	is_last_day = get_last_day(repayment_start_date) == repayment_start_date
 	prev_date = disbursement_date
 	current_date = repayment_start_date
 	i = 0
 	repay_over_number_of_periods = repayment_method == "Repay Over Number of Periods"
 	while True:
-		i += 1
 		interest_amount = get_interest_amount(
 			principal_amount=principal,
 			rate_of_interest=rate_of_interest,
@@ -214,7 +204,15 @@ def repayment_simulator(
 			interest_day_count_convention=interest_day_count_convention,
 		)
 
-		principal -= monthly_repayment_amount - interest_amount
+		if ceil_monthly_repayment:
+			monthly_repayment_amount = ceil(monthly_repayment_amount)
+		diff = monthly_repayment_amount - interest_amount
+
+		if flt(diff - principal, precision) > 0:
+			monthly_repayment_amount = principal
+			principal = 0
+		else:
+			principal -= diff
 
 		if generate_schedule:
 			schedule.append(
@@ -223,15 +221,40 @@ def repayment_simulator(
 						"principal_amount": principal,
 						"posting_date": current_date,
 						"interest_amount": interest_amount,
+						"repayment_amount": monthly_repayment_amount,
 					}
 				)
 			)
 
+		i += 1
 		if repay_over_number_of_periods:
 			if i == repayment_periods:
 				break
+		else:
+			if principal == 0:
+				break
+
 		prev_date = current_date
-		current_date = add_months(current_date, 1)
+
+		# ideally, for "One Time" frequency, the loop should have broken by now
+		# so not defined here
+		match frequency:
+			case "Daily":
+				current_date = add_days(current_date, 1)
+			case "Weekly":
+				current_date = add_days(current_date, 7)
+			case "Monthly":
+				if is_last_day:
+					current_date = get_last_day(add_months(current_date, 1))
+				else:
+					current_date = add_months(current_date, 1)
+			case "Quarterly":
+				if is_last_day:
+					current_date = get_last_day(add_months(current_date, 3))
+				else:
+					current_date = add_months(current_date, 3)
+			case "Yearly":
+				current_date = add_years(current_date, 1)
 
 	if generate_schedule:
 		return principal, schedule

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -18,6 +18,9 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import calcul
 from lending.loan_management.doctype.loan_repayment_schedule.loan_repayment_schedule import (
 	get_monthly_repayment_amount,
 )
+from lending.loan_management.doctype.loan_repayment_schedule.utils import (
+	get_ceil_monthly_repayment,
+)
 
 
 class LoanRestructure(AccountsController):
@@ -366,8 +369,13 @@ class LoanRestructure(AccountsController):
 			)
 
 		if self.new_repayment_method == "Repay Over Number of Periods":
+			ceil_monthly_repayment = get_ceil_monthly_repayment(loan=self.loan)
 			self.new_monthly_repayment_amount = get_monthly_repayment_amount(
-				self.new_loan_amount, self.new_rate_of_interest, self.new_repayment_period_in_months, "Monthly"
+				self.new_loan_amount,
+				self.new_rate_of_interest,
+				self.new_repayment_period_in_months,
+				"Monthly",
+				ceil_monthly_repayment=ceil_monthly_repayment,
 			)
 
 	def restructure_loan(self):

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -370,12 +370,18 @@ class LoanRestructure(AccountsController):
 
 		if self.new_repayment_method == "Repay Over Number of Periods":
 			ceil_monthly_repayment = get_ceil_monthly_repayment(loan=self.loan)
+			interest_day_count_convention = frappe.get_cached_value(
+				"Company", self.company, "interest_day_count_convention"
+			)
 			self.new_monthly_repayment_amount = get_monthly_repayment_amount(
 				self.new_loan_amount,
 				self.new_rate_of_interest,
 				self.new_repayment_period_in_months,
 				"Monthly",
 				ceil_monthly_repayment=ceil_monthly_repayment,
+				interest_day_count_convention=interest_day_count_convention,
+				disbursement_date=self.restructure_date,
+				repayment_start_date=self.repayment_start_date,
 			)
 
 	def restructure_loan(self):

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -141,7 +141,7 @@ class LoanWriteOff(AccountsController):
 
 		update_values = {"written_off_amount": written_off_amount}
 
-		if not (self.is_settlement_write_off or cancel) or write_off_count >= 1:
+		if not (self.is_settlement_write_off or cancel) or write_off_count > 1:
 			update_values["status"] = "Written Off"
 		elif not self.is_settlement_write_off:
 			update_values["status"] = "Disbursed"


### PR DESCRIPTION
Add checkbox in Loan Product to configure whether to round off (ceil, actually) monthly repayments or not.

<img width="479" alt="image" src="https://github.com/user-attachments/assets/e629eb59-2275-4293-80ed-ed7aad9290e7" />

Before the option is checked:
<img width="934" alt="image" src="https://github.com/user-attachments/assets/270962ce-2b6a-4976-942e-74638cd1f154" />

After:
<img width="925" alt="image" src="https://github.com/user-attachments/assets/acce2093-9a61-441d-957e-4ae9ab3fa8c4" />

Resolves #31 

Edit: This started out as a minor fix to the repayment amount in response to #31, but is now far bigger in scope as previously all repayment schedules used the PMT formula and, as a result, the monthly repayment amount came out to be somewhat incorrect.
This PR also attempts to use one single function to calculate interest amounts everywhere.