### PR TITLE
fix: moratorium during restructure

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1653,21 +1653,21 @@ class TestLoan(IntegrationTestCase):
 		)
 
 		repayment_entry = create_repayment_entry(
-			loan.name, "2024-08-25", 15000, repayment_type="Pre Payment"
+			loan.name, "2024-10-25", 15000, repayment_type="Pre Payment"
 		)
 		repayment_entry.submit()
 
-		process_daily_loan_demands(posting_date="2024-09-01", loan=loan.name)
+		process_daily_loan_demands(posting_date="2024-11-01", loan=loan.name)
 
 		repayment_entry = create_repayment_entry(
-			loan.name, "2024-09-01", 138.90, repayment_type="Normal Repayment"
+			loan.name, "2024-11-16", 138.90, repayment_type="Normal Repayment"
 		)
 		repayment_entry.submit()
 
-		process_daily_loan_demands(posting_date="2024-10-01", loan=loan.name)
+		process_daily_loan_demands(posting_date="2024-12-01", loan=loan.name)
 
 		repayment_entry = create_repayment_entry(
-			loan.name, "2024-09-26", 15000, repayment_type="Pre Payment"
+			loan.name, "2024-11-26", 15000, repayment_type="Pre Payment"
 		)
 		repayment_entry.submit()
 

--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
@@ -51,6 +51,6 @@ class LoanAdjustment(Document):
 					self.posting_date,
 					repayment.loan_repayment_type,
 					repayment.amount,
-					self.name,
+					adjustment_name=self.name,
 					payment_account=self.payment_account,
 				)

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2110,12 +2110,13 @@ class LoanRepayment(AccountsController):
 			moratorium_end_date = frappe.db.get_value(
 				"Loan Repayment Schedule", {"loan": self.against_loan, "docstatus": 1}, "moratorium_end_date"
 			)
-			if get_datetime(moratorium_end_date) >= get_datetime(self.posting_date):
-				frappe.throw(
-					_(
-						"Cannot make Advance or Pre Payments during moratorium period. (Moratorium End Date: {}, Posting Date: {})"
-					).format(moratorium_end_date, self.posting_date)
-				)
+			if moratorium_end_date:
+				if get_datetime(moratorium_end_date) >= get_datetime(self.posting_date):
+					frappe.throw(
+						_(
+							"Cannot make Advance or Pre Payments during moratorium period. (Moratorium End Date: {}, Posting Date: {})"
+						).format(moratorium_end_date, self.posting_date)
+					)
 
 
 def create_repayment_entry(

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -521,6 +521,8 @@ class LoanRepaymentSchedule(Document):
 			tenure = self.repayment_periods
 			if self.repayment_frequency == "Monthly" and self.moratorium_tenure:
 				tenure += cint(self.moratorium_tenure)
+		elif self.restructure_type in ("Advance Payment", "Pre Payment") and self.moratorium_tenure:
+			tenure = self.repayment_periods + self.moratorium_tenure
 		elif loan_status == "Partially Disbursed":
 			prev_schedule = frappe.db.get_value(
 				"Loan Repayment Schedule", {"loan": self.loan, "docstatus": 1, "status": "Active"}

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -361,7 +361,9 @@ class LoanRepaymentSchedule(Document):
 				and self.repayment_frequency == "Monthly"
 				and self.repayment_schedule_type == "Monthly as per cycle date"
 			):
-				payment_date = add_months(self.repayment_start_date, -1 * self.moratorium_tenure)
+				# payment_date = add_months(self.repayment_start_date, -1 * self.moratorium_tenure)
+				payment_date = self.repayment_start_date
+				self.repayment_start_date = add_months(payment_date, self.moratorium_tenure)
 				self.moratorium_end_date = add_months(self.repayment_start_date, -1)
 			elif self.moratorium_tenure and self.repayment_frequency == "Monthly":
 				self.moratorium_end_date = add_months(self.repayment_start_date, self.moratorium_tenure)

--- a/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
@@ -1,9 +1,70 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests.utils import FrappeTestCase
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import date_diff
+
+from lending.loan_management.doctype.loan_repayment_schedule.utils import (
+	get_amounts,
+	get_monthly_repayment_amount,
+)
+from lending.loan_management.doctype.loan_restructure.loan_restructure import create_loan_repayment
+from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
+	process_daily_loan_demands,
+)
+from lending.tests.test_utils import (
+	create_loan,
+	create_repayment_entry,
+	init_customers,
+	init_loan_products,
+	make_loan_disbursement_entry,
+	master_init,
+)
 
 
-class TestLoanRepaymentSchedule(FrappeTestCase):
-	pass
+class TestLoanRepaymentSchedule(IntegrationTestCase):
+	def setUp(self):
+		master_init()
+		init_loan_products()
+		init_customers()
+		self.applicant2 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer"}, "name")
+
+	def test_correct_moratorium_periods_after_restructure(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			285000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date="2024-12-05",
+			posting_date="2024-11-05",
+			rate_of_interest=17,
+			applicant_type="Customer",
+			moratorium_tenure=3,
+			moratorium_type="Principal",
+		)
+		loan.submit()
+		loan.load_from_db()
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-11-05", repayment_start_date="2024-12-05"
+		)
+		process_daily_loan_demands(loan=loan.name, posting_date="2025-12-05")
+		loan_demand_amount = 181958
+		repayment_entry = create_repayment_entry(
+			loan=loan.name,
+			posting_date="2025-12-05",
+			paid_amount=loan_demand_amount + 1000,
+			repayment_type="Pre Payment",
+		)
+		repayment_entry.submit()
+		repayment_schedule = frappe.get_doc(
+			"Loan Repayment Schedule", {"loan": loan.name, "docstatus": 1}
+		)
+		repayment_schedule_rows = repayment_schedule.get("repayment_schedule")
+		num_of_rows = len(repayment_schedule_rows)
+		self.assertEqual(num_of_rows, 15)
+		monthly_repayment_amount = get_monthly_repayment_amount(285000, 17, 12, "Monthly")
+		self.assertTrue(
+			abs(repayment_schedule_rows[-1].total_payment - (monthly_repayment_amount + 1000) < 1000)
+		)

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -570,7 +570,11 @@ class LoanRestructure(AccountsController):
 	def make_waiver_and_capitalization_for_penalty(self):
 		if self.penal_interest_waiver:
 			create_loan_repayment(
-				self.loan, self.restructure_date, "Penalty Waiver", self.penal_interest_waiver, self.name
+				self.loan,
+				self.restructure_date,
+				"Penalty Waiver",
+				self.penal_interest_waiver,
+				restructure_name=self.name,
 			)
 
 		if self.balance_penalty_amount and self.treatment_of_penal_interest == "Capitalize":
