### PR TITLE
fix: add missing applicant_type field

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -250,6 +250,7 @@ class LoanRepayment(AccountsController):
 				"disbursed_amount",
 				"total_interest_payable",
 				"written_off_amount",
+				"applicant_type"
 			],
 			as_dict=1,
 		)


### PR DESCRIPTION
in `status = "Closed" if loan.applicant_type == "Employee" else "Loan Closure Requested"` line
`loan.applicant_type` is used to determine if loan is for employee and then close it but the value is not loaded in `loan = frappe.get_value`