### PR TITLE
fix: clear overdue principal demands during normal restructure

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1910,6 +1910,16 @@ class LoanRepayment(LoanController):
 				)
 			return
 
+		if (
+			self.repayment_type == "Principal Adjustment"
+			and self.loan_restructure
+			and frappe.db.get_value(
+				"Loan Restructure", self.loan_restructure, "restructure_type"
+			) == "Normal Restructure"
+		):
+			return
+
+
 		if cancel:
 			make_reverse_gl_entries(
 				voucher_type="Loan Repayment", voucher_no=self.name, posting_date=getdate()

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1910,15 +1910,8 @@ class LoanRepayment(LoanController):
 				)
 			return
 
-		if (
-			self.repayment_type == "Principal Adjustment"
-			and self.loan_restructure
-			and frappe.db.get_value(
-				"Loan Restructure", self.loan_restructure, "restructure_type"
-			) == "Normal Restructure"
-		):
+		if self.repayment_type == "Principal Adjustment" and self.loan_restructure:
 			return
-
 
 		if cancel:
 			make_reverse_gl_entries(

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -275,6 +275,7 @@ class LoanRestructure(AccountsController):
 				make_accrual_interest_entry_for_loans(posting_date=self.restructure_date, loan=self.loan)
 
 				self.make_waiver_and_capitalization_for_penalty()
+				self.set_principal_adjustment_on_restructure()
 				self.make_loan_repayment_for_adjustment()
 				self.make_loan_repayment_for_waiver()
 				self.make_loan_adjustment_for_capitalization()
@@ -591,6 +592,10 @@ class LoanRestructure(AccountsController):
 				self.balance_penalty_amount,
 				restructure_name=self.name,
 			)
+
+	def set_principal_adjustment_on_restructure(self):
+		if flt(self.principal_overdue) > 0 and flt(self.principal_adjusted) == 0:
+			self.principal_adjusted = flt(self.principal_overdue)
 
 	def make_loan_repayment_for_adjustment(self):
 		if self.principal_adjusted:

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -2,7 +2,10 @@
 # See license.txt
 
 import frappe
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Sum
 from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
 
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
@@ -105,7 +108,61 @@ class TestLoanRestructure(IntegrationTestCase):
 			pluck="name",
 		)
 
-		self.assertEqual(len(repayments), 5)
+		self.assertEqual(len(repayments), 6)
+
+	def test_clears_principal_overdue_demands_on_normal_restructure(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-04-05",
+			posting_date="2024-02-20",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+			penalty_charges_rate=36,
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+		)
+
+		process_loan_interest_accrual_for_loans(
+			posting_date="2024-04-04", loan=loan.name, company="_Test Company"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-04-05")
+
+		process_loan_interest_accrual_for_loans(loan=loan.name, posting_date="2024-04-10")
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date="2024-04-11",
+			interest_waiver_amount=500,
+			penal_waiver_amount=10,
+			other_charges_waiver=0,
+		)
+
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		LoanDemand = DocType("Loan Demand")
+
+		total_outstanding = (
+			frappe.qb.from_(LoanDemand)
+			.select(Sum(LoanDemand.outstanding_amount))
+			.where(LoanDemand.loan == loan.name)
+			.where(LoanDemand.demand_type == "EMI")
+			.where(LoanDemand.demand_subtype == "Principal")
+			.where(LoanDemand.docstatus == 1)
+		).run()[0][0]
+
+		self.assertEqual(flt(total_outstanding), 0)
 
 
 def create_loan_restructure(


### PR DESCRIPTION
Issue:
- Loan restructure generates a new repayment schedule, but existing principal demands from the old schedule were not automatically cleared.
- As a result, principal overdue continued to appear even after restructure.

Fix:
- During Normal Restructure approval, we set principal_adjusted equal to the current principal_overdue (only if no prior adjustment exists).
- This creates a Principal Adjustment Loan Repayment, which clears the old overdue principal demands.