### PR TITLE
fix: get existing lsa only if loan exists

### DIFF
--- a/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
+++ b/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
@@ -81,9 +81,11 @@ class LoanSecurityAssignment(Document):
 				)
 
 	def validate_loan_security_type(self):
-		existing_lsa = frappe.db.get_value(
-			"Loan Security Assignment", {"loan": self.loan, "docstatus": 1}, ["name"]
-		)
+		existing_lsa = None
+		if self.loan:
+			existing_lsa = frappe.db.get_value(
+				"Loan Security Assignment", {"loan": self.loan, "docstatus": 1}, ["name"]
+			)
 
 		if existing_lsa:
 			loan_security_type = frappe.db.get_value(


### PR DESCRIPTION
Issue: 
when creating loan security assignment for new loan application where loan doc is not yet created, loan goes as None whose filter wrongly matches with existing record where loan is none (loan not yet created) 

Fix:
check loan exists before fetching loan security assignment