### PR TITLE
fix: incorrect gl entry on loan repayment when Process Payroll Accounting Based on Employee is enabled via hrms

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -169,15 +169,18 @@ class TestLoan(IntegrationTestCase):
 			"Test Security 2", 250, "Nos", get_datetime(), get_datetime(add_to_date(nowdate(), hours=24))
 		)
 
-		self.applicant1 = make_employee("robert_loan@loan.com")
 		if not frappe.db.exists("Customer", "_Test Loan Customer"):
 			frappe.get_doc(get_customer_dict("_Test Loan Customer")).insert(ignore_permissions=True)
 
 		if not frappe.db.exists("Customer", "_Test Loan Customer 1"):
 			frappe.get_doc(get_customer_dict("_Test Loan Customer 1")).insert(ignore_permissions=True)
 
+		if not frappe.db.exists("Customer", "_Test Loan Customer 2"):
+			frappe.get_doc(get_customer_dict("_Test Loan Customer 2")).insert(ignore_permissions=True)
+
 		self.applicant2 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer"}, "name")
 		self.applicant3 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer 1"}, "name")
+		self.applicant1 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer 2"}, "name")
 
 		frappe.db.set_value(
 			"Loan Product", "Demand Loan", "customer_refund_account", "Customer Refund Account - _TC"

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2139,8 +2139,7 @@ class LoanRepayment(AccountsController):
 		if (
 			hasattr(self, "process_payroll_accounting_entry_based_on_employee")
 			and not self.process_payroll_accounting_entry_based_on_employee
-			or self.applicant_type == "Customer"
-		):
+		) or self.applicant_type == "Customer":
 			payment_party_type = ""
 			payment_party = ""
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2136,29 +2136,30 @@ class LoanRepayment(AccountsController):
 		payment_party_type = self.applicant_type
 		payment_party = self.applicant
 
-		if not (
+		if (
 			hasattr(self, "process_payroll_accounting_entry_based_on_employee")
-			and self.process_payroll_accounting_entry_based_on_employee
+			and not self.process_payroll_accounting_entry_based_on_employee
 		):
 			payment_party_type = ""
 			payment_party = ""
-			gl_entries.append(
-				self.get_gl_dict(
-					{
-						"account": account,
-						"against": against_account,
-						"debit": amount,
-						"debit_in_account_currency": amount,
-						"against_voucher_type": "Loan",
-						"against_voucher": self.against_loan,
-						"remarks": _(remarks),
-						"cost_center": self.cost_center,
-						"party": payment_party if not is_waiver_entry else "",
-						"party_type": payment_party_type if not is_waiver_entry else "",
-						"posting_date": getdate(self.posting_date),
-					}
-				)
+
+		gl_entries.append(
+			self.get_gl_dict(
+				{
+					"account": account,
+					"against": against_account,
+					"debit": amount,
+					"debit_in_account_currency": amount,
+					"against_voucher_type": "Loan",
+					"against_voucher": self.against_loan,
+					"remarks": _(remarks),
+					"cost_center": self.cost_center,
+					"party": payment_party if not is_waiver_entry else "",
+					"party_type": payment_party_type if not is_waiver_entry else "",
+					"posting_date": getdate(self.posting_date),
+				}
 			)
+		)
 		gl_entries.append(
 			self.get_gl_dict(
 				{

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2139,6 +2139,7 @@ class LoanRepayment(AccountsController):
 		if (
 			hasattr(self, "process_payroll_accounting_entry_based_on_employee")
 			and not self.process_payroll_accounting_entry_based_on_employee
+			or self.applicant_type == "Customer"
 		):
 			payment_party_type = ""
 			payment_party = ""

--- a/lending/tests/test_utils.py
+++ b/lending/tests/test_utils.py
@@ -630,7 +630,7 @@ def create_loan(
 	loan = frappe.get_doc(
 		{
 			"doctype": "Loan",
-			"applicant_type": applicant_type or "Employee",
+			"applicant_type": "Customer",
 			"company": "_Test Company",
 			"applicant": applicant,
 			"loan_product": loan_product,


### PR DESCRIPTION
Debit entry was being skipped in Loan Repayment gl entry when Process Payroll Accounting Based on Employee is enabled in loan repayment doc via hrms


The code that debits loan account falls within an [if condition block](https://github.com/frappe/lending/blob/develop/lending/loan_management/doctype/loan_repayment/loan_repayment.py#L2145) which checks whether **_process_payroll_accounting_entry_based_on_employee_**(this field is configured via pyroll settings and set in loan repayment doc when repayment happens via salary slip) is disabled
If _process_payroll_accounting_entry_based_on_employee_ is enabled, only the credit part of entry is added resulting in an unbalanced entry