### PR TITLE
fix: loan status update when cancelled the interest or penalty waiver

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1841,12 +1841,12 @@ class TestLoan(IntegrationTestCase):
 		process_daily_loan_demands(posting_date="2025-01-05", loan=loan.name)
 
 		repayment_entry = create_repayment_entry(
-			loan.name, "2025-01-16", 100000, repayment_type="Principal Adjustment"
+			loan.name, get_datetime("2025-01-16 00:06:10"), 100000, repayment_type="Principal Adjustment"
 		)
 		repayment_entry.submit()
 
 		repayment_entry = create_repayment_entry(
-			loan.name, "2025-01-16", 2600.00, repayment_type="Interest Waiver"
+			loan.name, get_datetime("2025-01-16 00:10:10"), 2600.00, repayment_type="Interest Waiver"
 		)
 		repayment_entry.submit()
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1203,6 +1203,8 @@ class LoanRepayment(AccountsController):
 			"Partial Settlement",
 			"Principal Adjustment",
 			"Security Deposit Adjustment",
+			"Interest Waiver",
+			"Penalty Waiver",
 		):
 			loan = frappe.qb.DocType("Loan")
 


### PR DESCRIPTION
When a Penalty Waiver or Interest Waiver repayment entry is created, and the shortfall is satisfied, the loan status is updated to Closed. However, if such a Penalty Waiver or Interest Waiver entry is later canceled, the loan status was not reverting back to Disbursed, so fixed that.