### PR TITLE
fix: get_pending_principal_amount precision

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1070,6 +1070,7 @@ def regenerate_repayment_schedule(loan, cancel=0):
 
 
 def get_pending_principal_amount(loan):
+	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	if loan.status in ("Disbursed", "Closed") or loan.disbursed_amount >= loan.loan_amount:
 		pending_principal_amount = (
 			flt(loan.total_payment)
@@ -1091,7 +1092,7 @@ def get_pending_principal_amount(loan):
 			+ flt(loan.refund_amount)
 		)
 
-	return pending_principal_amount
+	return flt(pending_principal_amount, precision)
 
 
 # This function returns the amounts that are payable at the time of loan repayment based on posting date


### PR DESCRIPTION
in `if not loan.is_secured_loan and pending_principal_amount <= 0:` line
returned `pending_principal_amount` from `get_pending_principal_amount` function has high precision
the high precision will make `pending_principal_amount <= 0` return false
the `get_pending_principal_amount` function must return value with currency precision