### PR TITLE
fix: Skip repayment start date recalculation for migrated or customized schedules

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -2131,6 +2131,68 @@ class TestLoan(IntegrationTestCase):
 				f"DPD mismatch for {posting_date} (Disbursement: {disbursement}): Expected {expected_dpd}, got {dpd_value}",
 			)
 
+	def test_migrated_repayment_schedule(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			posting_date="2025-01-01",
+			repayment_start_date="2025-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-01-01", repayment_start_date="2025-01-05"
+		)
+
+		parent_schedule_name = frappe.db.get_value(
+			"Loan Repayment Schedule", {"loan": loan.name, "status": "Active", "docstatus": 1}
+		)
+
+		payment_dates = [
+			"2025-01-05",
+			"2025-02-05",
+			"2025-03-10",
+			"2025-04-10",
+			"2025-05-10",
+			"2025-06-10",
+		]
+
+		rows = frappe.db.get_all(
+			"Repayment Schedule",
+			filters={"parent": parent_schedule_name},
+			fields=["name"],
+			order_by="idx asc",
+		)
+
+		for i, row in enumerate(rows):
+			if i < len(payment_dates):
+				frappe.db.set_value("Repayment Schedule", row.get("name"), "payment_date", payment_dates[i])
+
+		process_daily_loan_demands(posting_date="2025-03-10", loan=loan.name)
+
+		repayment_entry = create_repayment_entry(loan.name, "2025-03-10", 51471)
+		repayment_entry.submit()
+
+		repayment_entry = create_repayment_entry(
+			loan.name, "2025-03-10", 15000, repayment_type="Pre Payment"
+		)
+		repayment_entry.submit()
+
+		updated_rows = frappe.db.get_all(
+			"Repayment Schedule",
+			filters={"parent": parent_schedule_name},
+			fields=["payment_date"],
+			order_by="idx asc",
+		)
+
+		for i, row in enumerate(updated_rows):
+			self.assertEqual(str(row.get("payment_date")), payment_dates[i])
+
 	def test_charges_payment(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -785,7 +785,7 @@ def get_restructure_details(
 
 
 def get_pending_tenure_and_start_date(loan, posting_date, repayment_type, loan_disbursement=None):
-	from lending.loan_management.doctype.loan.loan import get_cyclic_date
+	# from lending.loan_management.doctype.loan.loan import get_cyclic_date
 
 	ignore_bpi = False
 
@@ -819,11 +819,14 @@ def get_pending_tenure_and_start_date(loan, posting_date, repayment_type, loan_d
 
 	if repayment_frequency == "One Time":
 		repayment_start_date = prev_repayment_start_date
-	elif repayment_schedule_type in "Monthly as per cycle date" and repayment_frequency == "Monthly":
-		if repayment_type == "Pre Payment":
-			ignore_bpi = True
+	# elif repayment_schedule_type in "Monthly as per cycle date" and repayment_frequency == "Monthly":
+	# 	# Skipping cyclic date calculation for migrated or manually updated repayment schedules.
+	# 	# In migrated loans or where repayment_start_date was explicitly modified,
+	# 	# we should retain the existing schedule dates and not recalculate based on product cycle.
+	# 	if repayment_type == "Pre Payment":
+	# 		ignore_bpi = True
 
-		repayment_start_date = get_cyclic_date(loan_product, posting_date, ignore_bpi=ignore_bpi)
+	# 	repayment_start_date = get_cyclic_date(loan_product, posting_date, ignore_bpi=ignore_bpi)
 	else:
 		if getdate(posting_date) <= getdate(prev_repayment_start_date):
 			repayment_start_date = prev_repayment_start_date


### PR DESCRIPTION
Summary: This change comments out the logic that recalculates the `repayment_start_date` using cyclic dates for "Monthly as per cycle date" schedules. This is to avoid overriding the start date in migrated or manually modified repayment schedules.

Reason: In migrated or manually adjusted loans, the repayment start date may have been explicitly set. Recalculating it could lead to discrepancies with the intended schedule.