### PR TITLE
fix: unhashable type error in suspense journal entry for NPA loans

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -1459,14 +1459,14 @@ def make_suspense_journal_entry(
 	account_details = frappe.get_value(
 		"Loan Product",
 		loan_product,
-		[
+		(
 			"suspense_interest_income",
 			"interest_income_account",
 			"penalty_suspense_account",
 			"penalty_income_account",
 			"additional_interest_income",
 			"additional_interest_suspense",
-		],
+		),
 		as_dict=1,
 		cache=True,
 	)


### PR DESCRIPTION
Issue:

Passing a list of field names (fieldname=[...]) instead of a tuple to frappe.get_value leads to this unhashable key error when caching is enabled.

![image](https://github.com/user-attachments/assets/b2194e4f-f7f0-4b0b-9cdb-59e63bd9790c)

![image](https://github.com/user-attachments/assets/6f2e0402-8194-46c6-ada3-6a9cda9e0191)

Fix:
Replaced the list with a tuple for the fieldname parameter in frappe.get_value to make it hashable and compatible