### PR TITLE
fix: accrual overlap validation

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3047,3 +3047,62 @@ class TestLoan(IntegrationTestCase):
 		expected_dates = [getdate(i) for i in expected_dates]
 		accrual_dates = [getdate(i) for i in loan_interest_accruals]
 		self.assertEqual(accrual_dates, expected_dates)
+
+	def test_overlapping_accrual_validation(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-08-16",
+			posting_date="2024-08-16",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+		)
+		loan.submit()
+		disbursement = make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-08-16", repayment_start_date="2024-08-16"
+		)
+
+		def make_accrual_entry(start_date, posting_date):
+			start_date = get_datetime(start_date)
+			posting_date = get_datetime(posting_date)
+			accrual_doc = frappe.new_doc("Loan Interest Accrual")
+			accrual_doc.loan = loan.name
+			accrual_doc.loan_disbursement = disbursement.name
+			accrual_doc.company = "_Test Company"
+			accrual_doc.rate_of_interest = 8.5
+			accrual_doc.start_date = start_date
+			accrual_doc.posting_date = posting_date
+			accrual_doc.interest_amount = 32
+			accrual_doc.base_amount = 100000
+			accrual_doc.additional_interest_amount = 0
+
+			return accrual_doc
+
+		original_accrual = make_accrual_entry("2024-08-20", "2024-08-25")
+		original_accrual.submit()
+		original_accrual.load_from_db()
+
+		overlapping_accruals = [
+			("2024-08-20", "2024-08-24"),  # same start date, but shorter
+			("2024-08-20", "2024-08-26"),  # same start date, but longer
+			("2024-08-19", "2024-08-25"),  # same end date, but longer
+			("2024-08-21", "2024-08-25"),  # same end date, but shorter
+			("2024-08-21", "2024-08-23"),  # inside the original accrual
+			("2024-08-18", "2024-08-27"),  # the original accrual will fit inside this
+			("2024-08-20", "2024-08-25"),  # same start and end dates
+			("2024-08-25", "2024-08-30"),  # touching from the right
+			("2024-08-18", "2024-08-25"),  # touching from the left
+		]
+		for start_date, posting_date in overlapping_accruals:
+			accrual_entry = make_accrual_entry(start_date, posting_date)
+			self.assertRaises(frappe.ValidationError, accrual_entry.submit)
+
+		non_overlapping_accruals = [
+			("2024-08-17", "2024-08-18"),  # to the left
+			("2024-08-26", "2024-08-30"),  # to the right
+		]
+		for start_date, posting_date in non_overlapping_accruals:
+			accrual_entry = make_accrual_entry(start_date, posting_date)

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1362,51 +1362,53 @@ class TestLoan(IntegrationTestCase):
 			self.assertIn(expected, gl_entries, f"Missing GL entry: {expected}")
 
 	def test_interest_accrual_overlap(self):
-		loan = create_loan(
-			self.applicant1,
-			"Term Loan Product 4",
-			1500000,
-			"Repay Over Number of Periods",
-			30,
-			repayment_start_date="2025-01-05",
-			posting_date="2024-11-28",
-			rate_of_interest=28,
-		)
+		for frequency in ["Monthly", "Weekly", "Daily"]:
+			set_loan_accrual_frequency(frequency)
+			loan = create_loan(
+				self.applicant1,
+				"Term Loan Product 4",
+				1500000,
+				"Repay Over Number of Periods",
+				30,
+				repayment_start_date="2025-01-05",
+				posting_date="2024-11-28",
+				rate_of_interest=28,
+			)
 
-		loan.submit()
+			loan.submit()
 
-		make_loan_disbursement_entry(
-			loan.name, loan.loan_amount, disbursement_date="2024-11-28", repayment_start_date="2025-01-05"
-		)
+			make_loan_disbursement_entry(
+				loan.name, loan.loan_amount, disbursement_date="2024-11-28", repayment_start_date="2025-01-05"
+			)
 
-		# Process Loan Interest Accrual
-		process_loan_interest_accrual_for_loans(
-			posting_date="2024-12-03", loan=loan.name, company="_Test Company"
-		)
-		process_loan_interest_accrual_for_loans(
-			posting_date="2024-12-04", loan=loan.name, company="_Test Company"
-		)
-		process_loan_interest_accrual_for_loans(
-			posting_date="2024-12-05", loan=loan.name, company="_Test Company"
-		)
+			# Process Loan Interest Accrual
+			process_loan_interest_accrual_for_loans(
+				posting_date="2024-12-03", loan=loan.name, company="_Test Company"
+			)
+			process_loan_interest_accrual_for_loans(
+				posting_date="2024-12-04", loan=loan.name, company="_Test Company"
+			)
+			process_loan_interest_accrual_for_loans(
+				posting_date="2024-12-05", loan=loan.name, company="_Test Company"
+			)
 
