### PR TITLE
fix: fields syntax in get_value

### DIFF
--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -589,7 +589,7 @@ def get_term_loan_payment_date(loan_repayment_schedule, date):
 	payment_date = frappe.db.get_value(
 		"Repayment Schedule",
 		{"parent": loan_repayment_schedule, "payment_date": ("<=", date)},
-		"MAX(payment_date)",
+		[{"MAX": "payment_date"}],
 	)
 
 	return payment_date
@@ -903,7 +903,7 @@ def get_last_accrual_date(
 		filters["loan_disbursement"] = loan_disbursement
 
 	last_interest_accrual_date = frappe.db.get_value(
-		"Loan Interest Accrual", filters, "MAX(posting_date)", for_update=True
+		"Loan Interest Accrual", filters, [{"MAX": "posting_date"}], for_update=True
 	)
 
 	if loan_repayment_schedule:
@@ -963,9 +963,9 @@ def get_last_disbursement_date(loan, posting_date, loan_disbursement=None):
 	schedule_type = frappe.db.get_value("Loan", loan, "repayment_schedule_type", cache=True)
 
 	if schedule_type == "Line of Credit":
-		field = "MIN(disbursement_date)"
+		field = [{"MIN": "disbursement_date"}]
 	else:
-		field = "MAX(disbursement_date)"
+		field = [{"MAX": "disbursement_date"}]
 
 	filters = {"docstatus": 1, "against_loan": loan, "disbursement_date": ("<=", posting_date)}
 


### PR DESCRIPTION
Required after frappe/frappe#32381 
(required for HRMS tests)