### PR TITLE
fix: back-dated repayment allocation by clearing demands on repost

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -369,6 +369,7 @@ class LoanRepayment(AccountsController):
 		repost.repost_date = self.value_date
 		repost.cancel_future_accruals_and_demands = True
 		repost.cancel_future_emi_demands = True
+		repost.clear_demand_allocation_before_repost = True
 		repost.submit()
 
 	def post_suspense_entries(self, cancel=0):

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -200,16 +200,6 @@ class LoanRepayment(AccountsController):
 		if self.flags.from_bulk_payment:
 			return
 
-		if self.is_backdated:
-			if frappe.flags.in_test:
-				self.create_repost()
-			else:
-				frappe.enqueue(
-					self.create_repost,
-					enqueue_after_commit=True,
-				)
-			return
-
 		reversed_accruals = []
 		make_sales_invoice_for_charge(
 			self.against_loan,
@@ -360,6 +350,16 @@ class LoanRepayment(AccountsController):
 				loan=self.against_loan,
 			)
 
+		if self.is_backdated:
+			if frappe.flags.in_test:
+				self.create_repost()
+			else:
+				frappe.enqueue(
+					self.create_repost,
+					enqueue_after_commit=True,
+				)
+			return
+
 		self.create_auto_waiver()
 
 	def create_repost(self):
@@ -369,7 +369,6 @@ class LoanRepayment(AccountsController):
 		repost.repost_date = self.value_date
 		repost.cancel_future_accruals_and_demands = True
 		repost.cancel_future_emi_demands = True
-		repost.clear_demand_allocation_before_repost = True
 		repost.submit()
 
 	def post_suspense_entries(self, cancel=0):
@@ -679,6 +678,7 @@ class LoanRepayment(AccountsController):
 		update_installment_counts(self.against_loan, loan_disbursement=self.loan_disbursement)
 
 		self.check_future_entries(cancel=1)
+
 		if self.flags.from_bulk_payment:
 			return
 		if self.is_backdated:

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -488,7 +488,7 @@ class TestLoanRepayment(IntegrationTestCase):
 
 		process_daily_loan_demands(posting_date="2025-03-15", loan=loan.name)
 
-		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-15")[
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-20")[
 			"payable_amount"
 		]
 

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -460,6 +460,53 @@ class TestLoanRepayment(IntegrationTestCase):
 				self.assertEqual(demand.outstanding_amount, 0)
 				self.assertEqual(demand.paid_amount, demand.demand_amount)
 
