### PR TITLE
chore: Type annotations for all DocTypes

### DIFF
--- a/lending/hooks.py
+++ b/lending/hooks.py
@@ -32,6 +32,8 @@ voucher_subtypes = "lending.loan_management.doctype.loan.loan.get_voucher_subtyp
 
 before_tests = "lending.tests.test_utils.before_tests"
 
+export_python_type_annotations = True
+
 # Includes in <head>
 # ------------------
 

--- a/lending/loan_management/doctype/co_lender_schedule/co_lender_schedule.json
+++ b/lending/loan_management/doctype/co_lender_schedule/co_lender_schedule.json
@@ -69,7 +69,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-09-12 09:21:24.082370",
+ "modified": "2025-03-19 11:46:37.796333",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Co-Lender Schedule",

--- a/lending/loan_management/doctype/days_past_due_log/days_past_due_log.json
+++ b/lending/loan_management/doctype/days_past_due_log/days_past_due_log.json
@@ -56,7 +56,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-11-22 11:25:41.038912",
+ "modified": "2025-03-19 11:46:45.297130",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Days Past Due Log",

--- a/lending/loan_management/doctype/days_past_due_log/days_past_due_log.py
+++ b/lending/loan_management/doctype/days_past_due_log/days_past_due_log.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class DaysPastDueLog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		days_past_due: DF.Int
+		loan: DF.Link | None
+		loan_disbursement: DF.Link | None
+		posting_date: DF.Date | None
+		process_loan_classification: DF.Link | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -709,7 +709,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-14 13:00:14.179337",
+ "modified": "2025-03-19 11:46:46.469690",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -34,6 +34,97 @@ from lending.utils import daterange
 
 # nosemgrep
 class Loan(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_disbursement_charge.loan_disbursement_charge import (
+			LoanDisbursementCharge,
+		)
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink
+		applicant_name: DF.Data | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		available_limit_amount: DF.Currency
+		cancellation_date: DF.Date | None
+		classification_code: DF.Link | None
+		classification_name: DF.Data | None
+		closure_date: DF.Date | None
+		company: DF.Link
+		cost_center: DF.Link | None
+		credit_adjustment_amount: DF.Currency
+		days_past_due: DF.Int
+		debit_adjustment_amount: DF.Currency
+		disbursed_amount: DF.Currency
+		disbursement_account: DF.Link
+		disbursement_date: DF.Date | None
+		excess_amount_paid: DF.Currency
+		fldg_trigger_date: DF.Date | None
+		fldg_triggered: DF.Check
+		freeze_account: DF.Check
+		freeze_date: DF.Date | None
+		interest_income_account: DF.Link
+		is_npa: DF.Check
+		is_secured_loan: DF.Check
+		is_term_loan: DF.Check
+		limit_applicable_end: DF.Date | None
+		limit_applicable_start: DF.Date | None
+		loan_account: DF.Link
+		loan_amount: DF.Currency
+		loan_application: DF.Link | None
+		loan_category: DF.Link | None
+		loan_charges: DF.Table[LoanDisbursementCharge]
+		loan_partner: DF.Link | None
+		loan_product: DF.Link
+		loan_restructure_count: DF.Int
+		manual_npa: DF.Check
+		maximum_limit_amount: DF.Currency
+		maximum_loan_amount: DF.Currency
+		monthly_repayment_amount: DF.Currency
+		moratorium_tenure: DF.Int
+		moratorium_type: DF.Literal["", "EMI", "Principal"]
+		payment_account: DF.Link
+		penalty_charges_rate: DF.Percent
+		penalty_income_account: DF.Link
+		posting_date: DF.Date
+		rate_of_interest: DF.Percent
+		refund_amount: DF.Currency
+		repayment_frequency: DF.Literal[
+			"Monthly", "Daily", "Weekly", "Bi-Weekly", "Quarterly", "One Time"
+		]
+		repayment_method: DF.Literal["", "Repay Fixed Amount per Period", "Repay Over Number of Periods"]
+		repayment_periods: DF.Int
+		repayment_schedule_type: DF.Data | None
+		repayment_start_date: DF.Date | None
+		settlement_date: DF.Date | None
+		status: DF.Literal[
+			"Draft",
+			"Sanctioned",
+			"Partially Disbursed",
+			"Disbursed",
+			"Active",
+			"Loan Closure Requested",
+			"Closed",
+			"Written Off",
+			"Settled",
+		]
+		tenure_post_restructure: DF.Int
+		total_amount_paid: DF.Currency
+		total_interest_payable: DF.Currency
+		total_payment: DF.Currency
+		total_principal_paid: DF.Currency
+		treatment_of_interest: DF.Literal["", "Capitalize", "Add to first repayment"]
+		unmark_npa: DF.Check
+		utilized_limit_amount: DF.Currency
+		watch_period_end_date: DF.Date | None
+		written_off_amount: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_status()
 		self.set_loan_amount()

--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.json
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.json
@@ -77,7 +77,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-07 20:32:01.217014",
+ "modified": "2025-03-19 11:46:39.834713",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Adjustment",
@@ -97,7 +97,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
@@ -9,6 +9,26 @@ from lending.loan_management.doctype.loan_restructure.loan_restructure import cr
 
 
 class LoanAdjustment(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_adjustment_detail.loan_adjustment_detail import (
+			LoanAdjustmentDetail,
+		)
+
+		adjustments: DF.Table[LoanAdjustmentDetail]
+		amended_from: DF.Link | None
+		foreclosure_type: DF.Literal["", "Manual Foreclosure", "Internal Foreclosure"]
+		loan: DF.Link | None
+		payment_account: DF.Link | None
+		posting_date: DF.Datetime | None
+	# end: auto-generated types
+
 	def validate(self):
 		amounts = calculate_amounts(self.loan, self.posting_date)
 

--- a/lending/loan_management/doctype/loan_adjustment_detail/loan_adjustment_detail.json
+++ b/lending/loan_management/doctype/loan_adjustment_detail/loan_adjustment_detail.json
@@ -27,7 +27,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-07-12 10:59:47.920785",
+ "modified": "2025-03-19 11:46:40.041421",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Adjustment Detail",

--- a/lending/loan_management/doctype/loan_adjustment_detail/loan_adjustment_detail.py
+++ b/lending/loan_management/doctype/loan_adjustment_detail/loan_adjustment_detail.py
@@ -6,4 +6,33 @@ from frappe.model.document import Document
 
 
 class LoanAdjustmentDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		loan_repayment_type: DF.Literal[
+			"Normal Repayment",
+			"Interest Waiver",
+			"Penalty Waiver",
+			"Charges Waiver",
+			"Principal Capitalization",
+			"Interest Capitalization",
+			"Charges Capitalization",
+			"Penalty Capitalization",
+			"Principal Adjustment",
+			"Interest Adjustment",
+			"Interest Carry Forward",
+			"Loan Closure",
+			"Security Deposit Adjustment",
+		]
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_application/loan_application.json
+++ b/lending/loan_management/doctype/loan_application/loan_application.json
@@ -215,7 +215,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-02 22:14:22.606618",
+ "modified": "2025-03-19 11:46:51.585652",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Application",

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -24,6 +24,38 @@ from lending.loan_management.doctype.loan_security_price.loan_security_price imp
 
 
 class LoanApplication(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.proposed_pledge.proposed_pledge import ProposedPledge
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink
+		applicant_name: DF.Data | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		description: DF.SmallText | None
+		is_secured_loan: DF.Check
+		is_term_loan: DF.Check
+		loan_amount: DF.Currency
+		loan_product: DF.Link
+		maximum_loan_amount: DF.Currency
+		posting_date: DF.Date | None
+		proposed_pledges: DF.Table[ProposedPledge]
+		rate_of_interest: DF.Percent
+		repayment_amount: DF.Currency
+		repayment_method: DF.Literal["", "Repay Fixed Amount per Period", "Repay Over Number of Periods"]
+		repayment_periods: DF.Int
+		status: DF.Literal["Open", "Approved", "Rejected"]
+		total_payable_amount: DF.Currency
+		total_payable_interest: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_pledge_amount()
 		self.set_loan_amount()

--- a/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.json
+++ b/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.json
@@ -161,7 +161,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-12 16:56:38.999819",
+ "modified": "2025-03-19 11:46:45.563385",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Balance Adjustment",

--- a/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.py
+++ b/lending/loan_management/doctype/loan_balance_adjustment/loan_balance_adjustment.py
@@ -15,6 +15,31 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 
 
 class LoanBalanceAdjustment(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		adjustment_account: DF.Link
+		adjustment_receivable_account: DF.Link | None
+		adjustment_type: DF.Literal["Credit Adjustment", "Debit Adjustment"]
+		amended_from: DF.Link | None
+		amount: DF.Currency
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		cost_center: DF.Link | None
+		loan: DF.Link
+		posting_date: DF.Date
+		reference_document_type: DF.Literal["Loan Repayment", "Loan Restructure"]
+		reference_name: DF.DynamicLink | None
+		reference_number: DF.Data | None
+		remarks: DF.Data | None
+	# end: auto-generated types
+
 	"""
 	Add credit/debit adjustments to loan ledger.
 	"""

--- a/lending/loan_management/doctype/loan_buyback/loan_buyback.json
+++ b/lending/loan_management/doctype/loan_buyback/loan_buyback.json
@@ -47,7 +47,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-06-03 09:50:12.576960",
+ "modified": "2025-03-19 11:46:37.628117",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Buyback",

--- a/lending/loan_management/doctype/loan_buyback/loan_buyback.py
+++ b/lending/loan_management/doctype/loan_buyback/loan_buyback.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class LoanBuyback(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		loan: DF.Link | None
+		loan_partner: DF.Link | None
+		posting_date: DF.Date | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_category/loan_category.json
+++ b/lending/loan_management/doctype/loan_category/loan_category.json
@@ -36,7 +36,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-11-27 15:35:27.175566",
+ "modified": "2025-03-19 11:46:40.261506",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Category",

--- a/lending/loan_management/doctype/loan_category/loan_category.py
+++ b/lending/loan_management/doctype/loan_category/loan_category.py
@@ -6,4 +6,17 @@ from frappe.model.document import Document
 
 
 class LoanCategory(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		disabled: DF.Check
+		loan_category_code: DF.Data
+		loan_category_name: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_charge_reference/loan_charge_reference.json
+++ b/lending/loan_management/doctype/loan_charge_reference/loan_charge_reference.json
@@ -43,7 +43,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-01 18:29:06.840057",
+ "modified": "2025-03-19 11:46:43.001671",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Charge Reference",

--- a/lending/loan_management/doctype/loan_charge_reference/loan_charge_reference.py
+++ b/lending/loan_management/doctype/loan_charge_reference/loan_charge_reference.py
@@ -6,4 +6,21 @@ from frappe.model.document import Document
 
 
 class LoanChargeReference(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		allocated_amount: DF.Currency
+		charge: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		pending_charge_amount: DF.Currency
+		sales_invoice: DF.Link | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_charges/loan_charges.json
+++ b/lending/loan_management/doctype/loan_charges/loan_charges.json
@@ -94,7 +94,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-29 20:33:10.270293",
+ "modified": "2025-03-19 11:46:43.855386",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Charges",

--- a/lending/loan_management/doctype/loan_charges/loan_charges.py
+++ b/lending/loan_management/doctype/loan_charges/loan_charges.py
@@ -6,4 +6,26 @@ from frappe.model.document import Document
 
 
 class LoanCharges(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		charge_based_on: DF.Literal["Percentage", "Fixed Amount"]
+		charge_type: DF.Link | None
+		income_account: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		percentage: DF.Percent
+		receivable_account: DF.Link | None
+		suspense_account: DF.Link | None
+		waiver_account: DF.Link | None
+		write_off_account: DF.Link | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_classification/loan_classification.json
+++ b/lending/loan_management/doctype/loan_classification/loan_classification.json
@@ -30,7 +30,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-12 17:27:39.016761",
+ "modified": "2025-03-19 11:46:42.377255",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Classification",

--- a/lending/loan_management/doctype/loan_classification/loan_classification.py
+++ b/lending/loan_management/doctype/loan_classification/loan_classification.py
@@ -6,4 +6,16 @@ from frappe.model.document import Document
 
 
 class LoanClassification(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		classification_code: DF.Data
+		classification_name: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_classification_range/loan_classification_range.json
+++ b/lending/loan_management/doctype/loan_classification_range/loan_classification_range.json
@@ -55,7 +55,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-09-01 18:54:44.242234",
+ "modified": "2025-03-19 11:46:44.079330",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Classification Range",

--- a/lending/loan_management/doctype/loan_classification_range/loan_classification_range.py
+++ b/lending/loan_management/doctype/loan_classification_range/loan_classification_range.py
@@ -6,4 +6,22 @@ from frappe.model.document import Document
 
 
 class LoanClassificationRange(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		classification_code: DF.Link | None
+		classification_name: DF.Data | None
+		is_written_off: DF.Check
+		max_dpd_range: DF.Int
+		min_dpd_range: DF.Int
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_demand/loan_demand.json
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.json
@@ -282,7 +282,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-14 18:26:38.411483",
+ "modified": "2025-03-19 11:46:40.514216",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Demand",
@@ -317,7 +317,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -12,6 +12,42 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import update
 
 
 class LoanDemand(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Link | None
+		company: DF.Link | None
+		cost_center: DF.Link | None
+		demand_amount: DF.Currency
+		demand_date: DF.Datetime | None
+		demand_subtype: DF.Data | None
+		demand_type: DF.Literal["EMI", "Penalty", "Normal", "Charges", "BPI", "Additional Interest"]
+		disbursement_date: DF.Date | None
+		invoice_date: DF.Date | None
+		is_term_loan: DF.Check
+		loan: DF.Link | None
+		loan_disbursement: DF.Link | None
+		loan_partner: DF.Link | None
+		loan_product: DF.Link | None
+		loan_repayment_schedule: DF.Link | None
+		outstanding_amount: DF.Currency
+		paid_amount: DF.Currency
+		partner_share: DF.Currency
+		partner_share_allocated: DF.Currency
+		posting_date: DF.Datetime | None
+		process_loan_demand: DF.Link | None
+		repayment_schedule_detail: DF.Data | None
+		sales_invoice: DF.Link | None
+		waived_amount: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.outstanding_amount = flt(self.demand_amount) - flt(self.paid_amount)
 		self.partner_share_allocated = 0

--- a/lending/loan_management/doctype/loan_demand_offset_detail/loan_demand_offset_detail.json
+++ b/lending/loan_management/doctype/loan_demand_offset_detail/loan_demand_offset_detail.json
@@ -26,7 +26,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-25 07:56:57.897822",
+ "modified": "2025-03-19 11:46:39.467538",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Demand Offset Detail",

--- a/lending/loan_management/doctype/loan_demand_offset_detail/loan_demand_offset_detail.py
+++ b/lending/loan_management/doctype/loan_demand_offset_detail/loan_demand_offset_detail.py
@@ -6,4 +6,25 @@ from frappe.model.document import Document
 
 
 class LoanDemandOffsetDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		demand_type: DF.Literal[
+			"EMI (Principal + Interest)",
+			"Principal",
+			"Interest",
+			"Additional Interest",
+			"Penalty",
+			"Charges",
+		]
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_demand_offset_order/loan_demand_offset_order.json
+++ b/lending/loan_management/doctype/loan_demand_offset_order/loan_demand_offset_order.json
@@ -25,7 +25,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-12-03 12:05:09.752664",
+ "modified": "2025-03-19 11:46:39.294058",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Demand Offset Order",

--- a/lending/loan_management/doctype/loan_demand_offset_order/loan_demand_offset_order.py
+++ b/lending/loan_management/doctype/loan_demand_offset_order/loan_demand_offset_order.py
@@ -6,4 +6,20 @@ from frappe.model.document import Document
 
 
 class LoanDemandOffsetOrder(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_demand_offset_detail.loan_demand_offset_detail import (
+			LoanDemandOffsetDetail,
+		)
+
+		components: DF.Table[LoanDemandOffsetDetail]
+		title: DF.Data | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
@@ -368,7 +368,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-09 16:19:36.800394",
+ "modified": "2025-03-19 11:46:49.327153",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Disbursement",

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -42,6 +42,57 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 
 # nosemgrep
 class LoanDisbursement(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_disbursement_charge.loan_disbursement_charge import (
+			LoanDisbursementCharge,
+		)
+
+		against_loan: DF.Link
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		bank_account: DF.Link | None
+		bpi_amount_difference: DF.Currency
+		bpi_difference_date: DF.Date | None
+		broken_period_interest: DF.Currency
+		clearance_date: DF.Date | None
+		company: DF.Link
+		cost_center: DF.Link | None
+		current_disbursed_amount: DF.Currency
+		days_past_due: DF.Int
+		disbursed_amount: DF.Currency
+		disbursement_account: DF.Link | None
+		disbursement_date: DF.Date
+		is_term_loan: DF.Check
+		loan_account: DF.Link | None
+		loan_disbursement_charges: DF.Table[LoanDisbursementCharge]
+		loan_partner: DF.Link | None
+		loan_product: DF.Link | None
+		monthly_repayment_amount: DF.Currency
+		posting_date: DF.Date | None
+		principal_amount_paid: DF.Currency
+		reference_date: DF.Date | None
+		reference_number: DF.Data | None
+		refund_account: DF.Link | None
+		repayment_frequency: DF.Literal[
+			"Monthly", "Daily", "Weekly", "Bi-Weekly", "Quarterly", "One Time"
+		]
+		repayment_method: DF.Literal["", "Repay Over Number of Periods", "Repay Fixed Amount per Period"]
+		repayment_schedule_type: DF.Data | None
+		repayment_start_date: DF.Date | None
+		sanctioned_loan_amount: DF.Currency
+		status: DF.Literal["", "Draft", "Submitted", "Cancelled", "Closed"]
+		tenure: DF.Int
+		withhold_security_deposit: DF.Check
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_status()
 		self.set_missing_values()

--- a/lending/loan_management/doctype/loan_disbursement_charge/loan_disbursement_charge.json
+++ b/lending/loan_management/doctype/loan_disbursement_charge/loan_disbursement_charge.json
@@ -35,7 +35,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-12 19:47:07.918342",
+ "modified": "2025-03-19 11:46:40.835475",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Disbursement Charge",

--- a/lending/loan_management/doctype/loan_disbursement_charge/loan_disbursement_charge.py
+++ b/lending/loan_management/doctype/loan_disbursement_charge/loan_disbursement_charge.py
@@ -6,4 +6,20 @@ from frappe.model.document import Document
 
 
 class LoanDisbursementCharge(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		account: DF.Link | None
+		amount: DF.Currency
+		charge: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_freeze_log/loan_freeze_log.json
+++ b/lending/loan_management/doctype/loan_freeze_log/loan_freeze_log.json
@@ -40,7 +40,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-11 08:07:05.587405",
+ "modified": "2025-03-19 11:46:38.877982",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Freeze Log",

--- a/lending/loan_management/doctype/loan_freeze_log/loan_freeze_log.py
+++ b/lending/loan_management/doctype/loan_freeze_log/loan_freeze_log.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class LoanFreezeLog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		freeze_date: DF.Date | None
+		loan: DF.Link | None
+		reason_for_freezing: DF.SmallText | None
+		unfreeze_date: DF.Date | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.json
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.json
@@ -261,7 +261,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-14 22:38:21.470997",
+ "modified": "2025-03-19 11:46:48.771267",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Interest Accrual",
@@ -300,7 +300,6 @@
   }
  ],
  "quick_entry": 1,
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -25,6 +25,42 @@ from lending.utils import daterange
 
 
 class LoanInterestAccrual(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		accrual_date: DF.Date | None
+		accrual_type: DF.Literal[
+			"Regular", "Repayment", "Disbursement", "Credit Adjustment", "Debit Adjustment", "Refund"
+		]
+		additional_interest_amount: DF.Currency
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		base_amount: DF.Currency
+		company: DF.Link | None
+		cost_center: DF.Link | None
+		interest_amount: DF.Currency
+		interest_type: DF.Literal["Normal Interest", "Penal Interest"]
+		is_npa: DF.Check
+		is_term_loan: DF.Check
+		last_accrual_date: DF.Date | None
+		loan: DF.Link
+		loan_demand: DF.Link | None
+		loan_disbursement: DF.Link | None
+		loan_product: DF.Link | None
+		loan_repayment_schedule: DF.Link | None
+		loan_repayment_schedule_detail: DF.Data | None
+		posting_date: DF.Datetime | None
+		process_loan_interest_accrual: DF.Link | None
+		rate_of_interest: DF.Float
+		start_date: DF.Datetime | None
+	# end: auto-generated types
+
 	def validate(self):
 		if not self.posting_date:
 			self.posting_date = nowdate()

--- a/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.json
+++ b/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.json
@@ -49,7 +49,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-01 23:33:15.840425",
+ "modified": "2025-03-19 11:46:42.553118",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan IRAC Provisioning Configuration",

--- a/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.py
+++ b/lending/loan_management/doctype/loan_irac_provisioning_configuration/loan_irac_provisioning_configuration.py
@@ -6,4 +6,21 @@ from frappe.model.document import Document
 
 
 class LoanIRACProvisioningConfiguration(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		classification_code: DF.Link | None
+		classification_name: DF.Data | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		provision_rate: DF.Percent
+		security_type: DF.Literal["Secured", "Unsecured", "Semi-Secured"]
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_limit_change_log/loan_limit_change_log.json
+++ b/lending/loan_management/doctype/loan_limit_change_log/loan_limit_change_log.json
@@ -45,7 +45,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-10 18:36:56.526456",
+ "modified": "2025-03-19 11:46:38.592126",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Limit Change Log",

--- a/lending/loan_management/doctype/loan_limit_change_log/loan_limit_change_log.py
+++ b/lending/loan_management/doctype/loan_limit_change_log/loan_limit_change_log.py
@@ -6,6 +6,21 @@ from frappe.model.document import Document
 
 
 class LoanLimitChangeLog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		change_date: DF.Date | None
+		event: DF.Literal["Loan Booking", "Limit Renewal", "Disbursement", "Repayment"]
+		loan: DF.Link | None
+		value_change: DF.Currency
+		value_type: DF.Literal["Maximum Limit Amount", "Utilized Limit Amount", "Available Limit Amount"]
+	# end: auto-generated types
+
 	pass
 
 

--- a/lending/loan_management/doctype/loan_npa_log/loan_npa_log.json
+++ b/lending/loan_management/doctype/loan_npa_log/loan_npa_log.json
@@ -51,7 +51,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-17 11:01:06.214520",
+ "modified": "2025-03-19 11:46:39.607504",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan NPA Log",

--- a/lending/loan_management/doctype/loan_npa_log/loan_npa_log.py
+++ b/lending/loan_management/doctype/loan_npa_log/loan_npa_log.py
@@ -7,6 +7,22 @@ from frappe.utils import getdate
 
 
 class LoanNPALog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		delinked: DF.Check
+		event: DF.Data | None
+		loan: DF.Link | None
+		manual_npa: DF.Check
+		npa: DF.Check
+		npa_date: DF.Date | None
+	# end: auto-generated types
+
 	pass
 
 

--- a/lending/loan_management/doctype/loan_partner/loan_partner.json
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.json
@@ -268,7 +268,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-02-16 20:55:48.954408",
+ "modified": "2025-03-19 11:46:41.989923",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner",

--- a/lending/loan_management/doctype/loan_partner/loan_partner.py
+++ b/lending/loan_management/doctype/loan_partner/loan_partner.py
@@ -8,6 +8,56 @@ from frappe.model.document import Document
 
 
 class LoanPartner(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_partner_shareable.loan_partner_shareable import (
+			LoanPartnerShareable,
+		)
+
+		credit_account: DF.Link | None
+		effective_date: DF.Date
+		enable_partner_accounting: DF.Check
+		fldg_account: DF.Link | None
+		fldg_corporate_guarantee_percentage: DF.Percent
+		fldg_fixed_deposit_percentage: DF.Percent
+		fldg_limit_calculation_component: DF.Literal[
+			"", "Disbursement", "Outstanding Principal", "Outstanding Principal & Interest Accrued"
+		]
+		fldg_trigger_dpd: DF.Int
+		organization_type: DF.Literal["", "Centralized", "Decentralized"]
+		partial_payment_mechanism: DF.Data | None
+		partner_base_interest_rate: DF.Percent
+		partner_code: DF.Data
+		partner_interest_share: DF.Link | None
+		partner_loan_share_percentage: DF.Percent
+		partner_name: DF.Data
+		payable_account: DF.Link | None
+		primary_address: DF.Link | None
+		receivable_account: DF.Link | None
+		repayment_schedule_type: DF.Literal[
+			"",
+			"EMI (PMT) based",
+			"Collection at partner's percentage",
+			"POS reduction plus interest at partner ROI",
+		]
+		restructure_of_loans_applicable: DF.Check
+		servicer_fee: DF.Check
+		shareables: DF.Table[LoanPartnerShareable]
+		type_of_fldg_applicable: DF.Literal[
+			"",
+			"Fixed Deposit Only",
+			"Corporate Guarantee Only",
+			"Both Fixed Deposit and Corporate Guarantee",
+		]
+		waiving_of_charges_applicable: DF.Check
+	# end: auto-generated types
+
 	def onload(self):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)

--- a/lending/loan_management/doctype/loan_partner_address/loan_partner_address.json
+++ b/lending/loan_management/doctype/loan_partner_address/loan_partner_address.json
@@ -29,7 +29,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-19 17:53:45.592401",
+ "modified": "2025-03-19 11:46:41.196404",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Address",

--- a/lending/loan_management/doctype/loan_partner_address/loan_partner_address.py
+++ b/lending/loan_management/doctype/loan_partner_address/loan_partner_address.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class LoanPartnerAddress(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		address: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		primary: DF.Check
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_partner_adhoc_charges_shared/loan_partner_adhoc_charges_shared.json
+++ b/lending/loan_management/doctype/loan_partner_adhoc_charges_shared/loan_partner_adhoc_charges_shared.json
@@ -55,7 +55,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-09-19 00:01:29.855212",
+ "modified": "2025-03-19 11:46:41.677196",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Adhoc Charges Shared",

--- a/lending/loan_management/doctype/loan_partner_adhoc_charges_shared/loan_partner_adhoc_charges_shared.py
+++ b/lending/loan_management/doctype/loan_partner_adhoc_charges_shared/loan_partner_adhoc_charges_shared.py
@@ -6,4 +6,22 @@ from frappe.model.document import Document
 
 
 class LoanPartnerAdhocChargesShared(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		charge_type: DF.Link | None
+		own_ratio: DF.Percent
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		partner_percentage: DF.Percent
+		partner_ratio: DF.Percent
+		sharing_parameter: DF.Literal["", "Ratio", "Percentage"]
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
+++ b/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.json
@@ -58,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-10 11:22:29.539972",
+ "modified": "2025-03-19 11:46:41.410777",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Partner Shareable",

--- a/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.py
+++ b/lending/loan_management/doctype/loan_partner_shareable/loan_partner_shareable.py
@@ -6,4 +6,23 @@ from frappe.model.document import Document
 
 
 class LoanPartnerShareable(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		company_collection_percentage: DF.Percent
+		minimum_partner_loan_amount_percentage: DF.Percent
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		partner_collection_percentage: DF.Percent
+		partner_loan_amount_percentage: DF.Percent
+		shareable_type: DF.Link
+		sharing_parameter: DF.Literal["", "Collection Percentage", "Loan Amount Percentage"]
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -524,7 +524,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-04 12:11:11.782317",
+ "modified": "2025-03-19 11:46:51.211110",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_product/loan_product.py
+++ b/lending/loan_management/doctype/loan_product/loan_product.py
@@ -8,6 +8,78 @@ from frappe.model.document import Document
 
 
 class LoanProduct(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_charges.loan_charges import LoanCharges
+		from lending.loan_management.doctype.loan_product_loan_partner.loan_product_loan_partner import (
+			LoanProductLoanPartner,
+		)
+
+		additional_interest_accrued: DF.Link | None
+		additional_interest_income: DF.Link | None
+		additional_interest_receivable: DF.Link | None
+		additional_interest_suspense: DF.Link | None
+		additional_interest_waiver: DF.Link | None
+		amended_from: DF.Link | None
+		broken_period_interest_recovery_account: DF.Link
+		collection_offset_sequence_for_settlement_collection: DF.Link | None
+		collection_offset_sequence_for_standard_asset: DF.Link | None
+		collection_offset_sequence_for_sub_standard_asset: DF.Link | None
+		collection_offset_sequence_for_written_off_asset: DF.Link | None
+		company: DF.Link
+		customer_refund_account: DF.Link
+		cyclic_day_of_the_month: DF.Int
+		days_past_due_threshold_for_npa: DF.Int
+		disabled: DF.Check
+		disbursement_account: DF.Link
+		excess_amount_acceptance_limit: DF.Float
+		grace_period_in_days: DF.Int
+		interest_accrued_account: DF.Link
+		interest_income_account: DF.Link
+		interest_receivable_account: DF.Link
+		interest_waiver_account: DF.Link
+		is_term_loan: DF.Check
+		loan_account: DF.Link
+		loan_category: DF.Link | None
+		loan_charges: DF.Table[LoanCharges]
+		loan_partners: DF.TableMultiSelect[LoanProductLoanPartner]
+		maximum_loan_amount: DF.Currency
+		min_days_bw_disbursement_first_repayment: DF.Int
+		payment_account: DF.Link
+		penalty_accrued_account: DF.Link
+		penalty_income_account: DF.Link
+		penalty_interest_rate: DF.Percent
+		penalty_receivable_account: DF.Link
+		penalty_suspense_account: DF.Link | None
+		penalty_waiver_account: DF.Link
+		product_code: DF.Data
+		product_name: DF.Data
+		rate_of_interest: DF.Percent
+		repayment_date_on: DF.Literal["", "Start of the next month", "End of the current month"]
+		repayment_schedule_type: DF.Literal[
+			"",
+			"Monthly as per repayment start date",
+			"Pro-rated calendar months",
+			"Monthly as per cycle date",
+			"Line of Credit",
+		]
+		same_as_regular_interest_accounts: DF.Check
+		security_deposit_account: DF.Link
+		subsidy_adjustment_account: DF.Link | None
+		suspense_collection_account: DF.Link | None
+		suspense_interest_income: DF.Link | None
+		validate_normal_repayment: DF.Check
+		write_off_account: DF.Link
+		write_off_amount: DF.Currency
+		write_off_recovery_account: DF.Link
+	# end: auto-generated types
+
 	def before_validate(self):
 		self.set_missing_values()
 

--- a/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.json
+++ b/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.json
@@ -21,7 +21,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-03 00:33:27.497599",
+ "modified": "2025-03-19 11:46:41.052580",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product Loan Partner",

--- a/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.py
+++ b/lending/loan_management/doctype/loan_product_loan_partner/loan_product_loan_partner.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class LoanProductLoanPartner(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		loan_partner: DF.Link
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_refund/loan_refund.json
+++ b/lending/loan_management/doctype/loan_refund/loan_refund.json
@@ -118,15 +118,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "amended_from",
-   "fieldtype": "Link",
-   "label": "Amended From",
-   "no_copy": 1,
-   "options": "Loan Refund",
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "fieldname": "reference_number",
    "fieldtype": "Data",
    "label": "Reference Number"
@@ -155,7 +146,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-09-06 04:55:26.739848",
+ "modified": "2025-03-19 11:46:45.820194",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Refund",

--- a/lending/loan_management/doctype/loan_refund/loan_refund.py
+++ b/lending/loan_management/doctype/loan_refund/loan_refund.py
@@ -13,6 +13,29 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import get_ne
 
 
 class LoanRefund(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		cost_center: DF.Link | None
+		is_excess_amount_refund: DF.Check
+		is_security_amount_refund: DF.Check
+		loan: DF.Link
+		loan_product: DF.Link | None
+		posting_date: DF.Date
+		reference_number: DF.Data | None
+		refund_account: DF.Link
+		refund_amount: DF.Currency
+	# end: auto-generated types
+
 	"""
 	Add refund if total repayment is more than that is owed.
 	"""

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -540,7 +540,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-07 20:23:27.695470",
+ "modified": "2025-03-19 11:46:46.079233",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",
@@ -578,7 +578,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -27,6 +27,98 @@ from lending.loan_management.doctype.loan_security_shortfall.loan_security_short
 
 
 class LoanRepayment(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_repayment_charges.loan_repayment_charges import (
+			LoanRepaymentCharges,
+		)
+		from lending.loan_management.doctype.loan_repayment_detail.loan_repayment_detail import (
+			LoanRepaymentDetail,
+		)
+		from lending.loan_management.doctype.prepayment_charges.prepayment_charges import (
+			PrepaymentCharges,
+		)
+
+		against_loan: DF.Link
+		amended_from: DF.Link | None
+		amount_paid: DF.Currency
+		applicant: DF.DynamicLink
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		bank_account: DF.Link | None
+		clearance_date: DF.Date | None
+		company: DF.Link | None
+		cost_center: DF.Link | None
+		days_past_due: DF.Int
+		due_date: DF.Date | None
+		excess_amount: DF.Currency
+		interest_payable: DF.Currency
+		is_backdated: DF.Check
+		is_npa: DF.Check
+		is_term_loan: DF.Check
+		is_write_off_waiver: DF.Check
+		loan_account: DF.Link | None
+		loan_adjustment: DF.Link | None
+		loan_disbursement: DF.Link | None
+		loan_partner: DF.Link | None
+		loan_partner_interest_rate: DF.Percent
+		loan_partner_payment_ratio: DF.Percent
+		loan_partner_repayment_schedule_type: DF.Data | None
+		loan_partner_share_percentage: DF.Percent
+		loan_product: DF.Link | None
+		loan_restructure: DF.Link | None
+		manual_remarks: DF.SmallText | None
+		mode_of_payment: DF.Link | None
+		payable_amount: DF.Currency
+		payable_charges: DF.Table[LoanRepaymentCharges]
+		payable_principal_amount: DF.Currency
+		payment_account: DF.Link | None
+		penalty_amount: DF.Currency
+		penalty_income_account: DF.Link | None
+		pending_principal_amount: DF.Currency
+		posting_date: DF.Datetime
+		prepayment_charges: DF.Table[PrepaymentCharges]
+		principal_amount_paid: DF.Currency
+		rate_of_interest: DF.Percent
+		reference_date: DF.Date | None
+		reference_number: DF.Data | None
+		repayment_details: DF.Table[LoanRepaymentDetail]
+		repayment_schedule_type: DF.Data | None
+		repayment_type: DF.Literal[
+			"Normal Repayment",
+			"Interest Waiver",
+			"Penalty Waiver",
+			"Charges Waiver",
+			"Principal Capitalization",
+			"Principal Adjustment",
+			"Interest Carry Forward",
+			"Write Off Recovery",
+			"Security Deposit Adjustment",
+			"Advance Payment",
+			"Pre Payment",
+			"Subsidy Adjustments",
+			"Loan Closure",
+			"Partial Settlement",
+			"Full Settlement",
+			"Write Off Settlement",
+			"Charge Payment",
+		]
+		shortfall_amount: DF.Currency
+		total_charges_paid: DF.Currency
+		total_charges_payable: DF.Currency
+		total_interest_paid: DF.Currency
+		total_partner_interest_share: DF.Currency
+		total_partner_principal_share: DF.Currency
+		total_penalty_paid: DF.Currency
+		unbooked_interest_paid: DF.Currency
+		unbooked_penalty_paid: DF.Currency
+	# end: auto-generated types
+
 	def before_validate(self):
 		self.set_repayment_account()
 

--- a/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.json
+++ b/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.json
@@ -26,7 +26,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-07-07 18:00:21.050733",
+ "modified": "2025-03-19 11:46:37.353655",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Charges",

--- a/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.py
+++ b/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class LoanRepaymentCharges(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		charge_code: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_repayment_detail/loan_repayment_detail.json
+++ b/lending/loan_management/doctype/loan_repayment_detail/loan_repayment_detail.json
@@ -56,7 +56,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-01 18:29:17.000043",
+ "modified": "2025-03-19 11:46:47.071944",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Detail",

--- a/lending/loan_management/doctype/loan_repayment_detail/loan_repayment_detail.py
+++ b/lending/loan_management/doctype/loan_repayment_detail/loan_repayment_detail.py
@@ -7,4 +7,23 @@ from frappe.model.document import Document
 
 
 class LoanRepaymentDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		demand_subtype: DF.Data | None
+		demand_type: DF.Data | None
+		loan_demand: DF.Link | None
+		paid_amount: DF.Currency
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		partner_share: DF.Currency
+		sales_invoice: DF.Link | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
@@ -120,7 +120,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-13 15:31:44.140499",
+ "modified": "2025-03-19 11:46:37.007942",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Repost",

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -12,6 +12,34 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 
 
 class LoanRepaymentRepost(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_repayment_repost_cancel_detail.loan_repayment_repost_cancel_detail import (
+			LoanRepaymentRepostCancelDetail,
+		)
+		from lending.loan_management.doctype.loan_repayment_repost_detail.loan_repayment_repost_detail import (
+			LoanRepaymentRepostDetail,
+		)
+
+		amended_from: DF.Link | None
+		cancel_future_accruals_and_demands: DF.Check
+		cancel_future_emi_demands: DF.Check
+		clear_demand_allocation_before_repost: DF.Check
+		delete_gl_entries: DF.Check
+		entries_to_cancel: DF.Table[LoanRepaymentRepostCancelDetail]
+		ignore_on_cancel_amount_update: DF.Check
+		loan: DF.Link
+		loan_disbursement: DF.Link | None
+		repayment_entries: DF.Table[LoanRepaymentRepostDetail]
+		repost_date: DF.Date
+	# end: auto-generated types
+
 	def validate(self):
 		self.get_repayment_entries()
 

--- a/lending/loan_management/doctype/loan_repayment_repost_cancel_detail/loan_repayment_repost_cancel_detail.json
+++ b/lending/loan_management/doctype/loan_repayment_repost_cancel_detail/loan_repayment_repost_cancel_detail.json
@@ -20,7 +20,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-11-13 16:03:33.720421",
+ "modified": "2025-03-19 11:46:36.561283",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Repost Cancel Detail",

--- a/lending/loan_management/doctype/loan_repayment_repost_cancel_detail/loan_repayment_repost_cancel_detail.py
+++ b/lending/loan_management/doctype/loan_repayment_repost_cancel_detail/loan_repayment_repost_cancel_detail.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class LoanRepaymentRepostCancelDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		loan_repayment: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_repayment_repost_detail/loan_repayment_repost_detail.json
+++ b/lending/loan_management/doctype/loan_repayment_repost_detail/loan_repayment_repost_detail.json
@@ -26,7 +26,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-12-24 09:59:00.665048",
+ "modified": "2025-03-19 11:46:36.845241",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Repost Detail",

--- a/lending/loan_management/doctype/loan_repayment_repost_detail/loan_repayment_repost_detail.py
+++ b/lending/loan_management/doctype/loan_repayment_repost_detail/loan_repayment_repost_detail.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class LoanRepaymentRepostDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		loan_repayment: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		posting_date: DF.Date | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
@@ -381,7 +381,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-15 22:32:27.100543",
+ "modified": "2025-03-19 11:46:44.282572",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Schedule",
@@ -414,7 +414,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -28,6 +28,74 @@ from lending.loan_management.doctype.loan_repayment_schedule.utils import (
 
 
 class LoanRepaymentSchedule(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.co_lender_schedule.co_lender_schedule import (
+			CoLenderSchedule,
+		)
+		from lending.loan_management.doctype.repayment_schedule.repayment_schedule import (
+			RepaymentSchedule,
+		)
+
+		adjusted_interest: DF.Currency
+		amended_from: DF.Link | None
+		broken_period_interest: DF.Currency
+		broken_period_interest_days: DF.Int
+		colender_schedule: DF.Table[CoLenderSchedule]
+		company: DF.Link | None
+		current_principal_amount: DF.Currency
+		disbursed_amount: DF.Currency
+		loan: DF.Link
+		loan_amount: DF.Currency
+		loan_disbursement: DF.Link | None
+		loan_partner: DF.Link | None
+		loan_partner_rate_of_interest: DF.Float
+		loan_product: DF.Link | None
+		loan_restructure: DF.Link | None
+		maturity_date: DF.Date | None
+		monthly_repayment_amount: DF.Currency
+		moratorium_end_date: DF.Date | None
+		moratorium_tenure: DF.Int
+		moratorium_type: DF.Data | None
+		partner_base_interest_rate: DF.Percent
+		partner_loan_share_percentage: DF.Percent
+		partner_monthly_repayment_amount: DF.Currency
+		partner_repayment_schedule_type: DF.Data | None
+		posting_date: DF.Datetime | None
+		rate_of_interest: DF.Float
+		repayment_date_on: DF.Literal["Start of the next month", "End of the current month"]
+		repayment_frequency: DF.Literal[
+			"Monthly", "Daily", "Weekly", "Bi-Weekly", "Quarterly", "One Time"
+		]
+		repayment_method: DF.Literal["", "Repay Fixed Amount per Period", "Repay Over Number of Periods"]
+		repayment_periods: DF.Int
+		repayment_schedule: DF.Table[RepaymentSchedule]
+		repayment_schedule_type: DF.Data | None
+		repayment_start_date: DF.Date | None
+		restructure_type: DF.Literal["", "Normal Restructure", "Advance Payment", "Pre Payment"]
+		status: DF.Literal[
+			"Initiated",
+			"Rejected",
+			"Active",
+			"Restructured",
+			"Rescheduled",
+			"Outdated",
+			"Draft",
+			"Cancelled",
+			"Closed",
+		]
+		total_installments_overdue: DF.Int
+		total_installments_paid: DF.Int
+		total_installments_raised: DF.Int
+		treatment_of_interest: DF.Literal["Capitalize", "Add to first repayment"]
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_repayment_period()
 		self.set_repayment_start_date()

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.json
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.json
@@ -533,7 +533,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-15 22:33:37.712280",
+ "modified": "2025-03-19 11:46:44.614411",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure",
@@ -569,7 +569,6 @@
    "write": 1
   }
  ],
- "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -21,6 +21,75 @@ from lending.loan_management.doctype.loan_repayment_schedule.loan_repayment_sche
 
 
 class LoanRestructure(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		adjusted_interest_amount: DF.Currency
+		adjusted_unaccrued_interest: DF.Currency
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		available_security_deposit: DF.Currency
+		balance_charges: DF.Currency
+		balance_interest_amount: DF.Currency
+		balance_penalty_amount: DF.Currency
+		balance_principal: DF.Currency
+		balance_unaccrued_interest: DF.Currency
+		charges_overdue: DF.Currency
+		company: DF.Link | None
+		completed_tenure: DF.Int
+		current_restructure_count: DF.Int
+		disbursed_amount: DF.Currency
+		interest_overdue: DF.Currency
+		interest_waiver_amount: DF.Currency
+		loan: DF.Link
+		loan_disbursement: DF.Link | None
+		loan_product: DF.Link | None
+		loan_repayment: DF.Link | None
+		moratorium_end_date: DF.Date | None
+		new_loan_amount: DF.Currency
+		new_monthly_repayment_amount: DF.Currency
+		new_rate_of_interest: DF.Percent
+		new_repayment_method: DF.Literal[
+			"", "Repay Fixed Amount per Period", "Repay Over Number of Periods"
+		]
+		new_repayment_period_in_months: DF.Int
+		old_emi: DF.Currency
+		old_loan_amount: DF.Currency
+		old_rate_of_interest: DF.Percent
+		old_repayment_frequency: DF.Data | None
+		old_tenure: DF.Int
+		other_charges_waiver: DF.Currency
+		penal_interest_waiver: DF.Currency
+		penalty_overdue: DF.Currency
+		pending_principal_amount: DF.Currency
+		pre_restructure_dpd: DF.Int
+		principal_adjusted: DF.Currency
+		principal_overdue: DF.Currency
+		reason_for_restructure: DF.SmallText | None
+		repayment_method: DF.Data | None
+		repayment_start_date: DF.Date | None
+		restructure_charges: DF.Currency
+		restructure_date: DF.Datetime
+		restructure_type: DF.Literal["Normal Restructure", "Pre Payment", "Advance Payment"]
+		status: DF.Literal["", "Initiated", "Approved", "Rejected"]
+		total_amount_paid: DF.Currency
+		total_overdue_amount: DF.Currency
+		total_principal_paid: DF.Currency
+		treatment_of_normal_interest: DF.Literal["Capitalize", "Add To First EMI"]
+		treatment_of_other_charges: DF.Literal["Capitalize", "Carry Forward"]
+		treatment_of_penal_interest: DF.Literal["Capitalize", "Carry Forward"]
+		unaccrued_interest: DF.Currency
+		unaccrued_interest_treatment: DF.Literal["Capitalize", "Add To First EMI"]
+		unaccrued_interest_waiver: DF.Currency
+		waive_off_restructure_charges: DF.Check
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_against_initiated_restructure()
 		self.validate_restructure_date()

--- a/lending/loan_management/doctype/loan_restructure_limit_log/loan_restructure_limit_log.json
+++ b/lending/loan_management/doctype/loan_restructure_limit_log/loan_restructure_limit_log.json
@@ -1,176 +1,176 @@
 {
-"actions": [],
-"allow_rename": 1,
-"creation": "2023-05-08 16:03:20.333618",
-"default_view": "List",
-"doctype": "DocType",
-"editable_grid": 1,
-"engine": "InnoDB",
-"field_order": [
-    "branch",
-    "date",
-    "column_break_tvos",
-    "company",
-    "normal_limit_section",
-    "principal_outstanding",
-    "limit_percent",
-    "limit_amount",
-    "column_break_qqbk",
-    "utilized_limit",
-    "in_process_limit",
-    "available_limit",
-    "delinquent_limit_section",
-    "delinquent_principal_outstanding",
-    "delinquent_limit_percent",
-    "delinquent_limit_amount",
-    "column_break_7bil",
-    "delinquent_utilized_limit",
-    "delinquent_in_process_limit",
-    "delinquent_available_limit"
-],
-"fields": [
-    {
-    "fieldname": "branch",
-    "fieldtype": "Link",
-    "label": "Branch",
-    "options": "Branch"
-    },
-    {
-    "fieldname": "date",
-    "fieldtype": "Date",
-    "in_list_view": 1,
-    "label": "Date"
-    },
-    {
-    "fieldname": "principal_outstanding",
-    "fieldtype": "Currency",
-    "label": "Principal Outstanding"
-    },
-    {
-    "fieldname": "limit_percent",
-    "fieldtype": "Percent",
-    "label": "Limit Percent"
-    },
-    {
-    "fieldname": "limit_amount",
-    "fieldtype": "Currency",
-    "label": "Limit Amount"
-    },
-    {
-    "fieldname": "utilized_limit",
-    "fieldtype": "Currency",
-    "label": "Utilized Limit"
-    },
-    {
-    "fieldname": "in_process_limit",
-    "fieldtype": "Currency",
-    "label": "In Process Limit"
-    },
-    {
-    "fieldname": "company",
-    "fieldtype": "Link",
-    "in_list_view": 1,
-    "label": "Company",
-    "options": "Company"
-    },
-    {
-    "fieldname": "available_limit",
-    "fieldtype": "Currency",
-    "in_list_view": 1,
-    "label": "Available Limit"
-    },
-    {
-    "fieldname": "column_break_tvos",
-    "fieldtype": "Column Break"
-    },
-    {
-    "fieldname": "normal_limit_section",
-    "fieldtype": "Section Break",
-    "label": "Normal Limit"
-    },
-    {
-    "fieldname": "column_break_qqbk",
-    "fieldtype": "Column Break"
-    },
-    {
-    "fieldname": "delinquent_limit_section",
-    "fieldtype": "Section Break",
-    "label": "Delinquent Limit"
-    },
-    {
-    "fieldname": "delinquent_principal_outstanding",
-    "fieldtype": "Currency",
-    "label": "Delinquent Principal Outstanding"
-    },
-    {
-    "fieldname": "delinquent_limit_percent",
-    "fieldtype": "Percent",
-    "label": "Delinquent Limit Percent"
-    },
-    {
-    "fieldname": "delinquent_limit_amount",
-    "fieldtype": "Currency",
-    "label": "Delinquent Limit Amount"
-    },
-    {
-    "fieldname": "column_break_7bil",
-    "fieldtype": "Column Break"
-    },
-    {
-    "fieldname": "delinquent_utilized_limit",
-    "fieldtype": "Currency",
-    "in_list_view": 1,
-    "label": "Delinquent Utilized Limit"
-    },
-    {
-    "fieldname": "delinquent_in_process_limit",
-    "fieldtype": "Currency",
-    "label": "Delinquent In Process Limit"
-    },
-    {
-    "fieldname": "delinquent_available_limit",
-    "fieldtype": "Currency",
-    "label": "Delinquent Available Limit"
-    }
-],
-"in_create": 1,
-"index_web_pages_for_search": 1,
-"links": [],
-"modified": "2023-05-17 21:50:35.514486",
-"modified_by": "Administrator",
-"module": "Loan Management",
-"name": "Loan Restructure Limit Log",
-"owner": "Administrator",
-"permissions": [
-    {
-    "create": 1,
-    "delete": 1,
-    "email": 1,
-    "export": 1,
-    "print": 1,
-    "read": 1,
-    "report": 1,
-    "role": "System Manager",
-    "select": 1,
-    "share": 1,
-    "write": 1
-    },
-    {
-    "create": 1,
-    "delete": 1,
-    "email": 1,
-    "export": 1,
-    "print": 1,
-    "read": 1,
-    "report": 1,
-    "role": "Loan Manager",
-    "select": 1,
-    "share": 1,
-    "write": 1
-    }
-],
-"sort_field": "modified",
-"sort_order": "DESC",
-"states": [],
-"title_field": "branch"
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-05-08 16:03:20.333618",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "branch",
+  "date",
+  "column_break_tvos",
+  "company",
+  "normal_limit_section",
+  "principal_outstanding",
+  "limit_percent",
+  "limit_amount",
+  "column_break_qqbk",
+  "utilized_limit",
+  "in_process_limit",
+  "available_limit",
+  "delinquent_limit_section",
+  "delinquent_principal_outstanding",
+  "delinquent_limit_percent",
+  "delinquent_limit_amount",
+  "column_break_7bil",
+  "delinquent_utilized_limit",
+  "delinquent_in_process_limit",
+  "delinquent_available_limit"
+ ],
+ "fields": [
+  {
+   "fieldname": "branch",
+   "fieldtype": "Link",
+   "label": "Branch",
+   "options": "Branch"
+  },
+  {
+   "fieldname": "date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date"
+  },
+  {
+   "fieldname": "principal_outstanding",
+   "fieldtype": "Currency",
+   "label": "Principal Outstanding"
+  },
+  {
+   "fieldname": "limit_percent",
+   "fieldtype": "Percent",
+   "label": "Limit Percent"
+  },
+  {
+   "fieldname": "limit_amount",
+   "fieldtype": "Currency",
+   "label": "Limit Amount"
+  },
+  {
+   "fieldname": "utilized_limit",
+   "fieldtype": "Currency",
+   "label": "Utilized Limit"
+  },
+  {
+   "fieldname": "in_process_limit",
+   "fieldtype": "Currency",
+   "label": "In Process Limit"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "available_limit",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Available Limit"
+  },
+  {
+   "fieldname": "column_break_tvos",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "normal_limit_section",
+   "fieldtype": "Section Break",
+   "label": "Normal Limit"
+  },
+  {
+   "fieldname": "column_break_qqbk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "delinquent_limit_section",
+   "fieldtype": "Section Break",
+   "label": "Delinquent Limit"
+  },
+  {
+   "fieldname": "delinquent_principal_outstanding",
+   "fieldtype": "Currency",
+   "label": "Delinquent Principal Outstanding"
+  },
+  {
+   "fieldname": "delinquent_limit_percent",
+   "fieldtype": "Percent",
+   "label": "Delinquent Limit Percent"
+  },
+  {
+   "fieldname": "delinquent_limit_amount",
+   "fieldtype": "Currency",
+   "label": "Delinquent Limit Amount"
+  },
+  {
+   "fieldname": "column_break_7bil",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "delinquent_utilized_limit",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Delinquent Utilized Limit"
+  },
+  {
+   "fieldname": "delinquent_in_process_limit",
+   "fieldtype": "Currency",
+   "label": "Delinquent In Process Limit"
+  },
+  {
+   "fieldname": "delinquent_available_limit",
+   "fieldtype": "Currency",
+   "label": "Delinquent Available Limit"
+  }
+ ],
+ "in_create": 1,
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2025-03-19 11:46:43.519738",
+ "modified_by": "Administrator",
+ "module": "Loan Management",
+ "name": "Loan Restructure Limit Log",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Loan Manager",
+   "select": 1,
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "branch"
 }

--- a/lending/loan_management/doctype/loan_restructure_limit_log/loan_restructure_limit_log.py
+++ b/lending/loan_management/doctype/loan_restructure_limit_log/loan_restructure_limit_log.py
@@ -6,4 +6,29 @@ from frappe.model.document import Document
 
 
 class LoanRestructureLimitLog(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		available_limit: DF.Currency
+		branch: DF.Link | None
+		company: DF.Link | None
+		date: DF.Date | None
+		delinquent_available_limit: DF.Currency
+		delinquent_in_process_limit: DF.Currency
+		delinquent_limit_amount: DF.Currency
+		delinquent_limit_percent: DF.Percent
+		delinquent_principal_outstanding: DF.Currency
+		delinquent_utilized_limit: DF.Currency
+		in_process_limit: DF.Currency
+		limit_amount: DF.Currency
+		limit_percent: DF.Percent
+		principal_outstanding: DF.Currency
+		utilized_limit: DF.Currency
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_security/loan_security.json
+++ b/lending/loan_management/doctype/loan_security/loan_security.json
@@ -81,7 +81,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-12-18 18:03:45.581085",
+ "modified": "2025-03-19 11:46:50.152532",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security",

--- a/lending/loan_management/doctype/loan_security/loan_security.py
+++ b/lending/loan_management/doctype/loan_security/loan_security.py
@@ -12,6 +12,24 @@ from lending.loan_management.doctype.loan_security_price.loan_security_price imp
 
 
 class LoanSecurity(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		available_security_value: DF.Currency
+		disabled: DF.Check
+		haircut: DF.Percent
+		loan_security_code: DF.Data
+		loan_security_name: DF.Data
+		loan_security_type: DF.Link
+		original_security_value: DF.Currency
+		utilized_security_value: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.update_available_security_value()
 

--- a/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.json
+++ b/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.json
@@ -171,7 +171,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-11 08:26:14.563117",
+ "modified": "2025-03-19 11:46:50.635078",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Assignment",

--- a/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
+++ b/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
@@ -16,6 +16,40 @@ from lending.loan_management.doctype.loan_security_shortfall.loan_security_short
 
 
 class LoanSecurityAssignment(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.pledge.pledge import Pledge
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		description: DF.Text | None
+		loan: DF.Link | None
+		loan_application: DF.Link | None
+		maximum_loan_value: DF.Currency
+		pledge_time: DF.Datetime | None
+		reference_no: DF.Data | None
+		release_time: DF.Datetime | None
+		securities: DF.Table[Pledge]
+		status: DF.Literal[
+			"Pledge Requested",
+			"Unpledged",
+			"Pledged",
+			"Release Requested",
+			"Released",
+			"Repossessed",
+			"Cancelled",
+		]
+		total_security_value: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_securities()
 		self.validate_loan_security_type()

--- a/lending/loan_management/doctype/loan_security_deposit/loan_security_deposit.json
+++ b/lending/loan_management/doctype/loan_security_deposit/loan_security_deposit.json
@@ -95,7 +95,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-06 05:07:24.383696",
+ "modified": "2025-03-19 11:46:42.750137",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Deposit",

--- a/lending/loan_management/doctype/loan_security_deposit/loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/loan_security_deposit.py
@@ -6,4 +6,24 @@ from frappe.model.document import Document
 
 
 class LoanSecurityDeposit(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		allocated_amount: DF.Currency
+		allocated_date: DF.Date | None
+		amended_from: DF.Link | None
+		available_amount: DF.Currency
+		deposit_amount: DF.Currency
+		deposit_date: DF.Date | None
+		loan: DF.Link | None
+		loan_disbursement: DF.Link | None
+		refund_amount: DF.Currency
+		refund_date: DF.Date | None
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_security_price/loan_security_price.json
+++ b/lending/loan_management/doctype/loan_security_price/loan_security_price.json
@@ -77,7 +77,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-01-06 13:11:25.399176",
+ "modified": "2025-03-19 11:46:49.929893",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Price",

--- a/lending/loan_management/doctype/loan_security_price/loan_security_price.py
+++ b/lending/loan_management/doctype/loan_security_price/loan_security_price.py
@@ -9,6 +9,22 @@ from frappe.utils import get_datetime
 
 
 class LoanSecurityPrice(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		loan_security: DF.Link
+		loan_security_name: DF.Data | None
+		loan_security_price: DF.Currency
+		loan_security_type: DF.Link | None
+		valid_from: DF.Datetime
+		valid_upto: DF.Datetime
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_dates()
 

--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.json
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.json
@@ -127,7 +127,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-10 18:36:27.140449",
+ "modified": "2025-03-19 11:46:47.568225",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Release",

--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.py
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.py
@@ -10,6 +10,28 @@ from frappe.utils import flt, get_datetime, getdate
 
 
 class LoanSecurityRelease(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.unpledge.unpledge import Unpledge
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		description: DF.Text | None
+		loan: DF.Link
+		reference_no: DF.Data | None
+		securities: DF.Table[Unpledge]
+		status: DF.Literal["Requested", "Approved"]
+		unpledge_time: DF.Datetime | None
+	# end: auto-generated types
+
 	def validate(self):
 		self.validate_duplicate_securities()
 		self.validate_unpledge_qty()

--- a/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.json
+++ b/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.json
@@ -119,7 +119,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-06-30 11:57:09.378089",
+ "modified": "2025-03-19 11:46:49.678879",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Shortfall",

--- a/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
+++ b/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
@@ -12,6 +12,26 @@ from lending.loan_management.doctype.loan_security_release.loan_security_release
 
 
 class LoanSecurityShortfall(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		loan: DF.Link | None
+		loan_amount: DF.Currency
+		process_loan_security_shortfall: DF.Link | None
+		security_value: DF.Currency
+		shortfall_amount: DF.Currency
+		shortfall_percentage: DF.Percent
+		shortfall_time: DF.Datetime | None
+		status: DF.Literal["", "Pending", "Completed"]
+	# end: auto-generated types
+
 	pass
 
 

--- a/lending/loan_management/doctype/loan_security_type/loan_security_type.json
+++ b/lending/loan_management/doctype/loan_security_type/loan_security_type.json
@@ -46,7 +46,7 @@
   }
  ],
  "links": [],
- "modified": "2023-11-30 15:48:30.025175",
+ "modified": "2025-03-19 11:46:50.950227",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Type",

--- a/lending/loan_management/doctype/loan_security_type/loan_security_type.py
+++ b/lending/loan_management/doctype/loan_security_type/loan_security_type.py
@@ -7,4 +7,18 @@ from frappe.model.document import Document
 
 
 class LoanSecurityType(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		disabled: DF.Check
+		haircut: DF.Percent
+		loan_security_type: DF.Data
+		loan_to_value_ratio: DF.Percent
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_transfer/loan_transfer.json
+++ b/lending/loan_management/doctype/loan_transfer/loan_transfer.json
@@ -92,7 +92,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-28 21:40:49.656173",
+ "modified": "2025-03-19 11:46:38.355632",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Transfer",

--- a/lending/loan_management/doctype/loan_transfer/loan_transfer.py
+++ b/lending/loan_management/doctype/loan_transfer/loan_transfer.py
@@ -9,6 +9,27 @@ from frappe.utils import flt
 
 
 class LoanTransfer(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from lending.loan_management.doctype.loan_transfer_detail.loan_transfer_detail import (
+			LoanTransferDetail,
+		)
+
+		amended_from: DF.Link | None
+		applicant: DF.Link | None
+		company: DF.Link
+		from_branch: DF.Link
+		loans: DF.Table[LoanTransferDetail]
+		to_branch: DF.Link
+		transfer_date: DF.Date
+	# end: auto-generated types
+
 	def after_insert(self):
 		self.get_balances_and_make_journal_entry()
 

--- a/lending/loan_management/doctype/loan_transfer_detail/loan_transfer_detail.json
+++ b/lending/loan_management/doctype/loan_transfer_detail/loan_transfer_detail.json
@@ -20,7 +20,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-04 17:09:14.096375",
+ "modified": "2025-03-19 11:46:38.198007",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Transfer Detail",

--- a/lending/loan_management/doctype/loan_transfer_detail/loan_transfer_detail.py
+++ b/lending/loan_management/doctype/loan_transfer_detail/loan_transfer_detail.py
@@ -6,4 +6,18 @@ from frappe.model.document import Document
 
 
 class LoanTransferDetail(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		loan: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.json
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.json
@@ -143,7 +143,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-12 16:56:40.674495",
+ "modified": "2025-03-19 11:46:46.817812",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Write Off",

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -16,6 +16,28 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 
 
 class LoanWriteOff(AccountsController):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		applicant: DF.DynamicLink | None
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		cost_center: DF.Link | None
+		is_npa: DF.Check
+		is_settlement_write_off: DF.Check
+		loan: DF.Link
+		loan_product: DF.Link | None
+		posting_date: DF.Date
+		write_off_account: DF.Link | None
+		write_off_amount: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self.set_missing_values()
 		self.validate_write_off_amount()

--- a/lending/loan_management/doctype/pledge/pledge.json
+++ b/lending/loan_management/doctype/pledge/pledge.json
@@ -89,7 +89,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-11-30 15:49:24.263821",
+ "modified": "2025-03-19 11:46:49.051427",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Pledge",

--- a/lending/loan_management/doctype/pledge/pledge.py
+++ b/lending/loan_management/doctype/pledge/pledge.py
@@ -7,4 +7,26 @@ from frappe.model.document import Document
 
 
 class Pledge(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		haircut: DF.Percent
+		loan_security: DF.Link
+		loan_security_code: DF.Data | None
+		loan_security_name: DF.Data | None
+		loan_security_price: DF.Currency
+		loan_security_type: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		post_haircut_amount: DF.Currency
+		qty: DF.Float
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/prepayment_charges/prepayment_charges.json
+++ b/lending/loan_management/doctype/prepayment_charges/prepayment_charges.json
@@ -27,7 +27,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-01 17:00:12.804003",
+ "modified": "2025-03-19 11:46:37.996026",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Prepayment Charges",

--- a/lending/loan_management/doctype/prepayment_charges/prepayment_charges.py
+++ b/lending/loan_management/doctype/prepayment_charges/prepayment_charges.py
@@ -6,4 +6,19 @@ from frappe.model.document import Document
 
 
 class PrepaymentCharges(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		charge: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/process_loan_classification/process_loan_classification.json
+++ b/lending/loan_management/doctype/process_loan_classification/process_loan_classification.json
@@ -80,7 +80,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-05 14:26:01.401741",
+ "modified": "2025-03-19 11:46:44.995103",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Process Loan Classification",

--- a/lending/loan_management/doctype/process_loan_classification/process_loan_classification.py
+++ b/lending/loan_management/doctype/process_loan_classification/process_loan_classification.py
@@ -8,6 +8,24 @@ from frappe.utils import add_days, getdate
 
 
 class ProcessLoanClassification(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		force_update_dpd_in_loan: DF.Check
+		is_backdated: DF.Check
+		loan: DF.Link | None
+		loan_disbursement: DF.Link | None
+		loan_product: DF.Link | None
+		payment_reference: DF.Link | None
+		posting_date: DF.Date
+	# end: auto-generated types
+
 	def validate(self):
 		if getdate(self.posting_date) < add_days(getdate(), -1) and not self.loan:
 			frappe.throw(_("For backdated process loan classification, a Loan account is mandatory."))

--- a/lending/loan_management/doctype/process_loan_demand/process_loan_demand.json
+++ b/lending/loan_management/doctype/process_loan_demand/process_loan_demand.json
@@ -57,7 +57,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-14 12:38:08.152481",
+ "modified": "2025-03-19 11:46:39.099143",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Process Loan Demand",

--- a/lending/loan_management/doctype/process_loan_demand/process_loan_demand.py
+++ b/lending/loan_management/doctype/process_loan_demand/process_loan_demand.py
@@ -12,6 +12,21 @@ from lending.loan_management.doctype.loan_demand.loan_demand import (
 
 
 class ProcessLoanDemand(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		loan: DF.Link | None
+		loan_disbursement: DF.Link | None
+		loan_product: DF.Link | None
+		posting_date: DF.Date
+	# end: auto-generated types
+
 	def on_submit(self):
 		make_loan_demand_for_term_loans(
 			self.posting_date,

--- a/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.json
+++ b/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.json
@@ -61,7 +61,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-31 04:41:56.301053",
+ "modified": "2025-03-19 11:46:48.303674",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Process Loan Interest Accrual",

--- a/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.py
@@ -14,6 +14,24 @@ from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual
 
 
 class ProcessLoanInterestAccrual(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		accrual_type: DF.Literal[
+			"Regular", "Repayment", "Disbursement", "Credit Adjustment", "Debit Adjustment", "Refund"
+		]
+		amended_from: DF.Link | None
+		company: DF.Link | None
+		loan: DF.Link | None
+		loan_product: DF.Link | None
+		posting_date: DF.Date
+	# end: auto-generated types
+
 	def on_submit(self):
 		make_accrual_interest_entry_for_loans(
 			self.posting_date,

--- a/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.json
+++ b/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.json
@@ -29,7 +29,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-18 13:55:11.292399",
+ "modified": "2025-03-19 11:46:43.265725",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Process Loan Restructure Limit",

--- a/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.py
+++ b/lending/loan_management/doctype/process_loan_restructure_limit/process_loan_restructure_limit.py
@@ -7,6 +7,18 @@ from frappe.utils import flt, getdate
 
 
 class ProcessLoanRestructureLimit(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		posting_date: DF.Date | None
+	# end: auto-generated types
+
 	def on_submit(self):
 		calculate_monthly_restructure_limit(posting_date=self.posting_date)
 

--- a/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.json
+++ b/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.json
@@ -30,7 +30,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-01-17 03:59:14.494557",
+ "modified": "2025-03-19 11:46:48.084634",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Process Loan Security Shortfall",
@@ -67,5 +67,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.py
+++ b/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.py
@@ -12,6 +12,18 @@ from lending.loan_management.doctype.loan_security_shortfall.loan_security_short
 
 
 class ProcessLoanSecurityShortfall(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amended_from: DF.Link | None
+		update_time: DF.Datetime
+	# end: auto-generated types
+
 	def onload(self):
 		self.set_onload("update_time", get_datetime())
 

--- a/lending/loan_management/doctype/proposed_pledge/proposed_pledge.json
+++ b/lending/loan_management/doctype/proposed_pledge/proposed_pledge.json
@@ -69,7 +69,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-25 03:53:41.439726",
+ "modified": "2025-03-19 11:46:50.369102",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Proposed Pledge",

--- a/lending/loan_management/doctype/proposed_pledge/proposed_pledge.py
+++ b/lending/loan_management/doctype/proposed_pledge/proposed_pledge.py
@@ -7,4 +7,24 @@ from frappe.model.document import Document
 
 
 class ProposedPledge(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		amount: DF.Currency
+		haircut: DF.Percent
+		loan_security: DF.Link | None
+		loan_security_name: DF.Data | None
+		loan_security_price: DF.Currency
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		post_haircut_amount: DF.Currency
+		qty: DF.Float
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/repayment_schedule/repayment_schedule.json
+++ b/lending/loan_management/doctype/repayment_schedule/repayment_schedule.json
@@ -77,7 +77,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-09-10 10:51:32.032124",
+ "modified": "2025-03-19 11:46:48.523253",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Repayment Schedule",

--- a/lending/loan_management/doctype/repayment_schedule/repayment_schedule.py
+++ b/lending/loan_management/doctype/repayment_schedule/repayment_schedule.py
@@ -7,4 +7,24 @@ from frappe.model.document import Document
 
 
 class RepaymentSchedule(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		balance_loan_amount: DF.Currency
+		demand_generated: DF.Check
+		interest_amount: DF.Currency
+		number_of_days: DF.Int
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		payment_date: DF.Date | None
+		principal_amount: DF.Currency
+		total_payment: DF.Currency
+	# end: auto-generated types
+
 	pass

--- a/lending/loan_management/doctype/sanctioned_loan_amount/sanctioned_loan_amount.json
+++ b/lending/loan_management/doctype/sanctioned_loan_amount/sanctioned_loan_amount.json
@@ -51,7 +51,7 @@
   }
  ],
  "links": [],
- "modified": "2020-02-25 05:10:52.421193",
+ "modified": "2025-03-19 11:46:47.316646",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Sanctioned Loan Amount",
@@ -84,5 +84,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/lending/loan_management/doctype/sanctioned_loan_amount/sanctioned_loan_amount.py
+++ b/lending/loan_management/doctype/sanctioned_loan_amount/sanctioned_loan_amount.py
@@ -8,6 +8,20 @@ from frappe.model.document import Document
 
 
 class SanctionedLoanAmount(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		applicant: DF.DynamicLink
+		applicant_type: DF.Literal["Employee", "Member", "Customer"]
+		company: DF.Link
+		sanctioned_amount_limit: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		sanctioned_doc = frappe.db.exists(
 			"Sanctioned Loan Amount", {"applicant": self.applicant, "company": self.company}

--- a/lending/loan_management/doctype/unpledge/unpledge.json
+++ b/lending/loan_management/doctype/unpledge/unpledge.json
@@ -66,7 +66,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-30 15:49:40.175308",
+ "modified": "2025-03-19 11:46:47.808437",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Unpledge",

--- a/lending/loan_management/doctype/unpledge/unpledge.py
+++ b/lending/loan_management/doctype/unpledge/unpledge.py
@@ -7,4 +7,23 @@ from frappe.model.document import Document
 
 
 class Unpledge(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		haircut: DF.Percent
+		loan_security: DF.Link
+		loan_security_code: DF.Data | None
+		loan_security_name: DF.Data | None
+		loan_security_type: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		qty: DF.Float
+	# end: auto-generated types
+
 	pass


### PR DESCRIPTION
Uses the export_python_type_annotations hook.