### PR TITLE
fix: when uninstall lending app then remove the loan related field

### DIFF
--- a/lending/hooks.py
+++ b/lending/hooks.py
@@ -96,7 +96,7 @@ after_install = "lending.install.after_install"
 # Uninstallation
 # ------------
 
-# before_uninstall = "lending.uninstall.before_uninstall"
+before_uninstall = "lending.install.before_uninstall"
 # after_uninstall = "lending.uninstall.after_uninstall"
 
 # Desk Notifications


### PR DESCRIPTION
Previously, when uninstalling the Lending app, the loan-related custom fields were not getting deleted. Although before_uninstall was defined in the install.py file, it was not called in the hooks.py file. This has now been fixed by adding before_uninstall to the hooks.py.