### PR TITLE
fix: correct waiver and capitalization order in loan restructure

### DIFF
--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -274,11 +274,11 @@ class LoanRestructure(AccountsController):
 			if self.unaccrued_interest and self.restructure_type == "Normal Restructure":
 				make_accrual_interest_entry_for_loans(posting_date=self.restructure_date, loan=self.loan)
 
-				self.make_loan_adjustment_for_capitalization()
+				self.make_waiver_and_capitalization_for_interest()
 				self.make_waiver_and_capitalization_for_penalty()
+				self.make_waiver_and_capitalization_for_charges()
 				self.set_principal_adjustment_on_restructure()
 				self.make_loan_repayment_for_adjustment()
-				self.make_loan_repayment_for_waiver()
 
 			self.restructure_loan()
 
@@ -574,6 +574,53 @@ class LoanRestructure(AccountsController):
 			},
 		)
 
+	def make_waiver_and_capitalization_for_interest(self):
+		from lending.loan_management.doctype.loan_demand.loan_demand import create_loan_demand
+
+		if self.balance_interest_amount and self.treatment_of_normal_interest == "Capitalize":
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Interest Capitalization",
+				self.balance_interest_amount,
+				restructure_name=self.name,
+			)
+
+		if self.interest_waiver_amount:
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Interest Waiver",
+				self.interest_waiver_amount,
+				restructure_name=self.name,
+			)
+
+		if self.balance_unaccrued_interest and self.unaccrued_interest_treatment == "Capitalize":
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Interest Capitalization",
+				self.balance_unaccrued_interest,
+				restructure_name=self.name,
+			)
+
+		if self.unaccrued_interest_waiver:
+			create_loan_demand(
+				self.loan,
+				self.restructure_date,
+				"EMI",
+				"Interest",
+				self.unaccrued_interest_waiver,
+			)
+
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Interest Waiver",
+				self.unaccrued_interest_waiver,
+				restructure_name=self.name,
+			)
+
 	def make_waiver_and_capitalization_for_penalty(self):
 		if self.penal_interest_waiver:
 			create_loan_repayment(
@@ -590,6 +637,25 @@ class LoanRestructure(AccountsController):
 				self.restructure_date,
 				"Penalty Capitalization",
 				self.balance_penalty_amount,
+				restructure_name=self.name,
+			)
+
+	def make_waiver_and_capitalization_for_charges(self):
+		if self.balance_charges and self.treatment_of_other_charges == "Capitalize":
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Charges Capitalization",
+				self.balance_charges,
+				restructure_name=self.name,
+			)
+
+		if self.other_charges_waiver:
+			create_loan_repayment(
+				self.loan,
+				self.restructure_date,
+				"Charges Waiver",
+				self.other_charges_waiver,
 				restructure_name=self.name,
 			)
 
@@ -616,76 +682,10 @@ class LoanRestructure(AccountsController):
 				restructure_name=self.name,
 			)
 
-	def make_loan_repayment_for_waiver(self):
-		from lending.loan_management.doctype.loan_demand.loan_demand import create_loan_demand
-
-		if self.interest_waiver_amount:
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Interest Waiver",
-				self.interest_waiver_amount,
-				restructure_name=self.name,
-			)
-
-		if self.unaccrued_interest_waiver:
-			create_loan_demand(
-				self.loan,
-				self.restructure_date,
-				"EMI",
-				"Interest",
-				self.unaccrued_interest_waiver,
-			)
-
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Interest Waiver",
-				self.unaccrued_interest_waiver,
-				restructure_name=self.name,
-			)
-
-		if self.other_charges_waiver:
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Charges Waiver",
-				self.other_charges_waiver,
-				restructure_name=self.name,
-			)
-
 	def cancel_loan_adjustments(self):
 		for d in frappe.get_all("Loan Repayment", {"loan_restructure": self.name}):
 			doc = frappe.get_doc("Loan Repayment", d.name)
 			doc.cancel()
-
-	def make_loan_adjustment_for_capitalization(self):
-		if self.balance_interest_amount and self.treatment_of_normal_interest == "Capitalize":
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Interest Capitalization",
-				self.balance_interest_amount,
-				restructure_name=self.name,
-			)
-
-		if self.balance_unaccrued_interest and self.unaccrued_interest_treatment == "Capitalize":
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Interest Capitalization",
-				self.balance_unaccrued_interest,
-				restructure_name=self.name,
-			)
-
-		if self.balance_charges and self.treatment_of_other_charges == "Capitalize":
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Charges Capitalization",
-				self.balance_charges,
-				restructure_name=self.name,
-			)
 
 
 def create_loan_repayment(

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -170,12 +170,12 @@ class TestLoanRestructure(IntegrationTestCase):
 		loan = create_loan(
 			"_Test Customer 1",
 			"Term Loan Product 4",
-			100000,
+			2300000,
 			"Repay Over Number of Periods",
-			22,
-			repayment_start_date="2024-04-05",
-			posting_date="2024-02-20",
-			rate_of_interest=8.5,
+			24,
+			repayment_start_date="2025-11-05",
+			posting_date="2025-10-09",
+			rate_of_interest=27,
 			applicant_type="Customer",
 			penalty_charges_rate=36,
 		)
@@ -183,21 +183,19 @@ class TestLoanRestructure(IntegrationTestCase):
 		loan.submit()
 
 		make_loan_disbursement_entry(
-			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+			loan.name, loan.loan_amount, disbursement_date="2025-10-09", repayment_start_date="2025-11-05"
 		)
 
-		process_loan_interest_accrual_for_loans(
-			posting_date="2024-04-04", loan=loan.name, company="_Test Company"
-		)
-
-		process_daily_loan_demands(loan=loan.name, posting_date="2024-04-05")
-
-		process_loan_interest_accrual_for_loans(loan=loan.name, posting_date="2024-04-10")
+		process_loan_interest_accrual_for_loans(posting_date="2025-12-04", loan=loan.name, company="_Test Company")
+		process_daily_loan_demands(loan=loan.name, posting_date="2026-01-05")
+		process_loan_interest_accrual_for_loans(posting_date="2026-02-03", loan=loan.name, company="_Test Company")
 
 		loan_restructure = create_loan_restructure(
 			loan=loan.name,
-			restructure_date="2024-04-11",
-			unaccrued_interest_waiver=100,
+			restructure_date="2026-02-04",
+			interest_waiver_amount=1001,
+			unaccrued_interest_waiver=1004,
+			penal_waiver_amount=1002,
 		)
 
 		loan_restructure.status = "Approved"


### PR DESCRIPTION
**Issue:**
Previously, interest and unaccrued interest were capitalized before creating waiver entries.
Because of this, the overdue balance was cleared by capitalization, and no amount was left for waiver.

As a result, during submission, the system raised the following validation error:

"Waived interest amount XXX cannot be greater than overdue amount 0.0"

**Fix:**
Waiver and capitalization logic is now grouped properly for interest, penalty, and charges.
Adjustment entries are created only after these entries are processed.