### PR TITLE
fix: get_bulk_due_details == get_due_details

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2769,26 +2769,6 @@ def get_accrued_interest(
 	return flt(accrued_interest)
 
 
-def get_demanded_interest(loan, posting_date, demand_subtype="Interest", loan_disbursement=None):
-	filters = {
-		"loan": loan,
-		"docstatus": 1,
-		"demand_date": ("<=", posting_date),
-		"demand_subtype": demand_subtype,
-	}
-
-	if loan_disbursement:
-		filters["loan_disbursement"] = loan_disbursement
-
-	demand_interest = frappe.db.get_value(
-		"Loan Demand",
-		filters,
-		"SUM(demand_amount)",
-	)
-
-	return flt(demand_interest)
-
-
 def get_net_paid_amount(loan):
 	return frappe.db.get_value("Loan", {"name": loan}, "sum(total_amount_paid - refund_amount)")
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2406,7 +2406,6 @@ def process_amount_for_loan(
 			loan_disbursement=loan_disbursement,
 		)
 
-	amounts["interest_accrued"] = accrued_interest
 	amounts["total_charges_payable"] = charges
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
 	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
@@ -2606,7 +2605,6 @@ def init_amounts():
 		"pending_principal_amount": 0.0,
 		"payable_principal_amount": 0.0,
 		"payable_amount": 0.0,
-		"interest_accrued": 0.0,
 		"unaccrued_interest": 0.0,
 		"unbooked_interest": 0.0,
 		"unbooked_penalty": 0.0,

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2487,6 +2487,8 @@ def get_bulk_due_details(loans, posting_date):
 					principal_amount,
 					unbooked_interest,
 					amounts,
+					posting_date,
+					loan.status,
 				)
 				due_details.append(amounts)
 		else:
@@ -2495,7 +2497,7 @@ def get_bulk_due_details(loans, posting_date):
 			unbooked_interest = unbooked_interest_map.get(loan.name, 0)
 			demands = demand_map.get(loan.name, [])
 			amounts = process_amount_for_bulk_loans(
-				loan, demands, None, principal_amount, unbooked_interest, amounts
+				loan, demands, None, principal_amount, unbooked_interest, amounts, posting_date, loan.status
 			)
 			due_details.append(amounts)
 

--- a/lending/loan_management/doctype/loan_repayment/utils.py
+++ b/lending/loan_management/doctype/loan_repayment/utils.py
@@ -65,7 +65,14 @@ def get_disbursement_map(loans):
 
 
 def process_amount_for_bulk_loans(
-	loan, demands, disbursement, pending_principal_amount, unbooked_interest, amounts
+	loan,
+	demands,
+	loan_disbursement,
+	pending_principal_amount,
+	unbooked_interest,
+	amounts,
+	posting_date,
+	status,
 ):
 
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
@@ -74,6 +81,9 @@ def process_amount_for_bulk_loans(
 	penalty_amount = 0
 	payable_principal_amount = 0
 
+	last_demand_date = get_last_demand_date(
+		loan.name, posting_date, loan_disbursement=loan_disbursement, status=status
+	)
 	for demand in demands:
 		if demand.demand_subtype == "Interest":
 			total_pending_interest += demand.outstanding_amount
@@ -85,7 +95,7 @@ def process_amount_for_bulk_loans(
 			charges += demand.outstanding_amount
 
 	amounts["loan"] = loan.name
-	amounts["loan_disbursement"] = disbursement
+	amounts["loan_disbursement"] = loan_disbursement
 	amounts["total_charges_payable"] = charges
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
 	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
@@ -97,6 +107,7 @@ def process_amount_for_bulk_loans(
 	amounts["unbooked_interest"] = flt(unbooked_interest, precision)
 	amounts["written_off_amount"] = flt(loan.written_off_amount, precision)
 	amounts["unpaid_demands"] = demands
+	amounts["due_date"] = last_demand_date
 	amounts["excess_amount_paid"] = flt(loan.excess_amount_paid, precision)
 
 	return amounts

--- a/lending/loan_management/doctype/loan_repayment/utils.py
+++ b/lending/loan_management/doctype/loan_repayment/utils.py
@@ -81,7 +81,7 @@ def process_amount_for_bulk_loans(
 	penalty_amount = 0
 	payable_principal_amount = 0
 
-	last_demand_date = get_last_demand_date(loan.name, posting_date)
+	last_demand_date = get_last_demand_date(posting_date, loan.name)
 	for demand in demands:
 		if demand.demand_subtype == "Interest":
 			total_pending_interest += demand.outstanding_amount

--- a/lending/loan_management/doctype/loan_repayment/utils.py
+++ b/lending/loan_management/doctype/loan_repayment/utils.py
@@ -81,7 +81,7 @@ def process_amount_for_bulk_loans(
 	penalty_amount = 0
 	payable_principal_amount = 0
 
-	last_demand_date = get_last_demand_date(posting_date, loan.name)
+	last_demand_date = get_last_demand_date(posting_date, loan=loan.name)
 	for demand in demands:
 		if demand.demand_subtype == "Interest":
 			total_pending_interest += demand.outstanding_amount

--- a/lending/loan_management/doctype/loan_repayment/utils.py
+++ b/lending/loan_management/doctype/loan_repayment/utils.py
@@ -112,7 +112,7 @@ def get_unbooked_interest_for_loans(
 	filters = {
 		"loan": ("in", loan_list),
 		"docstatus": 1,
-		"posting_date": ("<=", posting_date),
+		"posting_date": ("<", posting_date),
 		"interest_type": interest_type,
 	}
 


### PR DESCRIPTION
We have two APIs for the same task. Their output didn't quite match.
This PR fixes:
- available_security_deposit calculation
- unbooked_interest calculation