### PR TITLE
refactor: queries to use Query Builder for v15 compatibility - v2

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -1244,6 +1244,7 @@ def update_loan_and_customer_status(
 			.where((Loan.applicant_type == applicant_type) & (Loan.applicant == applicant))
 		).run()[0][0] or 0
 
+		""" if max_dpd is greater than 0 loan still NPA, do nothing"""
 		if max_dpd == 0 or freeze_date:
 			prev_npa = (frappe.qb.from_(Loan).select(Loan.is_npa).where(Loan.name == loan)).run()[0][0]
 

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -7,6 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.query_builder.functions import Sum
 from frappe.utils import (
 	add_days,
@@ -459,39 +460,57 @@ def update_total_amount_paid(doc):
 
 
 def get_total_loan_amount(applicant_type, applicant, company):
+	Loan = DocType("Loan")
+	LoanInterestAccrual = DocType("Loan Interest Accrual")
+	LoanRepayment = DocType("Loan Repayment")
+
 	pending_amount = 0
-	loan_details = frappe.db.get_all(
-		"Loan",
-		filters={
-			"applicant_type": applicant_type,
-			"company": company,
-			"applicant": applicant,
-			"docstatus": 1,
-			"status": ("!=", "Closed"),
-		},
-		fields=[
-			"status",
-			"total_payment",
-			"disbursed_amount",
-			"total_interest_payable",
-			"total_principal_paid",
-			"written_off_amount",
-		],
-	)
+
+	loan_details = (
+		frappe.qb.from_(Loan)
+		.select(
+			Loan.status,
+			Loan.total_payment,
+			Loan.disbursed_amount,
+			Loan.total_interest_payable,
+			Loan.total_principal_paid,
+			Loan.written_off_amount,
+		)
+		.where(
+			(Loan.applicant_type == applicant_type)
+			& (Loan.company == company)
+			& (Loan.applicant == applicant)
+			& (Loan.docstatus == 1)
+			& (Loan.status != "Closed")
+		)
+	).run(as_dict=True)
 
 	total_interest_amount = flt(
-		frappe.db.get_value(
-			"Loan Interest Accrual",
-			{"applicant_type": applicant_type, "company": company, "applicant": applicant, "docstatus": 1},
-			[{"SUM": "interest_amount"}],
-		)
+		(
+			frappe.qb.from_(LoanInterestAccrual)
+			.select(fn.Sum(LoanInterestAccrual.interest_amount))
+			.where(
+				(LoanInterestAccrual.applicant_type == applicant_type)
+				& (LoanInterestAccrual.company == company)
+				& (LoanInterestAccrual.applicant == applicant)
+				& (LoanInterestAccrual.docstatus == 1)
+			)
+		).run()[0][0]
+		or 0
 	)
+
 	paid_interest = flt(
-		frappe.db.get_value(
-			"Loan Repayment",
-			{"applicant_type": applicant_type, "company": company, "applicant": applicant, "docstatus": 1},
-			[{"SUM": "total_interest_paid"}],
-		)
+		(
+			frappe.qb.from_(LoanRepayment)
+			.select(fn.Sum(LoanRepayment.total_interest_paid))
+			.where(
+				(LoanRepayment.applicant_type == applicant_type)
+				& (LoanRepayment.company == company)
+				& (LoanRepayment.applicant == applicant)
+				& (LoanRepayment.docstatus == 1)
+			)
+		).run()[0][0]
+		or 0
 	)
 
 	interest_amount = total_interest_amount - paid_interest
@@ -1124,14 +1143,26 @@ def update_loan_and_customer_status(
 		write_off_suspense_entries,
 	)
 
-	loan_status, repayment_schedule_type, loan_product, unmark_npa, current_npa = frappe.db.get_value(
-		"Loan", loan, ["status", "repayment_schedule_type", "loan_product", "unmark_npa", "is_npa"]
-	)
+	Loan = DocType("Loan")
+	LoanDisbursement = DocType("Loan Disbursement")
+	LoanNPALog = DocType("Loan NPA Log")
+	DPDLog = DocType("Days Past Due Log")
 
-	if loan_status == "Written Off":
-		is_written_off = 1
-	else:
-		is_written_off = 0
+	loan_values = (
+		frappe.qb.from_(Loan)
+		.select(
+			Loan.status,
+			Loan.repayment_schedule_type,
+			Loan.loan_product,
+			Loan.unmark_npa,
+			Loan.is_npa,
+		)
+		.where(Loan.name == loan)
+	).run()[0]
+
+	loan_status, repayment_schedule_type, loan_product, unmark_npa, current_npa = loan_values
+
+	is_written_off = 1 if loan_status == "Written Off" else 0
 
 	classification_code, classification_name = get_classification_code_and_name(
 		days_past_due, company, is_written_off=is_written_off
@@ -1148,27 +1179,32 @@ def update_loan_and_customer_status(
 				update_modified=False,
 			)
 
-		max_dpd = frappe.db.get_value(
-			"Loan Disbursement",
-			{
-				"against_loan": loan,
-				"docstatus": 1,
-			},
-			[{"MAX": "days_past_due"}],
-		)
+		max_dpd = (
+			frappe.qb.from_(LoanDisbursement)
+			.select(fn.Max(LoanDisbursement.days_past_due))
+			.where((LoanDisbursement.against_loan == loan) & (LoanDisbursement.docstatus == 1))
+		).run()[0][0] or 0
 		days_past_due = max_dpd
 
 	if loan_status == "Settled":
 		write_off_suspense_entries(loan, loan_product, posting_date, posting_date, company)
 		write_off_charges(loan, posting_date, posting_date, company)
+
 	elif is_backdated and days_past_due < dpd_threshold:
-		is_previous_npa = frappe.db.get_value(
-			"Loan NPA Log",
-			{"loan": loan, "npa_date": ("<", posting_date), "delinked": 0},
-			"npa",
-			order_by="npa_date desc",
-		)
-		max_date = frappe.db.get_value("Days Past Due Log", {"loan": loan}, [{"MAX": "posting_date"}])
+		is_previous_npa = (
+			frappe.qb.from_(LoanNPALog)
+			.select(LoanNPALog.npa)
+			.where(
+				(LoanNPALog.loan == loan) & (LoanNPALog.npa_date < posting_date) & (LoanNPALog.delinked == 0)
+			)
+			.orderby(LoanNPALog.npa_date, order=frappe.qb.desc)
+			.limit(1)
+		).run()
+		is_previous_npa = is_previous_npa[0][0] if is_previous_npa else 0
+
+		max_date = (
+			frappe.qb.from_(DPDLog).select(fn.Max(DPDLog.posting_date)).where(DPDLog.loan == loan)
+		).run()[0][0]
 
 		actual_diff = date_diff(getdate(max_date), getdate(posting_date))
 		actual_dpd = days_past_due + actual_diff
@@ -1193,23 +1229,30 @@ def update_loan_and_customer_status(
 
 	elif is_npa and not cint(unmark_npa) and not cint(current_npa):
 		for loan_id in get_all_active_loans_for_the_customer(applicant, applicant_type):
-			prev_npa = frappe.db.get_value("Loan", loan_id, "is_npa")
+			prev_npa = (frappe.qb.from_(Loan).select(Loan.is_npa).where(Loan.name == loan_id)).run()[0][0]
+
 			if not prev_npa:
 				move_unpaid_interest_to_suspense_ledger(loan_id, posting_date, value_date=posting_date)
 				move_receivable_charges_to_suspense_ledger(loan_id, company, posting_date, posting_date)
 
 		update_all_linked_loan_customer_npa_status(is_npa, applicant_type, applicant, posting_date, loan)
-	else:
-		max_dpd = frappe.db.get_value(
-			"Loan", {"applicant_type": applicant_type, "applicant": applicant}, [{"MAX": "days_past_due"}]
-		)
 
-		""" if max_dpd is greater than 0 loan still NPA, do nothing"""
+	else:
+		max_dpd = (
+			frappe.qb.from_(Loan)
+			.select(fn.Max(Loan.days_past_due))
+			.where((Loan.applicant_type == applicant_type) & (Loan.applicant == applicant))
+		).run()[0][0] or 0
+
 		if max_dpd == 0 or freeze_date:
-			prev_npa = frappe.db.get_value("Loan", loan, "is_npa")
+			prev_npa = (frappe.qb.from_(Loan).select(Loan.is_npa).where(Loan.name == loan)).run()[0][0]
+
 			if prev_npa:
 				for loan_id in get_all_active_loans_for_the_customer(applicant, applicant_type):
-					loan_product = frappe.db.get_value("Loan", loan_id, "loan_product")
+					loan_product = (
+						frappe.qb.from_(Loan).select(Loan.loan_product).where(Loan.name == loan_id)
+					).run()[0][0]
+
 					write_off_suspense_entries(loan_id, loan_product, posting_date, posting_date, company)
 					write_off_charges(loan_id, posting_date, posting_date, company)
 

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -2746,10 +2746,16 @@ class TestLoan(IntegrationTestCase):
 		repayment_entry.save()
 		repayment_entry.submit()
 
-		outstanding_demand = frappe.db.get_value(
-			"Loan Demand",
-			{"loan": loan.name, "loan_disbursement": disbursement.name},
-			[{"SUM": "outstanding_amount"}],
+		outstanding_demand = (
+			frappe.db.sql(
+				"""
+			SELECT SUM(outstanding_amount)
+			FROM `tabLoan Demand`
+			WHERE loan = %s AND loan_disbursement = %s
+			""",
+				(loan.name, disbursement.name),
+			)[0][0]
+			or 0
 		)
 
 		self.assertEqual(outstanding_demand, 0)

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -4,6 +4,8 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -868,6 +870,12 @@ def get_disbursal_amount(loan, on_current_security_price=0):
 
 
 def get_maximum_amount_as_per_pledged_security(loan):
-	return flt(
-		frappe.db.get_value("Loan Security Assignment", {"loan": loan}, [{"SUM": "maximum_loan_value"}])
-	)
+	LoanSecurityAssignment = DocType("Loan Security Assignment")
+
+	maximum_amount = (
+		frappe.qb.from_(LoanSecurityAssignment)
+		.select(fn.Sum(LoanSecurityAssignment.maximum_loan_value))
+		.where(LoanSecurityAssignment.loan == loan)
+	).run()[0][0] or 0
+
+	return flt(maximum_amount)

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -973,23 +973,30 @@ def get_last_accrual_date(
 
 
 def get_last_disbursement_date(loan, posting_date, loan_disbursement=None):
-	schedule_type = frappe.db.get_value("Loan", loan, "repayment_schedule_type", cache=True)
+	Loan = DocType("Loan")
+	LoanDisbursement = DocType("Loan Disbursement")
+
+	schedule_type = (
+		frappe.qb.from_(Loan).select(Loan.repayment_schedule_type).where(Loan.name == loan)
+	).run()[0][0]
 
 	if schedule_type == "Line of Credit":
-		field = [{"MIN": "disbursement_date"}]
+		agg_field = fn.Min(LoanDisbursement.disbursement_date)
 	else:
-		field = [{"MAX": "disbursement_date"}]
+		agg_field = fn.Max(LoanDisbursement.disbursement_date)
 
-	filters = {"docstatus": 1, "against_loan": loan, "disbursement_date": ("<=", posting_date)}
+	conditions = (
+		(LoanDisbursement.docstatus == 1)
+		& (LoanDisbursement.against_loan == loan)
+		& (LoanDisbursement.disbursement_date <= posting_date)
+	)
 
 	if loan_disbursement:
-		filters["name"] = loan_disbursement
+		conditions &= LoanDisbursement.name == loan_disbursement
 
-	last_disbursement_date = frappe.db.get_value(
-		"Loan Disbursement",
-		filters,
-		field,
-	)
+	last_disbursement_date = (
+		frappe.qb.from_(LoanDisbursement).select(agg_field).where(conditions)
+	).run()[0][0]
 
 	return last_disbursement_date
 

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -4,6 +4,8 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.query_builder.functions import Cast
 from frappe.utils import (
 	add_days,
@@ -878,34 +880,47 @@ def get_last_accrual_date(
 	repayment_schedule_detail=None,
 	loan_disbursement=None,
 ):
-	filters = {"loan": loan, "docstatus": 1, "interest_type": interest_type}
+	LoanInterestAccrual = DocType("Loan Interest Accrual")
+	LoanRepaymentSchedule = DocType("Loan Repayment Schedule")
+
+	conditions = (
+		(LoanInterestAccrual.loan == loan)
+		& (LoanInterestAccrual.docstatus == 1)
+		& (LoanInterestAccrual.interest_type == interest_type)
+	)
 
 	if demand:
-		filters["loan_demand"] = demand
+		conditions &= LoanInterestAccrual.loan_demand == demand
 
 	if repayment_schedule_detail:
-		filters["loan_repayment_schedule_detail"] = repayment_schedule_detail
+		conditions &= LoanInterestAccrual.loan_repayment_schedule_detail == repayment_schedule_detail
 
 	if is_future_accrual:
-		filters["posting_date"] = ("<=", posting_date)
+		conditions &= LoanInterestAccrual.posting_date <= posting_date
 
 	if loan_disbursement:
-		filters["loan_disbursement"] = loan_disbursement
+		conditions &= LoanInterestAccrual.loan_disbursement == loan_disbursement
 
-	last_interest_accrual_date = frappe.db.get_value(
-		"Loan Interest Accrual", filters, [{"MAX": "posting_date"}], for_update=True
-	)
+	last_interest_accrual_date = (
+		frappe.qb.from_(LoanInterestAccrual)
+		.select(fn.Max(LoanInterestAccrual.posting_date))
+		.where(conditions)
+		.for_update()
+	).run()[0][0]
 
 	if loan_repayment_schedule:
 		if last_interest_accrual_date:
 			return add_days(last_interest_accrual_date, 1)
 		else:
-			dates = frappe.db.get_value(
-				"Loan Repayment Schedule",
-				loan_repayment_schedule,
-				["moratorium_end_date", "posting_date", "moratorium_type"],
-				as_dict=1,
-			)
+			dates = (
+				frappe.qb.from_(LoanRepaymentSchedule)
+				.select(
+					LoanRepaymentSchedule.moratorium_end_date,
+					LoanRepaymentSchedule.posting_date,
+					LoanRepaymentSchedule.moratorium_type,
+				)
+				.where(LoanRepaymentSchedule.name == loan_repayment_schedule)
+			).run(as_dict=True)[0]
 
 			if dates.moratorium_type == "EMI" and dates.moratorium_end_date:
 				final_date = dates.moratorium_end_date
@@ -929,12 +944,20 @@ def get_last_accrual_date(
 
 		return last_interest_accrual_date
 	else:
-		moratorium_details = frappe.db.get_value(
-			"Loan Repayment Schedule",
-			{"loan": loan, "docstatus": 1, "status": "Active"},
-			["moratorium_end_date", "moratorium_type"],
-			as_dict=1,
-		)
+		moratorium_details = (
+			frappe.qb.from_(LoanRepaymentSchedule)
+			.select(
+				LoanRepaymentSchedule.moratorium_end_date,
+				LoanRepaymentSchedule.moratorium_type,
+			)
+			.where(
+				(LoanRepaymentSchedule.loan == loan)
+				& (LoanRepaymentSchedule.docstatus == 1)
+				& (LoanRepaymentSchedule.status == "Active")
+			)
+		).run(as_dict=True)
+
+		moratorium_details = moratorium_details[0] if moratorium_details else None
 
 		if (
 			moratorium_details

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -981,9 +981,9 @@ def get_last_disbursement_date(loan, posting_date, loan_disbursement=None):
 	).run()[0][0]
 
 	if schedule_type == "Line of Credit":
-		agg_field = fn.Min(LoanDisbursement.disbursement_date)
+		field = fn.Min(LoanDisbursement.disbursement_date)
 	else:
-		agg_field = fn.Max(LoanDisbursement.disbursement_date)
+		field = fn.Max(LoanDisbursement.disbursement_date)
 
 	conditions = (
 		(LoanDisbursement.docstatus == 1)
@@ -995,7 +995,7 @@ def get_last_disbursement_date(loan, posting_date, loan_disbursement=None):
 		conditions &= LoanDisbursement.name == loan_disbursement
 
 	last_disbursement_date = (
-		frappe.qb.from_(LoanDisbursement).select(agg_field).where(conditions)
+		frappe.qb.from_(LoanDisbursement).select(field).where(conditions)
 	).run()[0][0]
 
 	return last_disbursement_date

--- a/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -79,17 +79,23 @@ class TestLoanInterestAccrual(IntegrationTestCase):
 			accrual_date="2024-04-20",
 		)
 
-		last_accrual_date_a = frappe.db.get_value(
-			"Loan Interest Accrual",
-			{"loan": loan_a.name, "docstatus": 1},
-			[{"MAX": "posting_date"}],
-		)
+		last_accrual_date_a = frappe.db.sql(
+			"""
+			SELECT MAX(posting_date)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s AND docstatus = 1
+			""",
+			(loan_a.name,),
+		)[0][0]
 
-		last_accrual_date_b = frappe.db.get_value(
-			"Loan Interest Accrual",
-			{"loan": loan_b.name, "docstatus": 1},
-			[{"MAX": "posting_date"}],
-		)
+		last_accrual_date_b = frappe.db.sql(
+			"""
+			SELECT MAX(posting_date)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s AND docstatus = 1
+			""",
+			(loan_b.name,),
+		)[0][0]
 
 		self.assertEqual(getdate(last_accrual_date_a), getdate("2024-04-10"))
 		self.assertEqual(getdate(last_accrual_date_b), getdate("2024-04-20"))
@@ -199,9 +205,16 @@ class TestLoanInterestAccrual(IntegrationTestCase):
 		maturity_date = frappe.db.get_value(
 			"Loan Repayment Schedule", {"loan": loan.name, "docstatus": 1}, "maturity_date"
 		)
-		last_accrual_date = frappe.db.get_value(
-			"Loan Interest Accrual", {"loan": loan.name, "docstatus": 1}, [{"MAX": "posting_date"}]
-		)
+
+		last_accrual_date = frappe.db.sql(
+			"""
+			SELECT MAX(posting_date)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s AND docstatus = 1
+			""",
+			(loan.name,),
+		)[0][0]
+
 		self.assertEqual(getdate(last_accrual_date), add_days(getdate(maturity_date), -1))
 
 		process_loan_interest_accrual_for_loans(
@@ -273,15 +286,19 @@ class TestLoanInterestAccrual(IntegrationTestCase):
 		)
 		freeze_date = "2024-04-10"
 
-		accrual_sum_till_freeze_date = frappe.db.get_value(
-			"Loan Interest Accrual",
-			{
-				"loan": loan.name,
-				"docstatus": 1,
-				"posting_date": ("<", freeze_date),
-				"interest_type": "Normal Interest",
-			},
-			[{"SUM": "interest_amount"}],
+		accrual_sum_till_freeze_date = (
+			frappe.db.sql(
+				"""
+			SELECT SUM(interest_amount)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s
+			AND docstatus = 1
+			AND posting_date < %s
+			AND interest_type = 'Normal Interest'
+			""",
+				(loan.name, freeze_date),
+			)[0][0]
+			or 0
 		)
 
 		frappe.db.set_value("Loan", loan.name, {"freeze_account": 1, "freeze_date": freeze_date})

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -6,6 +6,8 @@ import traceback
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.query_builder.functions import Coalesce, Round, Sum
 from frappe.utils import add_days, cint, flt, get_datetime, getdate, random_string
 
@@ -713,9 +715,13 @@ class LoanRepayment(AccountsController):
 			return
 		else:
 			# No need to do this in case of backdated prepayment as will be handled in repost
-			max_demand_date = frappe.db.get_value(
-				"Loan Interest Accrual", {"loan": self.against_loan}, [{"MAX": "posting_date"}]
-			)
+			LoanInterestAccrual = DocType("Loan Interest Accrual")
+			max_demand_date = (
+				frappe.qb.from_(LoanInterestAccrual)
+				.select(fn.Max(LoanInterestAccrual.posting_date))
+				.where(LoanInterestAccrual.loan == self.against_loan)
+			).run()[0][0]
+
 			if max_demand_date and getdate(max_demand_date) > getdate(self.value_date):
 				delink_npa_logs(self.against_loan, self.value_date)
 
@@ -1196,28 +1202,33 @@ class LoanRepayment(AccountsController):
 
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-		auto_write_off_amount, excess_amount_limit = frappe.db.get_value(
-			"Loan Product",
-			self.loan_product,
-			["write_off_amount", "excess_amount_acceptance_limit"],
-		)
+		LoanProduct = DocType("Loan Product")
+		LoanDemand = DocType("Loan Demand")
+
+		product_values = (
+			frappe.qb.from_(LoanProduct)
+			.select(LoanProduct.write_off_amount, LoanProduct.excess_amount_acceptance_limit)
+			.where(LoanProduct.name == self.loan_product)
+		).run(as_dict=True)[0]
+
+		auto_write_off_amount = product_values.write_off_amount
+		excess_amount_limit = product_values.excess_amount_acceptance_limit
 
 		shortfall_amount = self.pending_principal_amount - self.principal_amount_paid
 
 		if self.repayment_type in ("Interest Waiver", "Penalty Waiver", "Charges Waiver"):
-			total_payable = (
-				frappe.db.get_value(
-					"Loan Demand",
-					{
-						"loan": self.against_loan,
-						"docstatus": 1,
-						"outstanding_amount": (">", 0),
-						"demand_date": ("<=", self.value_date),
-					},
-					[{"SUM": "outstanding_amount"}],
+			total_payable_result = (
+				frappe.qb.from_(LoanDemand)
+				.select(fn.Sum(LoanDemand.outstanding_amount))
+				.where(
+					(LoanDemand.loan == self.against_loan)
+					& (LoanDemand.docstatus == 1)
+					& (LoanDemand.outstanding_amount > 0)
+					& (LoanDemand.demand_date <= self.value_date)
 				)
-				or 0
-			)
+			).run()[0][0]
+
+			total_payable = total_payable_result or 0
 		else:
 			total_payable = self.payable_amount
 
@@ -2496,14 +2507,17 @@ def get_demand_query():
 
 def get_pending_principal_amount(loan, loan_disbursement=None):
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
+	LoanDisbursement = DocType("Loan Disbursement")
 
-	LoanDisbursement = frappe.qb.DocType("Loan Disbursement")
 	if loan_disbursement and loan.repayment_schedule_type == "Line of Credit":
-		pending_principal_amount = frappe.db.get_value(
-			"Loan Disbursement",
-			loan_disbursement,
-			Sum(LoanDisbursement.disbursed_amount - LoanDisbursement.principal_amount_paid),
-		)
+		pending_principal_amount_result = (
+			frappe.qb.from_(LoanDisbursement)
+			.select(fn.Sum(LoanDisbursement.disbursed_amount - LoanDisbursement.principal_amount_paid))
+			.where(LoanDisbursement.name == loan_disbursement)
+		).run()[0][0]
+
+		pending_principal_amount = flt(pending_principal_amount_result or 0)
+
 	elif loan.status == "Cancelled":
 		pending_principal_amount = 0
 	elif (
@@ -2827,9 +2841,14 @@ def calculate_amounts(
 			for_update=for_update,
 		)
 
-	amounts["available_security_deposit"] = frappe.db.get_value(
-		"Loan Security Deposit", {"loan": against_loan}, [{"SUM": "available_amount"}]
-	)
+	LoanSecurityDeposit = DocType("Loan Security Deposit")
+	available_amount_result = (
+		frappe.qb.from_(LoanSecurityDeposit)
+		.select(fn.Sum(LoanSecurityDeposit.available_amount))
+		.where(LoanSecurityDeposit.loan == against_loan)
+	).run()[0][0] or 0
+
+	amounts["available_security_deposit"] = available_amount_result
 
 	# update values for closure
 	if payment_type in ("Loan Closure", "Full Settlement", "Write Off Settlement"):
@@ -2934,21 +2953,21 @@ def get_last_demand_date(
 		get_last_disbursement_date,
 	)
 
-	filters = {
-		"loan": loan,
-		"docstatus": 1,
-		"demand_subtype": demand_subtype,
-		"demand_date": ("<=", posting_date),
-	}
+	LoanDemand = DocType("Loan Demand")
+
+	conditions = (
+		(LoanDemand.loan == loan)
+		& (LoanDemand.docstatus == 1)
+		& (LoanDemand.demand_subtype == demand_subtype)
+		& (LoanDemand.demand_date <= posting_date)
+	)
 
 	if loan_disbursement:
-		filters["loan_disbursement"] = loan_disbursement
+		conditions &= LoanDemand.loan_disbursement == loan_disbursement
 
-	last_demand_date = frappe.db.get_value(
-		"Loan Demand",
-		filters,
-		[{"MAX": "demand_date"}],
-	)
+	last_demand_date = (
+		frappe.qb.from_(LoanDemand).select(fn.Max(LoanDemand.demand_date)).where(conditions)
+	).run()[0][0]
 
 	if not last_demand_date:
 		last_demand_date = get_last_disbursement_date(
@@ -2961,21 +2980,23 @@ def get_last_demand_date(
 def get_latest_accrual_date(
 	loan, posting_date, interest_type="Normal Interest", loan_disbursement=None
 ):
-	filters = {
-		"loan": loan,
-		"docstatus": 1,
-		"interest_type": interest_type,
-		"posting_date": ("<", posting_date),
-	}
+	LoanInterestAccrual = DocType("Loan Interest Accrual")
+
+	conditions = (
+		(LoanInterestAccrual.loan == loan)
+		& (LoanInterestAccrual.docstatus == 1)
+		& (LoanInterestAccrual.interest_type == interest_type)
+		& (LoanInterestAccrual.posting_date < posting_date)
+	)
 
 	if loan_disbursement:
-		filters["loan_disbursement"] = loan_disbursement
+		conditions &= LoanInterestAccrual.loan_disbursement == loan_disbursement
 
-	latest_accrual_date = frappe.db.get_value(
-		"Loan Interest Accrual",
-		filters,
-		[{"MAX": "posting_date"}],
-	)
+	latest_accrual_date = (
+		frappe.qb.from_(LoanInterestAccrual)
+		.select(fn.Max(LoanInterestAccrual.posting_date))
+		.where(conditions)
+	).run()[0][0]
 
 	return latest_accrual_date
 
@@ -2998,24 +3019,26 @@ def get_accrued_interest(
 	last_demand_date=None,
 	loan_disbursement=None,
 ):
-	filters = [
-		["loan", "=", loan],
-		["docstatus", "=", 1],
-		["posting_date", "<", posting_date],
-		["interest_type", "=", interest_type],
-	]
+	LoanInterestAccrual = DocType("Loan Interest Accrual")
+
+	conditions = (
+		(LoanInterestAccrual.loan == loan)
+		& (LoanInterestAccrual.docstatus == 1)
+		& (LoanInterestAccrual.posting_date < posting_date)
+		& (LoanInterestAccrual.interest_type == interest_type)
+	)
 
 	if last_demand_date:
-		filters.append(["posting_date", ">=", last_demand_date])
+		conditions &= LoanInterestAccrual.posting_date >= last_demand_date
 
 	if loan_disbursement:
-		filters.append(["loan_disbursement", "=", loan_disbursement])
+		conditions &= LoanInterestAccrual.loan_disbursement == loan_disbursement
 
-	accrued_interest = frappe.db.get_value(
-		"Loan Interest Accrual",
-		filters,
-		[{"SUM": "interest_amount"}],
-	)
+	accrued_interest = (
+		frappe.qb.from_(LoanInterestAccrual)
+		.select(fn.Sum(LoanInterestAccrual.interest_amount))
+		.where(conditions)
+	).run()[0][0] or 0
 
 	return flt(accrued_interest)
 

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -228,18 +228,33 @@ class TestLoanRepayment(IntegrationTestCase):
 		process_loan_interest_accrual_for_loans(
 			loan=loan.name, posting_date=add_days("2024-05-05", 6), company="_Test Company"
 		)
-		penal_interest = frappe.get_value(
-			"Loan Interest Accrual",
-			{"loan": loan.name, "interest_type": "Penal Interest", "docstatus": 1},
-			[{"SUM": "interest_amount"}],
-		)
+
+		penal_interest = frappe.db.sql(
+			"""
+			SELECT SUM(interest_amount)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s
+			AND interest_type = 'Penal Interest'
+			AND docstatus = 1
+			""",
+			(loan.name,),
+		)[0][0]
+
 		self.assertGreater(penal_interest, 0)
+
 		create_repayment_entry(loan=loan.name, value_date="2024-05-05", paid_amount=178025).submit()
-		penal_interest = frappe.get_value(
-			"Loan Interest Accrual",
-			{"loan": loan.name, "interest_type": "Penal Interest", "docstatus": 1},
-			[{"SUM": "interest_amount"}],
-		)
+
+		penal_interest = frappe.db.sql(
+			"""
+			SELECT SUM(interest_amount)
+			FROM `tabLoan Interest Accrual`
+			WHERE loan = %s
+			AND interest_type = 'Penal Interest'
+			AND docstatus = 1
+			""",
+			(loan.name,),
+		)[0][0]
+
 		self.assertEqual(penal_interest, None)
 
 	def test_demand_generation_upon_pre_payment(self):

--- a/lending/loan_management/doctype/loan_repayment/utils.py
+++ b/lending/loan_management/doctype/loan_repayment/utils.py
@@ -1,4 +1,6 @@
 import frappe
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.utils import cint, flt
 
 
@@ -153,35 +155,35 @@ def get_unbooked_interest_for_loans(
 
 
 def get_last_demand_date(posting_date, demand_subtype="Interest", loan=None):
-	filters = {
-		"docstatus": 1,
-		"demand_subtype": demand_subtype,
-		"demand_date": ("<=", posting_date),
-	}
+	LoanDemand = DocType("Loan Demand")
+
+	conditions = (
+		(LoanDemand.docstatus == 1)
+		& (LoanDemand.demand_subtype == demand_subtype)
+		& (LoanDemand.demand_date <= posting_date)
+	)
 
 	if loan:
-		filters["loan"] = loan
+		conditions &= LoanDemand.loan == loan
 
-	last_demand_date = frappe.db.get_value(
-		"Loan Demand",
-		filters,
-		[{"MAX": "demand_date"}],
-	)
+	last_demand_date = (
+		frappe.qb.from_(LoanDemand).select(fn.Max(LoanDemand.demand_date)).where(conditions)
+	).run()[0][0]
 
 	return last_demand_date
 
 
 def get_latest_accrual_date(posting_date, interest_type="Interest"):
-	filters = {
-		"docstatus": 1,
-		"interest_type": interest_type,
-		"posting_date": (">", posting_date),
-	}
+	LoanInterestAccrual = DocType("Loan Interest Accrual")
 
-	latest_accrual_date = frappe.db.get_value(
-		"Loan Interest Accrual",
-		filters,
-		[{"MAX": "posting_date"}],
-	)
+	latest_accrual_date = (
+		frappe.qb.from_(LoanInterestAccrual)
+		.select(fn.Max(LoanInterestAccrual.posting_date))
+		.where(
+			(LoanInterestAccrual.docstatus == 1)
+			& (LoanInterestAccrual.interest_type == interest_type)
+			& (LoanInterestAccrual.posting_date > posting_date)
+		)
+	).run()[0][0]
 
 	return latest_accrual_date

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -3,6 +3,8 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.utils import add_days, cint, flt, getdate
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import (
@@ -174,17 +176,21 @@ class LoanRepaymentRepost(Document):
 					frappe.db.set_value("Loan", repayment_doc.against_loan, "status", "Disbursed")
 					repayment_doc.update_repayment_schedule_status(cancel=1)
 
-			filters = {"against_loan": self.loan, "docstatus": 1, "value_date": ("<", self.repost_date)}
-
-			totals = frappe.db.get_value(
-				"Loan Repayment",
-				filters,
-				[
-					{"SUM": "principal_amount_paid", "as": "total_principal_paid"},
-					{"SUM": "amount_paid", "as": "total_amount_paid"},
-				],
-				as_dict=1,
+			LoanRepayment = DocType("Loan Repayment")
+			conditions = (
+				(LoanRepayment.against_loan == self.loan)
+				& (LoanRepayment.docstatus == 1)
+				& (LoanRepayment.value_date < self.repost_date)
 			)
+
+			totals = (
+				frappe.qb.from_(LoanRepayment)
+				.select(
+					fn.Sum(LoanRepayment.principal_amount_paid).as_("total_principal_paid"),
+					fn.Sum(LoanRepayment.amount_paid).as_("total_amount_paid"),
+				)
+				.where(conditions)
+			).run(as_dict=True)[0]
 
 			frappe.db.set_value(
 				"Loan",
@@ -197,16 +203,18 @@ class LoanRepaymentRepost(Document):
 			)
 
 			if self.loan_disbursement:
-				total_principal_paid = frappe.db.get_value(
-					"Loan Repayment",
-					{
-						"against_loan": self.loan,
-						"loan_disbursement": self.loan_disbursement,
-						"docstatus": 1,
-						"value_date": ("<", self.repost_date),
-					},
-					[{"SUM": "principal_amount_paid"}],
+				conditions = (
+					(LoanRepayment.against_loan == self.loan)
+					& (LoanRepayment.loan_disbursement == self.loan_disbursement)
+					& (LoanRepayment.docstatus == 1)
+					& (LoanRepayment.value_date < self.repost_date)
 				)
+
+				total_principal_paid = (
+					frappe.qb.from_(LoanRepayment)
+					.select(fn.Sum(LoanRepayment.principal_amount_paid))
+					.where(conditions)
+				).run()[0][0] or 0
 
 				frappe.db.set_value(
 					"Loan Disbursement",
@@ -230,14 +238,15 @@ class LoanRepaymentRepost(Document):
 
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-		is_written_off = frappe.db.get_value(
-			"Loan Write Off",
-			{
-				"loan": self.loan,
-				"docstatus": 1,
-				"is_settlement_write_off": 0,
-				"posting_date": (">=", self.repost_date),
-			},
+		LoanWriteOff = DocType("Loan Write Off")
+		conditions = (
+			(LoanWriteOff.loan == self.loan)
+			& (LoanWriteOff.docstatus == 1)
+			& (LoanWriteOff.is_settlement_write_off == 0)
+			& (LoanWriteOff.posting_date >= self.repost_date)
+		)
+		is_written_off = (
+			frappe.qb.from_(LoanWriteOff).select(LoanWriteOff.name).where(conditions).run()[0][0]
 		)
 
 		if is_written_off:
@@ -352,12 +361,19 @@ class LoanRepaymentRepost(Document):
 			update_installment_counts(self.loan)
 
 			if repayment_doc.repayment_type == "Full Settlement":
-				loan_write_off = frappe.db.get_value(
-					"Loan Write Off",
-					{"loan": self.loan, "docstatus": 1, "is_settlement_write_off": 1},
-					["name", "write_off_amount"],
-					as_dict=1,
+				LoanWriteOff = DocType("Loan Write Off")
+				lwo_conditions = (
+					(LoanWriteOff.loan == self.loan)
+					& (LoanWriteOff.docstatus == 1)
+					& (LoanWriteOff.is_settlement_write_off == 1)
 				)
+				loan_write_off = (
+					frappe.qb.from_(LoanWriteOff)
+					.select(LoanWriteOff.name, LoanWriteOff.write_off_amount)
+					.where(lwo_conditions)
+					.run(as_dict=True)
+				)
+				loan_write_off = loan_write_off[0] if loan_write_off else None
 
 				if loan_write_off:
 					write_off_amount = flt(
@@ -390,12 +406,13 @@ class LoanRepaymentRepost(Document):
 			frappe.db.set_value("Loan", self.loan, "status", "Written Off")
 
 		if self.loan_disbursement:
-			filters = {"against_loan": self.loan, "docstatus": 1}
-			total_principal_paid = frappe.db.get_value(
-				"Loan Repayment",
-				filters,
-				[{"SUM": "principal_amount_paid"}],
-			)
+			LoanRepayment = DocType("Loan Repayment")
+			filters = (LoanRepayment.against_loan == self.loan) & (LoanRepayment.docstatus == 1)
+			total_principal_paid = (
+				frappe.qb.from_(LoanRepayment)
+				.select(fn.Sum(LoanRepayment.principal_amount_paid))
+				.where(filters)
+			).run()[0][0] or 0
 
 			frappe.db.set_value(
 				"Loan",
@@ -422,8 +439,9 @@ class LoanRepaymentRepost(Document):
 			}
 		).submit()
 
-		loan = frappe.db.get_value("Loan", self.loan, "status")
-		if loan == "Closed":
+		Loan = DocType("Loan")
+		loan_status = frappe.qb.from_(Loan).select(Loan.status).where(Loan.name == self.loan).run()[0][0]
+		if loan_status == "Closed":
 			create_process_loan_classification(
 				posting_date=self.repost_date,
 				loan=self.loan,

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -183,21 +183,25 @@ class LoanRepaymentRepost(Document):
 				& (LoanRepayment.value_date < self.repost_date)
 			)
 
-			totals = (
+			totals_result = (
 				frappe.qb.from_(LoanRepayment)
 				.select(
 					fn.Sum(LoanRepayment.principal_amount_paid).as_("total_principal_paid"),
 					fn.Sum(LoanRepayment.amount_paid).as_("total_amount_paid"),
 				)
 				.where(conditions)
-			).run(as_dict=True)[0]
+			).run(as_dict=True)
+
+			totals = (
+				totals_result[0] if totals_result else {"total_principal_paid": 0, "total_amount_paid": 0}
+			)
 
 			frappe.db.set_value(
 				"Loan",
 				self.loan,
 				{
-					"total_principal_paid": flt(totals.total_principal_paid),
-					"total_amount_paid": flt(totals.total_amount_paid),
+					"total_principal_paid": flt(totals["total_principal_paid"]),
+					"total_amount_paid": flt(totals["total_amount_paid"]),
 					"excess_amount_paid": 0,
 				},
 			)
@@ -210,11 +214,13 @@ class LoanRepaymentRepost(Document):
 					& (LoanRepayment.value_date < self.repost_date)
 				)
 
-				total_principal_paid = (
+				total_principal_paid_result = (
 					frappe.qb.from_(LoanRepayment)
 					.select(fn.Sum(LoanRepayment.principal_amount_paid))
 					.where(conditions)
-				).run()[0][0] or 0
+				).run()
+
+				total_principal_paid = total_principal_paid_result[0][0] if total_principal_paid_result else 0
 
 				frappe.db.set_value(
 					"Loan Disbursement",
@@ -245,9 +251,9 @@ class LoanRepaymentRepost(Document):
 			& (LoanWriteOff.is_settlement_write_off == 0)
 			& (LoanWriteOff.posting_date >= self.repost_date)
 		)
-		is_written_off = (
-			frappe.qb.from_(LoanWriteOff).select(LoanWriteOff.name).where(conditions).run()[0][0]
-		)
+
+		result = frappe.qb.from_(LoanWriteOff).select(LoanWriteOff.name).where(conditions).run()
+		is_written_off = result[0][0] if result else None
 
 		if is_written_off:
 			frappe.db.set_value("Loan", self.loan, "status", "Disbursed")
@@ -440,7 +446,11 @@ class LoanRepaymentRepost(Document):
 		).submit()
 
 		Loan = DocType("Loan")
-		loan_status = frappe.qb.from_(Loan).select(Loan.status).where(Loan.name == self.loan).run()[0][0]
+		loan_status_result = (
+			frappe.qb.from_(Loan).select(Loan.status).where(Loan.name == self.loan).run()
+		)
+		loan_status = loan_status_result[0][0] if loan_status_result else None
+
 		if loan_status == "Closed":
 			create_process_loan_classification(
 				posting_date=self.repost_date,

--- a/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
@@ -56,8 +56,16 @@ class TestLoanRepaymentSchedule(IntegrationTestCase):
 		)
 		process_daily_loan_demands(loan=loan.name, posting_date="2025-12-05")
 
-		loan_demand_amount = frappe.db.get_value(
-			"Loan Demand", {"loan": loan.name, "docstatus": 1}, [{"SUM": "demand_amount"}]
+		loan_demand_amount = (
+			frappe.db.sql(
+				"""
+			SELECT SUM(demand_amount)
+			FROM `tabLoan Demand`
+			WHERE loan = %s AND docstatus = 1
+			""",
+				(loan.name,),
+			)[0][0]
+			or 0
 		)
 
 		repayment_entry = create_repayment_entry(
@@ -170,9 +178,19 @@ class TestLoanRepaymentSchedule(IntegrationTestCase):
 				getdate("2024-11-05"),
 				add_days(getdate("2025-12-05"), -1),
 			)
-			paid_interest = frappe.get_value(
-				"Loan Interest Accrual", {"loan": loan.name}, [{"SUM": "interest_amount"}]
+
+			paid_interest = (
+				frappe.db.sql(
+					"""
+				SELECT SUM(interest_amount)
+				FROM `tabLoan Interest Accrual`
+				WHERE loan = %s
+				""",
+					(loan.name,),
+				)[0][0]
+				or 0
 			)
+
 			self.assertEqual(flt(paid_interest, 0), flt(payable_interest, 0))
 
 	def test_moratorium_date_jump(self):

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -3,6 +3,8 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.utils import add_days, cint, flt, getdate
 
 from erpnext.controllers.accounts_controller import AccountsController
@@ -113,9 +115,14 @@ class LoanRestructure(AccountsController):
 
 	def validate_restructure_date(self):
 		if self.restructure_type == "Normal Restructure":
-			max_due_date = frappe.db.get_value(
-				"Loan Interest Accrual", {"loan": self.loan, "docstatus": 1}, [{"MAX": "posting_date"}]
-			)
+			LoanInterestAccrual = DocType("Loan Interest Accrual")
+
+			max_due_date = (
+				frappe.qb.from_(LoanInterestAccrual)
+				.select(fn.Max(LoanInterestAccrual.posting_date))
+				.where((LoanInterestAccrual.loan == self.loan) & (LoanInterestAccrual.docstatus == 1))
+			).run()[0][0]
+
 			if max_due_date and getdate(self.restructure_date) < getdate(max_due_date):
 				frappe.throw(_("Restructure Date cannot be before last due date {0}").format(max_due_date))
 

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -4,6 +4,8 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder import functions as fn
 from frappe.utils import cint, flt, getdate
 
 import erpnext
@@ -576,27 +578,31 @@ def get_write_off_waivers(loan_name, posting_date):
 
 
 def get_write_off_recovery_details(loan_name, posting_date, settlement_date=None):
+	LoanRepayment = DocType("Loan Repayment")
 
-	filters = {"against_loan": loan_name, "posting_date": ("<=", posting_date), "docstatus": 1}
-
-	if settlement_date:
-		filters["value_date"] = (">", settlement_date)
-	else:
-		filters["repayment_type"] = ("in", ["Write Off Recovery", "Write Off Settlement"])
-
-	write_of_recovery_details = frappe.db.get_value(
-		"Loan Repayment",
-		filters,
-		[
-			{"SUM": "total_penalty_paid", "as": "total_penalty"},
-			{"SUM": "total_interest_paid", "as": "total_interest"},
-			{"SUM": "total_charges_paid", "as": "total_charges"},
-			{"SUM": "principal_amount_paid", "as": "total_principal"},
-		],
-		as_dict=1,
+	conditions = (
+		(LoanRepayment.against_loan == loan_name)
+		& (LoanRepayment.posting_date <= posting_date)
+		& (LoanRepayment.docstatus == 1)
 	)
 
-	return write_of_recovery_details or {}
+	if settlement_date:
+		conditions &= LoanRepayment.value_date > settlement_date
+	else:
+		conditions &= LoanRepayment.repayment_type.isin(["Write Off Recovery", "Write Off Settlement"])
+
+	write_off_recovery_details = (
+		frappe.qb.from_(LoanRepayment)
+		.select(
+			fn.Sum(LoanRepayment.total_penalty_paid).as_("total_penalty"),
+			fn.Sum(LoanRepayment.total_interest_paid).as_("total_interest"),
+			fn.Sum(LoanRepayment.total_charges_paid).as_("total_charges"),
+			fn.Sum(LoanRepayment.principal_amount_paid).as_("total_principal"),
+		)
+		.where(conditions)
+	).run(as_dict=True)
+
+	return write_off_recovery_details[0] if write_off_recovery_details else {}
 
 
 def get_accrued_interest_for_write_off_recovery(loan_name, posting_date):


### PR DESCRIPTION
- This PR refactors multiple Frappe Lending functions to replace legacy `frappe.db.get_value` and ORM-based aggregation queries with Frappe Query Builder (QB)