### PR TITLE
fix: first EMI interest day calculation after normal restructure

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -934,6 +934,36 @@ class LoanRepaymentSchedule(Document):
 	):
 		months = 365
 		if self.repayment_frequency == "Monthly":
+			days, months = self.get_monthly_interest_days_and_months(
+				payment_date,
+				additional_days,
+				balance_amount,
+				rate_of_interest,
+				schedule_field,
+				principal_share_percentage,
+				interest_share_percentage,
+				months,
+			)
+		else:
+			days = self.get_non_monthly_days(payment_date)
+
+		return days, months
+
+	def get_monthly_interest_days_and_months(
+		self,
+		payment_date,
+		additional_days,
+		balance_amount,
+		rate_of_interest,
+		schedule_field,
+		principal_share_percentage,
+		interest_share_percentage,
+		months,
+	):
+		if self.is_first_emi_after_normal_restructure(payment_date):
+			days = date_diff(payment_date, self.posting_date)
+
+		else:
 			expected_payment_date = get_last_day(payment_date)
 			if self.repayment_date_on == "Start of the next month":
 				expected_payment_date = add_days(expected_payment_date, 1)
@@ -983,21 +1013,38 @@ class LoanRepaymentSchedule(Document):
 					days = date_diff(payment_date, self.posting_date)
 				else:
 					days = date_diff(get_last_day(payment_date), payment_date)
-		else:
-			if payment_date == self.repayment_start_date:
-				days = date_diff(payment_date, self.posting_date)
-			elif self.repayment_frequency == "Bi-Weekly":
-				days = 14
-			elif self.repayment_frequency == "Weekly":
-				days = 7
-			elif self.repayment_frequency == "Daily":
-				days = 1
-			elif self.repayment_frequency == "Quarterly":
-				days = 3
-			elif self.repayment_frequency == "One Time":
-				days = date_diff(self.repayment_start_date, self.posting_date)
 
 		return days, months
+
+	def is_first_emi_after_normal_restructure(self, payment_date):
+		return (
+			self.restructure_type == "Normal Restructure"
+			and self.loan_restructure
+			and getdate(payment_date) == getdate(self.repayment_start_date)
+			and getdate(self.posting_date) < getdate(payment_date)
+			and self.repayment_schedule_type
+			in (
+				"Monthly as per cycle date",
+				"Monthly as per repayment start date",
+				"Line of Credit",
+				"Pro-rated calendar months",
+			)
+		)
+
+
+	def get_non_monthly_days(self, payment_date):
+		if payment_date == self.repayment_start_date:
+			return date_diff(payment_date, self.posting_date)
+		elif self.repayment_frequency == "Bi-Weekly":
+			return 14
+		elif self.repayment_frequency == "Weekly":
+			return 7
+		elif self.repayment_frequency == "Daily":
+			return 1
+		elif self.repayment_frequency == "Quarterly":
+			return 3
+		elif self.repayment_frequency == "One Time":
+			return date_diff(self.repayment_start_date, self.posting_date)
 
 	def add_broken_period_interest(
 		self,

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Sum
 from frappe.tests import IntegrationTestCase
-from frappe.utils import flt
+from frappe.utils import date_diff, flt
 
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
@@ -233,10 +233,55 @@ class TestLoanRestructure(IntegrationTestCase):
 		for expected in expected_entries:
 			self.assertIn(expected, gl_entries, f"Missing GL entry: {expected}")
 
+	def test_normal_restructure_first_emi_schedule_days(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			1200000,
+			"Repay Over Number of Periods",
+			36,
+			repayment_start_date="2025-10-05",
+			posting_date="2024-09-19",
+			rate_of_interest=24,
+			applicant_type="Customer",
+			penalty_charges_rate=36,
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-09-19", repayment_start_date="2025-10-05"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2026-01-05")
+
+		restructure_date = "2026-02-02"
+		repayment_start_date = "2026-02-05"
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date=restructure_date,
+			repayment_start_date=repayment_start_date
+		)
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		loan_repayment_schedule = frappe.get_doc(
+			"Loan Repayment Schedule", {"loan": loan.name, "docstatus": 1, "loan_restructure": loan_restructure.name}
+		)
+
+		date_diff_value = date_diff(repayment_start_date, restructure_date)
+		number_of_days_for_first_emi = loan_repayment_schedule.repayment_schedule[0].number_of_days
+
+		self.assertEqual(date_diff_value, number_of_days_for_first_emi)
+
 
 def create_loan_restructure(
 	loan,
 	restructure_date,
+	repayment_start_date=None,
 	interest_waiver_amount=None,
 	unaccrued_interest_waiver=None,
 	penal_waiver_amount=None,
@@ -250,6 +295,7 @@ def create_loan_restructure(
 	doc = frappe.new_doc("Loan Restructure")
 	doc.loan = loan
 	doc.restructure_date = restructure_date
+	doc.repayment_start_date = repayment_start_date or restructure_date
 	doc.interest_waiver_amount = interest_waiver_amount
 	doc.unaccrued_interest_waiver = unaccrued_interest_waiver
 	doc.penal_interest_waiver = penal_waiver_amount


### PR DESCRIPTION
Earlier, for Normal Restructure, the first EMI was calculating interest for the full month instead of only from the restructure date to the repayment start date.
For example, when the restructure date was 2nd Jan and the repayment start date was 5th Jan, the first EMI included interest for the entire month instead of just 3 days.

This resulted in an incorrect interest component in the first EMI demand.

This PR fixes the calculation to accrue interest only for the actual period (from restructure date to repayment start date). The remaining amount is adjusted as the principal component, keeping the total EMI demand unchanged.