### PR TITLE
fix: posting_date for interest accruals should be t-1

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -2002,7 +2002,6 @@ class TestLoan(IntegrationTestCase):
 			"2024-08-17",
 			"2024-08-18",
 			"2024-08-19",
-			"2024-08-20",
 		]
 		expected_dates = [getdate(i) for i in expected_dates]
 		accrual_dates = [getdate(i) for i in loan_interest_accruals]
@@ -2018,7 +2017,6 @@ class TestLoan(IntegrationTestCase):
 		)
 		expected_dates = [
 			"2024-08-25",
-			"2024-08-31",
 		]
 		expected_dates = [getdate(i) for i in expected_dates]
 		accrual_dates = [getdate(i) for i in loan_interest_accruals]
@@ -2036,7 +2034,6 @@ class TestLoan(IntegrationTestCase):
 			"2024-09-15",
 			"2024-09-30",
 			"2024-10-15",
-			"2024-10-31",
 		]
 		expected_dates = [getdate(i) for i in expected_dates]
 		accrual_dates = [getdate(i) for i in loan_interest_accruals]

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1305,7 +1305,7 @@ class TestLoan(IntegrationTestCase):
 		repayment_entry.submit()
 		repayment_entry.load_from_db()
 
-		self.assertEqual(flt(repayment_entry.principal_amount_paid, 1), flt(49726.03, 1))
+		self.assertEqual(flt(repayment_entry.principal_amount_paid, 1), flt(51095.9, 1))
 
 	def test_additional_interest(self):
 		frappe.db.set_value(

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -328,7 +328,6 @@ def get_accrual_frequency_breaks(last_accrual_date, accrual_date, loan_accrual_f
 	last_accrual_date = getdate(last_accrual_date)
 	accrual_date = getdate(accrual_date)
 	out = []
-
 	if loan_accrual_frequency == "Daily":
 		current_date = add_days(last_accrual_date, 1)
 		day_delta = 1
@@ -486,14 +485,13 @@ def get_overlapping_dates(
 	)
 
 	accrual_frequency_breaks = get_accrual_frequency_breaks(
-		add_days(last_accrual_date, -1), posting_date, loan_accrual_frequency
+		add_days(last_accrual_date, -1), add_days(posting_date, -1), loan_accrual_frequency
 	)
 	# Merge accrual_frequency_breaks into repayment_schedule breaks and get all unique dates
 	for schedule_parent in parent_wise_schedules:
 		parent_wise_schedules[schedule_parent].extend(accrual_frequency_breaks)
 		parent_wise_schedules[schedule_parent] = list(set(parent_wise_schedules[schedule_parent]))
 		parent_wise_schedules[schedule_parent].sort()
-
 	return parent_wise_schedules
 
 
@@ -1087,7 +1085,6 @@ def get_parent_wise_dates(loan, last_accrual_date, posting_date, loan_disburseme
 		parent_wise_schedules.setdefault(schedule_date.parent, [])
 		parent_wise_schedules[schedule_date.parent].append(add_days(schedule_date.payment_date, -1))
 	maturity_map = add_maturity_breaks(parent_wise_schedules, schedules_details, posting_date)
-
 	return parent_wise_schedules, maturity_map
 
 
@@ -1095,11 +1092,10 @@ def add_maturity_breaks(parent_wise_schedules, schedules_details, posting_date):
 	maturity_map = {}
 	for schedule in schedules_details:
 		parent_wise_schedules.setdefault(schedule.name, [])
-		to_accrual_date = posting_date
 		maturity_date = schedule.get("maturity_date")
 		maturity_map[schedule.name] = maturity_date
 		if maturity_date and getdate(maturity_date) <= getdate(posting_date):
 			to_accrual_date = add_days(maturity_date, -1)
-		parent_wise_schedules[schedule.name].append(getdate(to_accrual_date))
+			parent_wise_schedules[schedule.name].append(getdate(to_accrual_date))
 
 	return maturity_map


### PR DESCRIPTION
If the posting date for the Process Loan Interest Accruals is `t` then Loan Interest Accruals should only happen till `t-1`