### PR TITLE
fix: NPA and non-NPA loan restructure watch period and classification handling

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -859,15 +859,15 @@ def make_refund_jv(loan, amount=0, reference_number=None, reference_date=None, s
 
 @frappe.whitelist()
 def update_days_past_due_in_loans(
-	loan_name,
-	posting_date=None,
-	loan_product=None,
-	process_loan_classification=None,
-	loan_disbursement=None,
-	ignore_freeze=False,
-	is_backdated=0,
-	force_update_dpd_in_loan=0,
-):
+	loan_name: str,
+	posting_date: str | None = None,
+	loan_product: str | None = None,
+	process_loan_classification: str | None = None,
+	loan_disbursement: str | None = None,
+	ignore_freeze: bool = False,
+	is_backdated: bool = False,
+	force_update_dpd_in_loan: bool = False,
+) -> None:
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import get_unpaid_demands
 
 	"""Update days past due in loans"""

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -924,13 +924,14 @@ def update_days_past_due_in_loans(
 		threshold_write_off_map = get_dpd_threshold_write_off_map()
 
 		loan_details = frappe.db.get_value(
-			"Loan", loan_name, ["applicant_type", "applicant", "freeze_date", "company"], as_dict=1
+			"Loan", loan_name, ["applicant_type", "applicant", "freeze_date", "company", "watch_period_end_date"], as_dict=1
 		)
 
 		applicant_type = loan_details.get("applicant_type")
 		applicant = loan_details.get("applicant")
 		company = loan_details.get("company")
 		freeze_date = loan_details.get("freeze_date")
+		watch_period_end_date = loan_details.get("watch_period_end_date")
 
 		if not ignore_freeze and freeze_date and getdate(freeze_date) < getdate(posting_date):
 			return
@@ -952,6 +953,15 @@ def update_days_past_due_in_loans(
 			if freeze_date:
 				days_past_due = 0
 				is_npa = 0
+
+			if watch_period_end_date and days_past_due == 1:
+				watch_period_days = frappe.db.get_value(
+					"Company", company, "watch_period_post_loan_restructure_in_days"
+				)
+				watch_period_end_date = add_days(demand.demand_date, watch_period_days)
+				update_watch_period_date_for_all_loans(
+					watch_period_end_date, applicant_type, applicant
+				)
 
 			if posting_date == add_days(getdate(), -1) or force_update_dpd_in_loan:
 				update_loan_and_customer_status(

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -3,6 +3,7 @@
 
 
 import json
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -860,7 +861,7 @@ def make_refund_jv(loan, amount=0, reference_number=None, reference_date=None, s
 @frappe.whitelist()
 def update_days_past_due_in_loans(
 	loan_name: str,
-	posting_date: str | None = None,
+	posting_date: str | date | datetime | None = None,
 	loan_product: str | None = None,
 	process_loan_classification: str | None = None,
 	loan_disbursement: str | None = None,

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -60,6 +60,7 @@ from lending.tests.test_utils import (
 	create_repayment_entry,
 	create_secured_demand_loan,
 	get_loan_interest_accrual,
+	loan_classification_ranges,
 	make_loan_disbursement_entry,
 	set_loan_accrual_frequency,
 	set_loan_settings_in_company,
@@ -72,6 +73,7 @@ class TestLoan(IntegrationTestCase):
 		set_loan_settings_in_company()
 		create_loan_accounts()
 		setup_loan_demand_offset_order()
+		loan_classification_ranges()
 
 		set_loan_accrual_frequency("Monthly")
 		simple_terms_loans = [

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.json
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.json
@@ -22,6 +22,7 @@
   "reason_for_restructure",
   "old_repayment_frequency",
   "moratorium_end_date",
+  "is_npa",
   "loan_details_section",
   "loan_product",
   "old_tenure",
@@ -528,16 +529,24 @@
    "fieldname": "moratorium_end_date",
    "fieldtype": "Date",
    "label": "Moratorium End Date"
+  },
+  {
+   "default": "0",
+   "fetch_from": "loan.is_npa",
+   "fieldname": "is_npa",
+   "fieldtype": "Check",
+   "label": "Is NPA",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-19 11:46:44.614411",
+ "modified": "2026-02-11 15:04:57.731068",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -569,6 +578,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.json
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.json
@@ -535,6 +535,7 @@
    "fetch_from": "loan.is_npa",
    "fieldname": "is_npa",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Is NPA",
    "read_only": 1
   }
@@ -542,7 +543,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-11 15:04:57.731068",
+ "modified": "2026-02-12 11:55:29.308410",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure",

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -49,6 +49,7 @@ class LoanRestructure(AccountsController):
 		disbursed_amount: DF.Currency
 		interest_overdue: DF.Currency
 		interest_waiver_amount: DF.Currency
+		is_npa: DF.Check
 		loan: DF.Link
 		loan_disbursement: DF.Link | None
 		loan_product: DF.Link | None
@@ -57,9 +58,7 @@ class LoanRestructure(AccountsController):
 		new_loan_amount: DF.Currency
 		new_monthly_repayment_amount: DF.Currency
 		new_rate_of_interest: DF.Percent
-		new_repayment_method: DF.Literal[
-			"", "Repay Fixed Amount per Period", "Repay Over Number of Periods"
-		]
+		new_repayment_method: DF.Literal["", "Repay Fixed Amount per Period", "Repay Over Number of Periods"]
 		new_repayment_period_in_months: DF.Int
 		old_emi: DF.Currency
 		old_loan_amount: DF.Currency
@@ -449,17 +448,17 @@ class LoanRestructure(AccountsController):
 	def restructure_loan(self):
 		if self.restructure_type == "Normal Restructure":
 			# Mark Loan as NPA
-			update_all_linked_loan_customer_npa_status(
-				1, self.applicant_type, self.applicant, self.restructure_date, loan=self.loan
-			)
-
-			watch_period_days = frappe.db.get_value(
-				"Company", self.company, "watch_period_post_loan_restructure_in_days"
-			)
-			watch_period_end_date = add_days(self.restructure_date, watch_period_days)
-			update_watch_period_date_for_all_loans(
-				watch_period_end_date, self.applicant_type, self.applicant
-			)
+			if self.is_npa:
+				update_all_linked_loan_customer_npa_status(
+					1, self.applicant_type, self.applicant, self.restructure_date, loan=self.loan
+				)
+				watch_period_days = frappe.db.get_value(
+					"Company", self.company, "watch_period_post_loan_restructure_in_days"
+				)
+				watch_period_end_date = add_days(self.restructure_date, watch_period_days)
+				update_watch_period_date_for_all_loans(
+					watch_period_end_date, self.applicant_type, self.applicant
+				)
 
 			frappe.db.set_value("Loan", self.loan, "days_past_due", 0)
 			status = "Restructured"

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -335,8 +335,8 @@ class TestLoanRestructure(IntegrationTestCase):
 
 	def test_npa_restructure_keeps_classification_same(self):
 		"""
-		Verify that after restructuring an NPA loan, the classification
-		remains unchanged during the active watch period.
+		Verify that after restructuring an NPA loan,
+		the loan classification stays the same during the watch period.
 		"""
 
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
@@ -383,18 +383,6 @@ class TestLoanRestructure(IntegrationTestCase):
 		self.assertEqual(loan.days_past_due, 0)
 		self.assertEqual(loan.is_npa, 1)
 		self.assertEqual(loan.classification_code, classification_code)
-
-		process_daily_loan_demands(loan=loan.name, posting_date="2024-09-05")
-		create_process_loan_classification(posting_date="2024-09-05", loan=loan.name, force_update_dpd_in_loan=1)
-
-		loan.load_from_db()
-
-		watch_period_days = frappe.db.get_value(
-			"Company", "_Test Company", "watch_period_post_loan_restructure_in_days"
-		)
-		watch_period_end_date = add_days("2024-09-05", watch_period_days)
-
-		self.assertEqual(loan.watch_period_end_date, getdate(watch_period_end_date))
 
 	def test_npa_restructure_watch_period_resets_on_dpd(self):
 		"""

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -5,8 +5,14 @@ import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Sum
 from frappe.tests import IntegrationTestCase
-from frappe.utils import date_diff, flt
+from frappe.utils import add_days, date_diff, flt, getdate
 
+from erpnext.selling.doctype.customer.test_customer import get_customer_dict
+
+from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
+from lending.loan_management.doctype.process_loan_classification.process_loan_classification import (
+	create_process_loan_classification,
+)
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
@@ -15,8 +21,10 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 )
 from lending.tests.test_utils import (
 	create_loan,
+	create_repayment_entry,
 	init_customers,
 	init_loan_products,
+	loan_classification_ranges,
 	make_loan_disbursement_entry,
 	master_init,
 	set_loan_accrual_frequency,
@@ -28,6 +36,7 @@ class TestLoanRestructure(IntegrationTestCase):
 		master_init()
 		init_loan_products()
 		init_customers()
+		loan_classification_ranges()
 		self.applicant2 = frappe.db.get_value("Customer", {"name": "_Test Loan Customer"}, "name")
 
 	def test_loan_restructure_capitalization(self):
@@ -276,6 +285,191 @@ class TestLoanRestructure(IntegrationTestCase):
 		number_of_days_for_first_emi = loan_repayment_schedule.repayment_schedule[0].number_of_days
 
 		self.assertEqual(date_diff_value, number_of_days_for_first_emi)
+
+	def test_non_npa_restructure_resets_dpd_without_watch_period(self):
+		"""
+		Verify that restructuring a non-NPA loan resets DPD to zero
+		without setting any watch period or NPA tagging.
+		"""
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-04-05",
+			posting_date="2024-02-20",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+		)
+
+		process_loan_interest_accrual_for_loans(
+			posting_date="2024-04-04", loan=loan.name, company="_Test Company"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-04-05")
+		process_loan_interest_accrual_for_loans(loan=loan.name, posting_date="2024-04-10")
+		create_process_loan_classification(posting_date="2024-04-11", loan=loan.name)
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date="2024-04-11",
+			repayment_start_date="2024-05-11",
+		)
+
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		loan.load_from_db()
+		self.assertFalse(loan.watch_period_end_date)
+		self.assertEqual(loan.days_past_due, 0)
+		self.assertEqual(loan.is_npa, 0)
+
+	def test_npa_restructure_keeps_classification_same(self):
+		"""
+		Verify that after restructuring an NPA loan, the classification
+		remains unchanged during the active watch period.
+		"""
+
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		customer = frappe.get_doc(get_customer_dict("NPA Restructure 1")).insert()
+		frappe.db.set_value("Loan Product", "Term Loan Product 4", "days_past_due_threshold_for_npa", 90)
+
+		loan = create_loan(
+			customer.name,
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-04-05",
+			posting_date="2024-02-20",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-08-05")
+
+		create_process_loan_classification(posting_date="2024-08-05", loan=loan.name, force_update_dpd_in_loan=1)
+
+		loan.load_from_db()
+		classification_code = loan.classification_code
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date="2024-08-06",
+			repayment_start_date="2024-09-05",
+		)
+
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		loan.load_from_db()
+		self.assertTrue(loan.watch_period_end_date)
+		self.assertEqual(loan.days_past_due, 0)
+		self.assertEqual(loan.is_npa, 1)
+		self.assertEqual(loan.classification_code, classification_code)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-09-05")
+		create_process_loan_classification(posting_date="2024-09-05", loan=loan.name, force_update_dpd_in_loan=1)
+
+		loan.load_from_db()
+
+		watch_period_days = frappe.db.get_value(
+			"Company", "_Test Company", "watch_period_post_loan_restructure_in_days"
+		)
+		watch_period_end_date = add_days("2024-09-05", watch_period_days)
+
+		self.assertEqual(loan.watch_period_end_date, getdate(watch_period_end_date))
+
+	def test_npa_restructure_watch_period_resets_on_dpd(self):
+		"""
+		Verify that when DPD increases after NPA restructuring,
+		the watch period is reset from the new DPD date.
+		"""
+
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		customer = frappe.get_doc(get_customer_dict("NPA Restructure 1")).insert()
+		frappe.db.set_value("Loan Product", "Term Loan Product 4", "days_past_due_threshold_for_npa", 90)
+
+		loan = create_loan(
+			customer.name,
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-04-05",
+			posting_date="2024-02-20",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-08-05")
+
+		create_process_loan_classification(posting_date="2024-08-05", loan=loan.name, force_update_dpd_in_loan=1)
+
+		loan.load_from_db()
+		classification_code = loan.classification_code
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date="2024-08-06",
+			repayment_start_date="2024-09-05",
+		)
+
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		loan.load_from_db()
+		self.assertTrue(loan.watch_period_end_date)
+		self.assertEqual(loan.days_past_due, 0)
+		self.assertEqual(loan.is_npa, 1)
+		self.assertEqual(loan.classification_code, classification_code)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-09-05")
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-09-05")
+		payable_amount = round(float(amounts["payable_amount"] or 0.0), 2)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-09-05", payable_amount)
+		repayment_entry.submit()
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-10-05")
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-10-05")
+		payable_amount = round(float(amounts["payable_amount"] or 0.0), 2)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-10-05", payable_amount)
+		repayment_entry.submit()
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-11-05")
+		create_process_loan_classification(posting_date="2024-11-05", loan=loan.name, force_update_dpd_in_loan=1)
+		loan.load_from_db()
+		watch_period_days = frappe.db.get_value(
+			"Company", "_Test Company", "watch_period_post_loan_restructure_in_days"
+		)
+		watch_period_end_date = add_days("2024-11-05", watch_period_days)
+
+		self.assertEqual(loan.watch_period_end_date, getdate(watch_period_end_date))
 
 
 def create_loan_restructure(

--- a/lending/tests/test_utils.py
+++ b/lending/tests/test_utils.py
@@ -1000,3 +1000,43 @@ def create_loan_refund(
 	doc.submit()
 
 	return doc
+
+
+def loan_classification_ranges():
+	classifications = ["Standard", "Sub-Standard 1", "Sub-Standard 2", "Doubtful 1", "Doubtful 2", "Doubtful 3", "Loss"]
+
+	for classification in classifications:
+		if not frappe.db.exists("Loan Classification", {"classification_code": classification}):
+			frappe.get_doc(
+				{
+					"doctype": "Loan Classification",
+					"classification_code": classification,
+					"classification_name": classification,
+				}
+			).insert(ignore_permissions=True)
+
+	loan_classification_ranges = [
+		{"classification_code": "Standard", "classification_name": "Standard", "min_dpd_range": 0, "max_dpd_range": 0},
+		{"classification_code": "Sub-Standard 1", "classification_name": "Sub-Standard 1", "min_dpd_range": 1, "max_dpd_range": 30},
+		{"classification_code": "Sub-Standard 2", "classification_name": "Sub-Standard 2", "min_dpd_range": 31, "max_dpd_range": 60},
+		{"classification_code": "Doubtful 1", "classification_name": "Doubtful 1", "min_dpd_range": 61, "max_dpd_range": 90},
+		{"classification_code": "Doubtful 2", "classification_name": "Doubtful 2", "min_dpd_range": 91, "max_dpd_range": 120},
+		{"classification_code": "Doubtful 3", "classification_name": "Doubtful 3", "min_dpd_range": 121, "max_dpd_range": 150},
+		{"classification_code": "Loss", "classification_name": "Loss", "min_dpd_range": 151, "max_dpd_range": 300},
+	]
+
+	doc = frappe.get_doc("Company", "_Test Company")
+	doc.days_past_due_threshold = 90
+	doc.watch_period_post_loan_restructure_in_days = 365
+
+	existing_codes = set()
+	for row in (doc.get("loan_classification_ranges") or []):
+		if row.get("classification_code"):
+			existing_codes.add(row.get("classification_code"))
+
+	for row in loan_classification_ranges:
+		if row.get("classification_code") not in existing_codes:
+			doc.append("loan_classification_ranges", row)
+			existing_codes.add(row.get("classification_code"))
+
+	doc.save(ignore_permissions=True)


### PR DESCRIPTION
Fixes issues in loan restructure handling for both NPA and non-NPA cases.

Changes made:
- For non-NPA loans, DPD is reset to zero after restructure without setting NPA status or watch period.
- For NPA loans, classification does not change during the active watch period.
- If DPD becomes 1 after NPA restructure, the watch period is reset based on the demand date.