### PR TITLE
ci: fix generate POT workflow

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -27,6 +27,11 @@ jobs:
           with:
             python-version: "3.14"
 
+        - name: Setup Node
+          uses: actions/setup-node@v6
+          with:
+            node-version: 24
+
         - name: Run script to update POT file
           run: |
             bash ${GITHUB_WORKSPACE}/.github/helper/update_pot_file.sh


### PR DESCRIPTION
This pull request updates the workflow for generating POT files by adding a step to set up Node.js before running the update script. This ensures that the required Node.js environment is available for any scripts that may depend on it.
