### PR TITLE
fix: TypeError in get_matching_queries by adding missing common_filters argument

### DIFF
--- a/lending/loan_management/utils.py
+++ b/lending/loan_management/utils.py
@@ -89,6 +89,7 @@ def get_matching_queries(
 	filter_by_reference_date,
 	from_reference_date,
 	to_reference_date,
+	common_filters=None,
 ):
 	queries = []
 


### PR DESCRIPTION
fixes: https://github.com/frappe/erpnext/issues/48383

![image](https://github.com/user-attachments/assets/ad3fe0ac-4f4f-4a7f-91d1-1247f51d5699)