+	def test_backdated_repayment_allocation_resets_on_repost(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			10000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			"2025-02-15",
+			"2025-01-25",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-01-25", repayment_start_date="2025-02-15"
+		)
+		process_daily_loan_demands(posting_date="2025-02-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-02-15")[
+			"payable_amount"
+		]
+		repayment_entry = create_repayment_entry(
+			loan.name, get_datetime("2025-02-15 00:06:10"), payable_amount
+		).submit()
+
+		process_daily_loan_demands(posting_date="2025-03-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-15")[
+			"payable_amount"
+		]
+
+		repayment_entry = create_repayment_entry(
+			loan.name, get_datetime("2025-03-20 00:06:10"), flt(payable_amount / 2, 2)
+		).submit()
+		repayment_entry = create_repayment_entry(
+			loan.name, get_datetime("2025-03-16 00:06:10"), flt(payable_amount / 2, 2)
+		).submit()
+
+		demands = frappe.db.get_all(
+			"Loan Demand",
+			{"loan": loan.name, "docstatus": 1},
+			["outstanding_amount"],
+		)
+		for demand in demands:
+			self.assertEqual(demand.outstanding_amount, 0)
+
 	def test_on_time_penal_cancellations(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
 		loan = create_loan(

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -460,53 +460,6 @@ class TestLoanRepayment(IntegrationTestCase):
 				self.assertEqual(demand.outstanding_amount, 0)
 				self.assertEqual(demand.paid_amount, demand.demand_amount)
 
-	def test_backdated_repayment_allocation_resets_on_repost(self):
-		loan = create_loan(
-			"_Test Customer 1",
-			"Term Loan Product 4",
-			10000,
-			"Repay Over Number of Periods",
-			2,
-			"Customer",
-			"2025-02-15",
-			"2025-01-25",
-			rate_of_interest=10,
-		)
-		loan.submit()
-
-		make_loan_disbursement_entry(
-			loan.name, loan.loan_amount, disbursement_date="2025-01-25", repayment_start_date="2025-02-15"
-		)
-		process_daily_loan_demands(posting_date="2025-02-15", loan=loan.name)
-
-		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-02-15")[
-			"payable_amount"
-		]
-		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2025-02-15 00:06:10"), payable_amount
-		).submit()
-
-		process_daily_loan_demands(posting_date="2025-03-15", loan=loan.name)
-
-		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-20")[
-			"payable_amount"
-		]
-
-		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2025-03-20 00:06:10"), flt(payable_amount / 2, 2)
-		).submit()
-		repayment_entry = create_repayment_entry(
-			loan.name, get_datetime("2025-03-16 00:06:10"), flt(payable_amount / 2, 2)
-		).submit()
-
-		demands = frappe.db.get_all(
-			"Loan Demand",
-			{"loan": loan.name, "docstatus": 1},
-			["outstanding_amount"],
-		)
-		for demand in demands:
-			self.assertEqual(demand.outstanding_amount, 0)
-
 	def test_on_time_penal_cancellations(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
 		loan = create_loan(

--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -1,23 +1,23 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import flt, get_datetime
 
-# On IntegrationTestCase, the doctype test records and all
-# link-field test record depdendencies are recursively loaded
-# Use these module variables to add/remove to/from that list
-EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
-
-
-class TestLoanRepaymentRepost(UnitTestCase):
-	"""
-	Unit tests for LoanRepaymentRepost.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
+from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
+from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
+	process_daily_loan_demands,
+)
+from lending.tests.test_utils import (
+	create_loan,
+	create_repayment_entry,
+	init_customers,
+	init_loan_products,
+	make_loan_disbursement_entry,
+	master_init,
+	set_loan_accrual_frequency,
+)
 
 
 class TestLoanRepaymentRepost(IntegrationTestCase):
@@ -26,4 +26,101 @@ class TestLoanRepaymentRepost(IntegrationTestCase):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def setUp(self):
+		master_init()
+		init_loan_products()
+		init_customers()
+		self.applicant2 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer"}, "name")
+
+	def test_backdated_repayment_allocation_resets_on_repost(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			10000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			"2025-02-15",
+			"2025-01-25",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-01-25", repayment_start_date="2025-02-15"
+		)
+		process_daily_loan_demands(posting_date="2025-02-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-02-15")[
+			"payable_amount"
+		]
+		repayment_entry = create_repayment_entry(
+			loan.name, get_datetime("2025-02-15 00:06:10"), payable_amount
+		).submit()
+
+		process_daily_loan_demands(posting_date="2025-03-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-20")[
+			"payable_amount"
+		]
+
+		create_repayment_entry(
+			loan.name, get_datetime("2025-03-20 00:06:10"), flt(payable_amount / 2, 2)
+		).submit()
+
+		create_repayment_entry(
+			loan.name, get_datetime("2025-03-16 00:06:10"), flt(payable_amount / 2, 2)
+		).submit()
+
+		demands = frappe.db.get_all(
+			"Loan Demand",
+			{"loan": loan.name, "docstatus": 1},
+			["outstanding_amount"],
+		)
+		for demand in demands:
+			self.assertEqual(demand.outstanding_amount, 0)
+
+	def test_repost_on_same_day_payments(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			10000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			"2025-02-15",
+			"2025-01-25",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-01-25", repayment_start_date="2025-02-15"
+		)
+		process_daily_loan_demands(posting_date="2025-02-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-02-15")[
+			"payable_amount"
+		]
+
+		create_repayment_entry(loan.name, "2025-02-15", payable_amount).submit()
+
+		process_daily_loan_demands(posting_date="2025-03-15", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2025-03-20")[
+			"payable_amount"
+		]
+
+		create_repayment_entry(loan.name, "2025-03-16", flt(payable_amount / 2, 2)).submit()
+
+		create_repayment_entry(loan.name, "2025-03-16", flt(payable_amount / 2, 2)).submit()
+
+		demands = frappe.db.get_all(
+			"Loan Demand",
+			{"loan": loan.name, "docstatus": 1},
+			["outstanding_amount"],
+		)
+		for demand in demands:
+			self.assertEqual(demand.outstanding_amount, 0)


### PR DESCRIPTION
When a **back-dated repayment** is created after later repayments already exist, demand allocations are applied incorrectly.

Example scenario:

* A demand is generated on **05-03-2025**.
* The first repayment is made on **20-03-2025**.
* Later, a repayment dated **16-03-2025** is added (back-dated).

Current behavior (bug):
Without clearing existing allocations, the 16-03 repayment sees demands already reduced by the 20-03 repayment. As a result, the 16-03 repayment is allocated to the wrong demand set.

If the demand date and repayment date are the same, or if repayments are posted in the right order, the issue does not happen. but this issue only comes when a repayment is added with a date earlier than another repayment that is already posted. For example, if a demand is created on 05-03-2025 and we first post a repayment on 20-03-2025, then later add another repayment on 16-03-2025, the allocation goes wrong. 

Why it happens:
The code for allocation (update_demands and allocate_amount_against_demands) works on whatever balance is showing on the demand at that time.
If a later repayment already reduced the demand, then when we insert an earlier repayment, the outstanding balance is no longer correct. So the repayment is applied wrongly.

<img width="5758" height="1363" alt="image" src="https://github.com/user-attachments/assets/3c395b65-43d5-403d-88af-97796dc906b9" />



Demand ID | Demand Date | Demand Subtype | Demand Amount | Paid Amount | Outstanding Amount
-- | -- | -- | -- | -- | --
LM-LD-91985 | 2025-03-15 | Principal | 4,994.53 | 2,479.53 | 2,515.00
LM-LD-91984 | 2025-03-15 | Interest | 38.31 | 38.31 | 0.00
LM-LD-91983 | 2025-02-15 | Principal | 5,005.47 | 5,005.47 | 0.00
LM-LD-91982 | 2025-02-15 | Interest | 57.53 | 57.53 | 0.00
Total |   |   | 10,095.84 | 7,580.84 | 2,515.00


<img width="5760" height="1596" alt="image" src="https://github.com/user-attachments/assets/9ac2bfaa-95a1-4692-8224-e691a7edc702" />



Repayment ID | Posting Date | Amount Paid | Principal Paid | Interest Paid
-- | -- | -- | -- | --
LM-REP-2633 | 2025-08-22 12:17:46 | 2,537.00 | 2,498.69 | 38.31
LM-REP-2632 | 2025-08-22 12:17:46 | 2,537.00 | 2,526.00 | 0.00
LM-REP-2631 | 2025-08-22 12:13:39 | 5,032.84 | 4,975.31 | 57.53
Total |   | 10,106.84 | 10,000.00 | 95.84

- Loan Demand shows Principal Paid = 7,485.00
- Loan Repayment shows Principal Paid = 10,000.00



**Fix:**
Set `repost.clear_demand_allocation_before_repost = True` when the repayment is back-dated. This clears old allocations and resets the demand amounts. Then the system replays repayments in the correct order (by date). This makes sure the 16-03 repayment is applied first, and the 20-03 repayment is applied after it.