### PR TITLE
fix: Add Principal Capitalization repayment type for restructure cases

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -367,7 +367,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Repayment Type",
-   "options": "Normal Repayment\nInterest Waiver\nPenalty Waiver\nCharges Waiver\nPrincipal Adjustment\nInterest Carry Forward\nWrite Off Recovery\nSecurity Deposit Adjustment\nAdvance Payment\nPre Payment\nSubsidy Adjustments\nLoan Closure\nPartial Settlement\nFull Settlement\nWrite Off Settlement\nCharge Payment\nPenalty Capitalization\nInterest Capitalization\nCharges Capitalization",
+   "options": "Normal Repayment\nInterest Waiver\nPenalty Waiver\nCharges Waiver\nPrincipal Adjustment\nInterest Carry Forward\nWrite Off Recovery\nSecurity Deposit Adjustment\nAdvance Payment\nPre Payment\nSubsidy Adjustments\nLoan Closure\nPartial Settlement\nFull Settlement\nWrite Off Settlement\nCharge Payment\nPenalty Capitalization\nInterest Capitalization\nCharges Capitalization\nPrincipal Capitalization",
    "reqd": 1
   },
   {
@@ -562,7 +562,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-03 17:52:49.914595",
+ "modified": "2026-02-06 15:41:39.868624",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -92,7 +92,7 @@ class LoanRepayment(LoanController):
 		reference_number: DF.Data | None
 		repayment_details: DF.Table[LoanRepaymentDetail]
 		repayment_schedule_type: DF.Data | None
-		repayment_type: DF.Literal["Normal Repayment", "Interest Waiver", "Penalty Waiver", "Charges Waiver", "Principal Adjustment", "Interest Carry Forward", "Write Off Recovery", "Security Deposit Adjustment", "Advance Payment", "Pre Payment", "Subsidy Adjustments", "Loan Closure", "Partial Settlement", "Full Settlement", "Write Off Settlement", "Charge Payment", "Penalty Capitalization", "Interest Capitalization", "Charges Capitalization"]
+		repayment_type: DF.Literal["Normal Repayment", "Interest Waiver", "Penalty Waiver", "Charges Waiver", "Principal Adjustment", "Interest Carry Forward", "Write Off Recovery", "Security Deposit Adjustment", "Advance Payment", "Pre Payment", "Subsidy Adjustments", "Loan Closure", "Partial Settlement", "Full Settlement", "Write Off Settlement", "Charge Payment", "Penalty Capitalization", "Interest Capitalization", "Charges Capitalization", "Principal Capitalization"]
 		shortfall_amount: DF.Currency
 		total_charges_paid: DF.Currency
 		total_charges_payable: DF.Currency
@@ -1493,7 +1493,10 @@ class LoanRepayment(LoanController):
 					self.total_charges_paid += self.total_charges_payable
 					amount_paid -= self.total_charges_payable
 
-			if self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver", "Penalty Capitalization", "Interest Capitalization", "Charges Capitalization"):
+			if self.repayment_type not in (
+				"Interest Waiver", "Penalty Waiver", "Charges Waiver",
+				"Penalty Capitalization", "Interest Capitalization", "Charges Capitalization"
+			):
 				self.principal_amount_paid += flt(amount_paid, precision)
 			elif self.repayment_type in ("Penalty Waiver", "Penalty Capitalization"):
 				self.total_penalty_paid += amount_paid
@@ -1657,6 +1660,7 @@ class LoanRepayment(LoanController):
 			"Partial Settlement",
 			"Full Settlement",
 			"Principal Adjustment",
+			"Principal Capitalization",
 		) or (
 			loan_status == "Settled"
 			and self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver")
@@ -1922,7 +1926,7 @@ class LoanRepayment(LoanController):
 				)
 			return
 
-		if self.repayment_type == "Principal Adjustment" and self.loan_restructure:
+		if self.repayment_type == "Principal Capitalization" and self.loan_restructure:
 			return
 
 		if cancel:

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -668,7 +668,7 @@ class LoanRestructure(AccountsController):
 			create_loan_repayment(
 				self.loan,
 				self.restructure_date,
-				"Principal Adjustment",
+				"Principal Capitalization",
 				self.principal_adjusted,
 				restructure_name=self.name,
 			)


### PR DESCRIPTION
Previously, both ad-hoc principal adjustments and restructure-based principal capitalization were recorded as Principal Adjustment, which caused confusion in reporting and data analysis.

Added a separate repayment type Principal Capitalization to keep it separate from principal adjustment and avoid reporting confusion.