-		process_daily_loan_demands(posting_date="2024-12-05", loan=loan.name)
+			process_daily_loan_demands(posting_date="2024-12-05", loan=loan.name)
 
-		repayment = create_repayment_entry(loan.name, "2024-12-05", 1150, repayment_type="Pre Payment")
+			repayment = create_repayment_entry(loan.name, "2024-12-05", 1150, repayment_type="Pre Payment")
 
-		repayment.submit()
-		process_loan_interest_accrual_for_loans(
-			posting_date="2024-12-08", loan=loan.name, company="_Test Company"
-		)
+			repayment.submit()
+			process_loan_interest_accrual_for_loans(
+				posting_date="2024-12-08", loan=loan.name, company="_Test Company"
+			)
 
-		process_daily_loan_demands(posting_date="2025-01-05", loan=loan.name)
-		process_loan_interest_accrual_for_loans(
-			posting_date="2025-01-10", loan=loan.name, company="_Test Company"
-		)
+			process_daily_loan_demands(posting_date="2025-01-05", loan=loan.name)
+			process_loan_interest_accrual_for_loans(
+				posting_date="2025-01-10", loan=loan.name, company="_Test Company"
+			)
 
-		repayment = create_repayment_entry(loan.name, "2025-01-03", 10000, repayment_type="Pre Payment")
+			repayment = create_repayment_entry(loan.name, "2025-01-03", 10000, repayment_type="Pre Payment")
 
-		repayment.submit()
+			repayment.submit()
 
 	def test_principal_amount_paid(self):
 		frappe.db.set_value(
@@ -3106,3 +3108,4 @@ class TestLoan(IntegrationTestCase):
 		]
 		for start_date, posting_date in non_overlapping_accruals:
 			accrual_entry = make_accrual_entry(start_date, posting_date)
+			accrual_entry.submit()

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -81,9 +81,9 @@ class LoanInterestAccrual(AccountsController):
 			)
 
 		if self.interest_type == "Normal Interest":
-			self.validate_last_accrual_date_before_current_posting_date()
+			self.validate_overlapping_accruals()
 
-	def validate_last_accrual_date_before_current_posting_date(self):
+	def validate_overlapping_accruals(self):
 		if self.interest_type != "Normal Interest":
 			return
 		loan_interest_accrual_doc = frappe.qb.DocType("Loan Interest Accrual")
@@ -99,11 +99,19 @@ class LoanInterestAccrual(AccountsController):
 			.where(
 				Cast(loan_interest_accrual_doc.start_date, "date") <= getdate(self.posting_date)
 			)  # overlaps
-			.select(loan_interest_accrual_doc.name)
+			.select(
+				loan_interest_accrual_doc.name,
+				loan_interest_accrual_doc.start_date,
+				loan_interest_accrual_doc.posting_date,
+			)
 		)
-		overlapping_accruals = query.run()
+		overlapping_accruals = query.run(as_list=True)
 		if overlapping_accruals:
-			frappe.throw(_("There are overlapping accruals here {}").format(overlapping_accruals))
+			frappe.throw(
+				_(
+					"There are overlapping accruals here {}, the current acrrual date gets accrued from {} to {}"
+				).format(overlapping_accruals, self.start_date, self.posting_date)
+			)
 
 	def on_submit(self):
 		from lending.loan_management.doctype.loan.loan import make_suspense_journal_entry
