### PR TITLE
fix: remove stock field from the loan tab

### DIFF
--- a/lending/install.py
+++ b/lending/install.py
@@ -36,7 +36,7 @@ LOAN_CUSTOM_FIELDS = {
 			"fieldname": "loan_tab",
 			"fieldtype": "Tab Break",
 			"label": "Loan",
-			"insert_after": "default_in_transit_warehouse",
+			"insert_after": "default_operating_cost_account",
 		},
 		{
 			"fieldname": "loan_settings",


### PR DESCRIPTION
fixes: https://github.com/frappe/lending/issues/742

Loan-related fields will appear, after you install the Lending Version 1 on a new site.

![image](https://github.com/user-attachments/assets/a0395c6f-4b9e-4c46-97e8-6d9c785857c5)
