### PR TITLE
fix: invalid query generation

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -1249,7 +1249,7 @@ def update_npa_check(is_npa, applicant_type, applicant, posting_date, manual_npa
 			& (_loan.status.isin(["Disbursed", "Partially Disbursed", "Active"]))
 			& (_loan.applicant_type == applicant_type)
 			& (_loan.applicant == applicant)
-			& (_loan.watch_period_end_date.isnull() | _loan.watch_period_end_date < posting_date)
+			& (_loan.watch_period_end_date.isnull() | (_loan.watch_period_end_date < posting_date))
 		)
 	)
 


### PR DESCRIPTION
`|` operator has a higher precedence so it gets bitwise ORed with a column instead of the criterion.

WTF.

Orignal code
```python
& (_loan.watch_period_end_date.isnull() | _loan.watch_period_end_date < posting_date)
```

Generated query:

```diff
- SELECT `name` FROM `tabLoan` WHERE ... AND `watch_period_end_date` IS NULL OR `watch_period_end_date`<'2025-04-07' FOR UPDATE
+ SELECT `name` FROM `tabLoan` WHERE ... AND (`watch_period_end_date` IS NULL OR `watch_period_end_date`<'2025-04-07') FOR UPDATE
```

These causes selecting more rows than necessary -> more locks than necessary -> timeouts. 