### PR TITLE
fix: default to 'Customer' as applicant_type in create_loan test helper only when argument not provided

### DIFF
--- a/lending/tests/test_utils.py
+++ b/lending/tests/test_utils.py
@@ -630,7 +630,7 @@ def create_loan(
 	loan = frappe.get_doc(
 		{
 			"doctype": "Loan",
-			"applicant_type": "Customer",
+			"applicant_type": applicant_type or "Customer",
 			"company": "_Test Company",
 			"applicant": applicant,
 			"loan_product": loan_product,


### PR DESCRIPTION
Ensure the _**create_loan**_ test helper method sets applicant_type to 'Customer' only when it is not explicitly passed as an argument. This allows test cases to specify different applicant types when needed eg: Employee