### PR TITLE
fix: waiver allocation for settled loans

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -267,9 +267,6 @@ class LoanRepayment(AccountsController):
 			else:
 				self.post_write_off_settlements()
 
-			# if self.repayment_schedule_type != "Line of Credit":
-			# 	frappe.db.set_value("Loan", self.against_loan, {"status": "Settled", "settlement_date": self.value_date})
-
 		update_loan_securities_values(self.against_loan, self.principal_amount_paid, self.doctype)
 		self.create_loan_limit_change_log()
 		self.make_gl_entries()

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -267,6 +267,9 @@ class LoanRepayment(AccountsController):
 			else:
 				self.post_write_off_settlements()
 
+			# if self.repayment_schedule_type != "Line of Credit":
+			# 	frappe.db.set_value("Loan", self.against_loan, {"status": "Settled", "settlement_date": self.value_date})
+
 		update_loan_securities_values(self.against_loan, self.principal_amount_paid, self.doctype)
 		self.create_loan_limit_change_log()
 		self.make_gl_entries()
@@ -1119,7 +1122,7 @@ class LoanRepayment(AccountsController):
 		unpaid_unbooked_interest = 0
 
 		if flt(unbooked_interest - self.unbooked_interest_paid, precision) > 0:
-			unpaid_unbooked_interest = unbooked_interest - self.unbooked_interest_paid
+			unpaid_unbooked_interest = flt(unbooked_interest - self.unbooked_interest_paid, precision)
 			create_loan_demand(
 				self.against_loan,
 				self.value_date,
@@ -1130,7 +1133,7 @@ class LoanRepayment(AccountsController):
 			)
 
 		if flt(self.interest_payable - self.total_interest_paid, precision) > 0:
-			interest_amount = self.interest_payable - self.total_interest_paid
+			interest_amount = flt(self.interest_payable - self.total_interest_paid, precision)
 			create_loan_repayment(
 				self.against_loan,
 				self.value_date,
@@ -1141,7 +1144,7 @@ class LoanRepayment(AccountsController):
 			)
 
 		if flt(self.penalty_amount - self.total_penalty_paid, precision) > 0:
-			penalty_amount = self.penalty_amount - self.total_penalty_paid
+			penalty_amount = flt(self.penalty_amount - self.total_penalty_paid, precision)
 			create_loan_repayment(
 				self.against_loan,
 				self.value_date,
@@ -1152,7 +1155,7 @@ class LoanRepayment(AccountsController):
 			)
 
 		if flt(self.total_charges_payable - self.total_charges_paid, precision) > 0:
-			charges_amount = self.total_charges_payable - self.total_charges_paid
+			charges_amount = flt(self.total_charges_payable - self.total_charges_paid, precision)
 			create_loan_repayment(
 				self.against_loan,
 				self.value_date,
@@ -1163,10 +1166,10 @@ class LoanRepayment(AccountsController):
 			)
 
 		if (
-			flt(self.payable_principal_amount - self.principal_amount_paid, 2) > 0
+			flt(self.payable_principal_amount - self.principal_amount_paid, precision) > 0
 			and self.repayment_type == "Full Settlement"
 		):
-			principal_amount = self.payable_principal_amount - self.principal_amount_paid
+			principal_amount = flt(self.payable_principal_amount - self.principal_amount_paid, precision)
 			loan_write_off = frappe.new_doc("Loan Write Off")
 			loan_write_off.loan = self.against_loan
 			loan_write_off.posting_date = self.value_date
@@ -1481,9 +1484,9 @@ class LoanRepayment(AccountsController):
 			if demand.get("demand_subtype") == "Principal":
 				total_demanded_principal += demand.get("outstanding_amount")
 
-		if (
-			self.repayment_type in ("Write Off Recovery", "Write Off Settlement")
-			or loan_status == "Settled"
+		if self.repayment_type in ("Write Off Recovery", "Write Off Settlement") or (
+			loan_status == "Settled"
+			and self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver")
 		):
 			if not self.total_charges_payable:
 				self.total_charges_payable = 0
@@ -1540,9 +1543,13 @@ class LoanRepayment(AccountsController):
 				allocation_order = self.get_allocation_order(
 					"Collection Offset Sequence for Written Off Asset"
 				)
-			elif (
-				self.repayment_type in ("Partial Settlement", "Full Settlement", "Principal Adjustment")
-				or loan_status == "Settled"
+			elif self.repayment_type in (
+				"Partial Settlement",
+				"Full Settlement",
+				"Principal Adjustment",
+			) or (
+				loan_status == "Settled"
+				and self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver")
 			):
 				allocation_order = self.get_allocation_order(
 					"Collection Offset Sequence for Settlement Collection"

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1629,3 +1629,51 @@ class TestLoanRepayment(IntegrationTestCase):
 
 		charges_waiver.submit()
 		self.assertEqual(charges_waiver.unbooked_interest_paid, 0)
+
+	def test_full_settlement_waivers_and_write_off(self):
+		set_loan_accrual_frequency("Daily")
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			2000000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date="2024-08-05",
+			posting_date="2024-07-05",
+			rate_of_interest=22,
+			applicant_type="Customer",
+			penalty_charges_rate=12,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-07-05", repayment_start_date="2024-08-05"
+		)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2024-08-04", company="_Test Company"
+		)
+
+		process_daily_loan_demands(posting_date="2024-08-05", loan=loan.name)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2024-09-04", company="_Test Company"
+		)
+
+		process_daily_loan_demands(posting_date="2024-09-05", loan=loan.name)
+
+		repayment_entry = create_repayment_entry(
+			loan.name, "2024-09-05", 1000000, repayment_type="Full Settlement"
+		)
+		repayment_entry.submit()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Settled")
+
+		demands = frappe.db.get_all(
+			"Loan Demand",
+			{"loan": loan.name, "docstatus": 1},
+			["outstanding_amount"],
+		)
+		for demand in demands:
+			self.assertEqual(demand.outstanding_amount, 0)

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -90,7 +90,11 @@ class LoanWriteOff(AccountsController):
 			self.write_off_amount = pending_principal_amount
 
 		if self.write_off_amount != pending_principal_amount:
-			frappe.throw(_("Write off amount should be equal to pending principal amount"))
+			frappe.throw(
+				_("Write off amount ({0}) should be equal to pending principal amount ({1})").format(
+					self.write_off_amount, pending_principal_amount
+				)
+			)
 
 	def on_submit(self):
 		from lending.loan_management.doctype.process_loan_classification.process_loan_classification import (


### PR DESCRIPTION
When a loan status was set to **Settled**, the allocation logic was going wrong, so fixed it.
