### PR TITLE
fix: penal accruals should have the same starting_date and posting_date for one day penal accruals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -89,7 +89,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -762,7 +762,6 @@ class TestLoan(IntegrationTestCase):
 			"Loan Interest Accrual", {"loan": loan.name}, ["start_date", "posting_date"]
 		)
 		for i in accruals:
-			print(i.start_date, i.posting_date, i)
 			self.assertEqual(i.start_date, i.posting_date)
 
 	def test_loan_write_off_limit(self):

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -559,7 +559,7 @@ def calculate_penal_interest_for_loans(
 			from_date_for_entry = from_date
 			for current_date in get_accrual_frequency_breaks(from_date, posting_date, "Daily"):
 				# no_of_days = date_diff(posting_date, from_date)
-				from_date_for_entry = add_days(current_date, -1)
+				from_date_for_entry = current_date
 				# just here for daily penal accruals
 				no_of_days = 1
 				penal_interest_amount = flt(demand.pending_amount) * penal_interest_rate * no_of_days / 36500


### PR DESCRIPTION
Earlier start_date was one day before posting_date. This change makes them more aligned with normal interest accruals.