@@ -579,13 +583,17 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Penalty Capitalization",
 				self.balance_penalty_amount,
-				self.name,
+				restructure_name=self.name,
 			)
 
 	def make_loan_repayment_for_adjustment(self):
 		if self.principal_adjusted:
 			create_loan_repayment(
-				self.loan, self.restructure_date, "Principal Adjustment", self.principal_adjusted, self.name
+				self.loan,
+				self.restructure_date,
+				"Principal Adjustment",
+				self.principal_adjusted,
+				restructure_name=self.name,
 			)
 
 		if self.adjusted_interest_amount:
@@ -594,7 +602,7 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Interest Adjustment",
 				self.adjusted_interest_amount,
-				self.name,
+				restructure_name=self.name,
 			)
 
 	def make_loan_repayment_for_waiver(self):
@@ -602,7 +610,11 @@ class LoanRestructure(AccountsController):
 
 		if self.interest_waiver_amount:
 			create_loan_repayment(
-				self.loan, self.restructure_date, "Interest Waiver", self.interest_waiver_amount, self.name
+				self.loan,
+				self.restructure_date,
+				"Interest Waiver",
+				self.interest_waiver_amount,
+				restructure_name=self.name,
 			)
 
 		if self.unaccrued_interest_waiver:
@@ -615,12 +627,20 @@ class LoanRestructure(AccountsController):
 			)
 
 			create_loan_repayment(
-				self.loan, self.restructure_date, "Interest Waiver", self.unaccrued_interest_waiver, self.name
+				self.loan,
+				self.restructure_date,
+				"Interest Waiver",
+				self.unaccrued_interest_waiver,
+				restructure_name=self.name,
 			)
 
 		if self.other_charges_waiver:
 			create_loan_repayment(
-				self.loan, self.restructure_date, "Charges Waiver", self.other_charges_waiver, self.name
+				self.loan,
+				self.restructure_date,
+				"Charges Waiver",
+				self.other_charges_waiver,
+				restructure_name=self.name,
 			)
 
 	def cancel_loan_adjustments(self):
@@ -635,7 +655,7 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Interest Capitalization",
 				self.balance_interest_amount,
-				self.name,
+				restructure_name=self.name,
 			)
 
 		if self.balance_unaccrued_interest and self.unaccrued_interest_treatment == "Capitalize":
@@ -644,7 +664,7 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Interest Capitalization",
 				self.balance_unaccrued_interest,
-				self.name,
+				restructure_name=self.name,
 			)
 
 		if self.balance_charges and self.treatment_of_other_charges == "Capitalize":
@@ -653,7 +673,7 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Charges Capitalization",
 				self.balance_charges,
-				self.name,
+				restructure_name=self.name,
 			)
 
 		if self.balance_principal:
@@ -662,7 +682,7 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Principal Capitalization",
 				self.balance_principal,
-				self.name,
+				restructure_name=self.name,
 			)
 
 	def make_loan_adjustment_for_carry_forward(self):
@@ -673,7 +693,7 @@ class LoanRestructure(AccountsController):
 					self.restructure_date,
 					"Interest Carry Forward",
 					self.balance_interest_amount,
-					self.name,
+					restructure_name=self.name,
 				)
 
 			if self.balance_unaccrued_interest and self.unaccrued_interest_treatment == "Add To First EMI":
@@ -682,7 +702,7 @@ class LoanRestructure(AccountsController):
 					self.restructure_date,
 					"Interest Carry Forward",
 					self.balance_unaccrued_interest,
-					self.name,
+					restructure_name=self.name,
 				)
 
 
@@ -691,8 +711,8 @@ def create_loan_repayment(
 	posting_date,
 	repayment_type,
 	waiver_amount,
-	adjustment_name=None,
 	restructure_name=None,
+	adjustment_name=None,
 	is_write_off_waiver=0,
 	payment_account=None,
 	loan_disbursement=None,


### PR DESCRIPTION
Repayment schedules with moratoriums had changes in tenure when they got rescheduled. This was because the repayment_method changes during reschedules. This adds a condition for that and fixes it