### PR TITLE
fix: adapt reversals of accruals and demands to date to datetime change

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1939,13 +1939,22 @@ class TestLoan(IntegrationTestCase):
 			loan=loan.name, posting_date="2024-07-07", company="_Test Company"
 		)
 
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2024-07-07")[
+			"payable_amount"
+		]
+
 		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2024-07-07 00:05:10"), 1053101.76
+			loan.name, get_datetime("2024-07-07 00:05:10"), payable_amount
 		)
 		repayment_entry.submit()
 
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-07-07")
+		payable_penalty_amount = amounts["unbooked_penalty"] + amounts["penalty_amount"]
 		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2024-07-07 00:06:10"), 14050.00, repayment_type="Penalty Waiver"
+			loan.name,
+			get_datetime("2024-07-07 00:06:10"),
+			payable_penalty_amount,
+			repayment_type="Penalty Waiver",
 		)
 		repayment_entry.submit()
 

--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, cint, flt, getdate
+from frappe.utils import add_days, cint, flt, get_datetime, getdate
 
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
@@ -513,6 +513,9 @@ def reverse_demands(
 	future_demands=False,
 	loan_repayment=None,
 ):
+
+	# Datetime adaptations
+	posting_date = get_datetime(getdate(posting_date))
 
 	# on settlement or closure, demand should be cleared from next day
 	# as other demands also get passed on the same day

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -1028,6 +1028,8 @@ def reverse_loan_interest_accruals(
 		write_off_suspense_entries,
 	)
 
+	# Datetimes are a pain. Reverse any accruals made that day irrespective of time
+	posting_date = get_datetime(getdate(posting_date))
 	filters = {
 		"loan": loan,
 		"posting_date": (">=", posting_date),


### PR DESCRIPTION
We recently changed the posting_dates of a few DocTypes from date to datetime, extra handling for that.