### PR TITLE
fix: charge payment visibility and set validation

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -447,9 +447,9 @@
    "search_index": 1
   },
   {
+   "depends_on": "eval:doc.repayment_type==\"Charge Payment\"",
    "fieldname": "payable_charges",
    "fieldtype": "Table",
-   "hidden": 1,
    "label": "Payable Charges",
    "options": "Loan Repayment Charges"
   },
@@ -555,7 +555,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-18 17:55:07.773459",
+ "modified": "2025-09-15 17:44:13.902229",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -128,8 +128,11 @@ class LoanRepayment(AccountsController):
 
 	def validate(self):
 		charges = None
-		if self.get("payable_charges") and self.repayment_type == "Charge Payment":
-			charges = [d.get("charge_code") for d in self.get("payable_charges")]
+		if self.get("payable_charges"):
+			if self.repayment_type == "Charge Payment":
+				charges = [d.get("charge_code") for d in self.get("payable_charges")]
+			else:
+				frappe.throw(_("Payable Charges can only be added if Charge Payment"))
 
 		amounts = calculate_amounts(
 			self.against_loan,

--- a/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.json
+++ b/lending/loan_management/doctype/loan_repayment_charges/loan_repayment_charges.json
@@ -20,18 +20,20 @@
   {
    "fieldname": "amount",
    "fieldtype": "Currency",
+   "in_standard_filter": 1,
    "label": "Amount"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-19 11:46:37.353655",
+ "modified": "2025-09-15 17:46:29.966332",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Charges",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
Charge Payment visibility and validation in Loan Repayment

Fixed issue with reposting Loan Repayment with or without Charge Payment   -> PR: https://github.com/frappe/lending/pull/914
