### PR TITLE
fix: add validation error on excess adjustment amount

### DIFF
--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
 from lending.loan_management.doctype.loan_restructure.loan_restructure import create_loan_repayment
@@ -45,18 +46,20 @@ class LoanAdjustment(Document):
 					},
 				)
 
-		available_sd = float(amounts.get("available_security_deposit", 0))
+		available_sd = float(amounts.get("available_security_deposit") or 0)
+
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
 		total_net_payable = round(
-			float(amounts.get("unaccrued_interest", 0))
-			+ float(amounts.get("interest_amount", 0))
-			+ float(amounts.get("penalty_amount", 0))
-			+ float(amounts.get("total_charges_payable", 0))
-			- available_sd
-			+ float(amounts.get("unbooked_interest", 0))
-			+ float(amounts.get("unbooked_penalty", 0))
-			+ float(amounts.get("pending_principal_amount", 0)),
-			2,
+			float(amounts.get("unaccrued_interest") or 0)
+			+ float(amounts.get("interest_amount") or 0)
+			+ float(amounts.get("penalty_amount") or 0)
+			+ float(amounts.get("total_charges_payable") or 0)
+			- float(amounts.get("available_security_deposit") or 0)
+			+ float(amounts.get("unbooked_interest") or 0)
+			+ float(amounts.get("unbooked_penalty") or 0)
+			+ float(amounts.get("pending_principal_amount") or 0),
+			precision,
 		)
 
 		total_adjustment_amount = sum(float(row.amount) for row in self.adjustments if row.amount)

--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
@@ -43,6 +44,37 @@ class LoanAdjustment(Document):
 						"amount": amounts.get("available_security_deposit", 0),
 					},
 				)
+
+		available_sd = float(amounts.get("available_security_deposit", 0))
+
+		total_net_payable = round(
+			float(amounts.get("unaccrued_interest", 0))
+			+ float(amounts.get("interest_amount", 0))
+			+ float(amounts.get("penalty_amount", 0))
+			+ float(amounts.get("total_charges_payable", 0))
+			- available_sd
+			+ float(amounts.get("unbooked_interest", 0))
+			+ float(amounts.get("unbooked_penalty", 0))
+			+ float(amounts.get("pending_principal_amount", 0)),
+			2,
+		)
+
+		total_adjustment_amount = sum(float(row.amount) for row in self.adjustments if row.amount)
+
+		sd_adjustment = next(
+			(row for row in self.adjustments if row.loan_repayment_type == "Security Deposit Adjustment"),
+			None,
+		)
+		if sd_adjustment:
+			total_adjustment_amount -= float(sd_adjustment.amount or 0)
+
+		if total_adjustment_amount > total_net_payable:
+			frappe.throw(
+				_(
+					f"Total adjustment amount ({total_adjustment_amount}) exceeds the total net payable ({total_net_payable}). "
+					f"You can only adjust up to {total_net_payable}."
+				)
+			)
 
 	def on_submit(self):
 		for repayment in self.get("adjustments"):

--- a/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/loan_adjustment.py
@@ -62,21 +62,21 @@ class LoanAdjustment(Document):
 			precision,
 		)
 
-		total_adjustment_amount = sum(float(row.amount) for row in self.adjustments if row.amount)
+		total_adjustment_amount = 0.0
 
-		sd_adjustment = next(
-			(row for row in self.adjustments if row.loan_repayment_type == "Security Deposit Adjustment"),
-			None,
-		)
-		if sd_adjustment:
-			total_adjustment_amount -= float(sd_adjustment.amount or 0)
+		for row in self.adjustments:
+			if not row.amount:
+				continue
+
+			amount = float(row.amount)
+			if row.loan_repayment_type != "Security Deposit Adjustment":
+				total_adjustment_amount += amount
 
 		if total_adjustment_amount > total_net_payable:
 			frappe.throw(
 				_(
-					f"Total adjustment amount ({total_adjustment_amount}) exceeds the total net payable ({total_net_payable}). "
-					f"You can only adjust up to {total_net_payable}."
-				)
+					"Total adjustment amount ({0}) exceeds the total net payable ({1}). You can only adjust up to {1}."
+				).format(total_adjustment_amount, total_net_payable)
 			)
 
 	def on_submit(self):

--- a/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
@@ -2,11 +2,10 @@
 # See license.txt
 
 import frappe
-
-# import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import getdate
 
+from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
@@ -73,3 +72,59 @@ class TestLoanAdjustment(IntegrationTestCase):
 		).insert()
 
 		self.assertTrue(doc.submit())
+
+	def test_validation_error_on_excess_adjustment_amount(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			500000,
+			"Repay Over Number of Periods",
+			12,
+			"Customer",
+			posting_date="2024-03-25",
+			rate_of_interest=12,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-03-25",
+			repayment_start_date="2024-04-01",
+			withhold_security_deposit=1,
+		)
+
+		process_daily_loan_demands(posting_date="2024-09-01", loan=loan.name)
+
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-09-01")
+		payable_amount = round(float(amounts["payable_amount"] or 0.0), 2)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-09-01", payable_amount)
+		repayment_entry.submit()
+
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-09-05")
+		total_net_payable = round(
+			float(amounts["unaccrued_interest"] or 0.0)
+			+ float(amounts["interest_amount"] or 0.0)
+			+ float(amounts["penalty_amount"] or 0.0)
+			+ float(amounts["total_charges_payable"] or 0.0)
+			- float(amounts["available_security_deposit"] or 0.0)
+			+ float(amounts["unbooked_interest"] or 0.0)
+			+ float(amounts["unbooked_penalty"] or 0.0)
+			+ float(amounts["pending_principal_amount"] or 0.0),
+			2,
+		)
+
+		loan_adjustment = frappe.get_doc(
+			{
+				"doctype": "Loan Adjustment",
+				"loan": loan.name,
+				"posting_date": "2024-09-05",
+				"foreclosure_type": "Internal Foreclosure",
+				"adjustments": [
+					{"loan_repayment_type": "Normal Repayment", "amount": total_net_payable + 1000}
+				],
+			}
+		)
+
+		self.assertRaises(frappe.ValidationError, loan_adjustment.save)

--- a/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
@@ -14,6 +14,7 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 )
 from lending.tests.test_utils import (
 	create_loan,
+	create_repayment_entry,
 	init_customers,
 	init_loan_products,
 	make_loan_disbursement_entry,


### PR DESCRIPTION
The issue occurs when a payment is made through the API. The system automatically attempts to add a "Security Deposit Adjustment" to the adjustments table if foreclosure type. However, if the total adjustment amount is greater than the loan's net payable, the excess amount causes the first repayment entry to fully settle the loan. As a result, the loan is marked as closed immediately after the first repayment. Since repayments cannot be posted to a closed loan (wrong error message), the system fails to create the subsequent Security Deposit Adjustment repayment entry.
