### PR TITLE
test: add assertEqual for penal and interest waiver

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1875,12 +1875,12 @@ class TestLoan(IntegrationTestCase):
 		)
 
 		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2024-07-07 00:05:10"), 1052079.26
+			loan.name, get_datetime("2024-07-07 00:05:10"), 1053101.76
 		)
 		repayment_entry.submit()
 
 		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2024-07-07 00:06:10"), 13217.10, repayment_type="Penalty Waiver"
+			loan.name, get_datetime("2024-07-07 00:06:10"), 14050.00, repayment_type="Penalty Waiver"
 		)
 		repayment_entry.submit()
 

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1847,6 +1847,9 @@ class TestLoan(IntegrationTestCase):
 		)
 		repayment_entry.submit()
 
+		loan_status = frappe.db.get_value("Loan", loan.name, "status")
+		self.assertEqual(loan_status, "Closed")
+
 	def test_excess_amount_for_penal_waiver(self):
 		loan = create_loan(
 			"_Test Customer 1",
@@ -1880,6 +1883,9 @@ class TestLoan(IntegrationTestCase):
 			loan.name, get_datetime("2024-07-07 00:06:10"), 13217.10, repayment_type="Penalty Waiver"
 		)
 		repayment_entry.submit()
+
+		loan_status = frappe.db.get_value("Loan", loan.name, "status")
+		self.assertEqual(loan_status, "Closed")
 
 	def test_dpd_calculation(self):
 		loan = create_loan(


### PR DESCRIPTION
In the previous [PR](https://github.com/frappe/lending/pull/519), assertEqual was not added, so please fix that. This will help resolve any issues if a testcase breaks.