### PR TITLE
fix: loan status when cancelled the loan repayment - v15

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -75,6 +75,10 @@ class LoanRepayment(AccountsController):
 		]
 		self.make_gl_entries(cancel=1)
 
+		loan_status = frappe.db.get_value("Loan", self.against_loan, "status")
+		if loan_status == "Closed":
+			frappe.db.set_value("Loan", self.against_loan, "status", "Disbursed")
+
 	def make_credit_note(self):
 		item_details = frappe.db.get_value(
 			"Loan Product",


### PR DESCRIPTION
- update loan status when a cancelled payroll entry or a cancelled loan repayment - version 15

Before:

[before_loan_status.webm](https://github.com/user-attachments/assets/fb7e48f5-e116-43ac-a01a-8b8ff18f9a56)


After:

[after_loan_status.webm](https://github.com/user-attachments/assets/b48967b6-44d3-494b-8076-01f9cf749a85)

