### PR TITLE
fix: rename_tenure_to_ loan_tenure

### DIFF
--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
@@ -277,7 +277,7 @@
    "depends_on": "eval:doc.is_term_loan && doc.repayment_frequency != \"One Time\" && doc.repayment_schedule_type == \"Line of Credit\"",
    "fieldname": "tenure",
    "fieldtype": "Int",
-   "label": "Tenure",
+   "label": "Loan Tenure",
    "mandatory_depends_on": "eval:doc.repayment_schedule_type==\"Line of Credit\""
   },
   {

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.json
@@ -382,7 +382,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-23 16:14:49.609564",
+ "modified": "2025-12-24 08:37:39.896223",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Disbursement",


### PR DESCRIPTION
Rename Tenure to  Loan Tenure to differentiate from Tenure in hrms
This gives ability to translate Tenure in other languages

Backport version-15-hotfix
