### PR TITLE
fix: Penal accrual reversals on normal repayments

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -270,7 +270,6 @@ class LoanRepayment(AccountsController):
 				"Interest Waiver",
 				"Penalty Waiver",
 				"Charges Waiver",
-				"Normal Repayment",
 			)
 			and not (self.flags.from_repost or self.flags.from_repost)
 		):


### PR DESCRIPTION
Penal accruals are now reversed if a normal repayment is made before their posting_date