@@ -384,7 +392,8 @@ def get_accrual_frequency_breaks(last_accrual_date, accrual_date, loan_accrual_f
 		day_delta = 7
 	elif loan_accrual_frequency == "Monthly":
 		current_date = get_last_day(last_accrual_date)
-		day_delta = 1
+		if current_date == last_accrual_date:
+			current_date = add_months(current_date, 1)
 	else:
 		frappe.throw(_("Loan Accrual Frequency not set in the Company DocType."))
 
@@ -421,7 +430,6 @@ def process_loan_interest_accrual_per_schedule(
 					loan.name,
 					posting_date,
 					"Normal Interest",
-					loan_repayment_schedule=parent,
 					is_future_accrual=is_future_accrual,
 					loan_disbursement=loan_disbursement,
 				)
@@ -433,7 +441,7 @@ def process_loan_interest_accrual_per_schedule(
 				loan.company,
 				loan.rate_of_interest,
 				pending_principal_amount,
-				last_accrual_date_for_schedule,
+				add_days(last_accrual_date_for_schedule, 1),
 				payment_date,
 			)
 
@@ -445,7 +453,7 @@ def process_loan_interest_accrual_per_schedule(
 						pending_principal_amount,
 						flt(payable_interest, precision),
 						process_loan_interest,
-						last_accrual_date_for_schedule,
+						add_days(last_accrual_date_for_schedule, 1),
 						payment_date,
 						accrual_type,
 						"Normal Interest",
@@ -890,7 +898,7 @@ def get_last_accrual_date(
 
 	if loan_repayment_schedule:
 		if last_interest_accrual_date:
-			return add_days(last_interest_accrual_date, 1)
+			return last_interest_accrual_date
 		else:
 			dates = frappe.db.get_value(
 				"Loan Repayment Schedule",
@@ -902,7 +910,7 @@ def get_last_accrual_date(
 			if dates.moratorium_type == "EMI" and dates.moratorium_end_date:
 				final_date = dates.moratorium_end_date
 			else:
-				final_date = dates.posting_date
+				final_date = add_days(dates.posting_date, -1)
 
 			return final_date
 
@@ -914,7 +922,6 @@ def get_last_accrual_date(
 		return last_interest_accrual_date
 
 	if last_interest_accrual_date:
-		last_interest_accrual_date = add_days(last_interest_accrual_date, 1)
 		if last_disbursement_date and getdate(last_disbursement_date) > getdate(
 			last_interest_accrual_date
 		):
@@ -935,7 +942,7 @@ def get_last_accrual_date(
 			and moratorium_details.moratorium_type == "EMI"
 			and getdate(moratorium_details.moratorium_end_date) > getdate(last_disbursement_date)
 		):
-			last_interest_accrual_date = add_days(moratorium_details.moratorium_end_date, 1)
+			last_interest_accrual_date = moratorium_details.moratorium_end_date
 		else:
 			last_interest_accrual_date = add_days(last_disbursement_date, -1)
 
@@ -1130,7 +1137,7 @@ def get_parent_wise_dates(loan, last_accrual_date, posting_date, loan_disburseme
 		posting_date = freeze_date
 	schedule_filters = {
 		"parent": ("in", schedules),
-		"payment_date": ("between", [last_accrual_date, posting_date]),
+		"payment_date": ("between", [add_days(getdate(last_accrual_date), 1), posting_date]),
 	}
 
 	if len(schedules) == 1:

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Cast
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -85,23 +86,24 @@ class LoanInterestAccrual(AccountsController):
 	def validate_last_accrual_date_before_current_posting_date(self):
 		if self.interest_type != "Normal Interest":
 			return
-		last_accrual_date = frappe.db.get_value(
-			"Loan Interest Accrual",
-			{
-				"docstatus": 1,
-				"loan": self.loan,
-				"loan_disbursement": self.loan_disbursement,
-				"interest_type": "Normal Interest",
-			},
-			"MAX(posting_date)",
+		loan_interest_accrual_doc = frappe.qb.DocType("Loan Interest Accrual")
+		query = (
+			frappe.qb.from_(loan_interest_accrual_doc)
+			.where(loan_interest_accrual_doc.docstatus == 1)
+			.where(loan_interest_accrual_doc.loan == self.loan)
+			.where(loan_interest_accrual_doc.loan_disbursement == self.loan_disbursement)
+			.where(loan_interest_accrual_doc.interest_type == "Normal Interest")
+			.where(
+				Cast(loan_interest_accrual_doc.posting_date, "date") >= getdate(self.start_date)
+			)  # checking for
+			.where(
+				Cast(loan_interest_accrual_doc.start_date, "date") <= getdate(self.posting_date)
+			)  # overlaps
+			.select(loan_interest_accrual_doc.name)
 		)
-		if last_accrual_date:
-			if getdate(self.start_date) < getdate(last_accrual_date):
-				frappe.throw(
-					_(
-						"There are already Loan Interest Accruals made till {}. Your accrual has the starting date {}"
-					).format(getdate(last_accrual_date), getdate(self.start_date))
-				)
+		overlapping_accruals = query.run()
+		if overlapping_accruals:
+			frappe.throw(_("There are overlapping accruals here {}").format(overlapping_accruals))
 
 	def on_submit(self):
 		from lending.loan_management.doctype.loan.loan import make_suspense_journal_entry

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -914,6 +914,7 @@ def get_last_accrual_date(
 		return last_interest_accrual_date
 
 	if last_interest_accrual_date:
+		last_interest_accrual_date = add_days(last_interest_accrual_date, 1)
 		if last_disbursement_date and getdate(last_disbursement_date) > getdate(
 			last_interest_accrual_date
 		):

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -199,7 +199,7 @@ class LoanRepaymentSchedule(Document):
 				self.current_principal_amount - principal_balance,
 				flt(payable_interest, precision),
 				"",
-				last_accrual_date,
+				add_days(last_accrual_date, 1),
 				add_days(self.posting_date, -1),
 				"Regular",
 				"Normal Interest",


### PR DESCRIPTION
Previously validation was raised if the accrual entry you are making comes before the latest accrual entry. That logic was scrapped and now we only look for overlaps.