### PR TITLE
fix: wrong interest calculation during loan write-off submit, fixed by using for_update=True

### DIFF
--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -280,7 +280,7 @@ def make_loan_waivers(loan, posting_date):
 
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-	amounts = calculate_amounts(loan, posting_date)
+	amounts = calculate_amounts(loan, posting_date, for_update=True)
 	if amounts.get("penalty_amount") > 0:
 		create_loan_repayment(
 			loan,


### PR DESCRIPTION
Before, Loan write-off was using calculate_amounts with for_update=False.  
This added extra interest and made the write-off numbers higher than the overdue amount.  
When the write-off was submitted, the system blocked it with a repayment validation error.
`Waived interest amount X cannot be greater than overdue amount Y`

This update switches to for_update=True so the interest is calculated the same way as repayment.
Now, the amount matches, and the write-off submits without errors.
