### PR TITLE
fix: switch to Query Builder in get_partial_pre_paid_interest

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -3039,23 +3039,32 @@ def get_unbooked_interest(loan, posting_date, loan_disbursement=None, last_deman
 
 	return unbooked_interest
 
+
 def get_partial_pre_paid_interest(loan, last_demand_date, loan_disbursement=None):
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
-	filters = {
-		"loan": loan,
-		"docstatus": 1,
-		"demand_type": "EMI",
-		"demand_subtype": "Interest",
-		"is_partial_pre_paid_interest": 1,
-		"demand_date": (">=", last_demand_date),
-	}
+
+	LoanDemand = DocType("Loan Demand")
+
+	query = (
+		frappe.qb.from_(LoanDemand)
+		.select(fn.Sum(LoanDemand.paid_amount))
+		.where(
+			(LoanDemand.loan == loan)
+			& (LoanDemand.docstatus == 1)
+			& (LoanDemand.demand_type == "EMI")
+			& (LoanDemand.demand_subtype == "Interest")
+			& (LoanDemand.is_partial_pre_paid_interest == 1)
+			& (LoanDemand.demand_date >= last_demand_date)
+		)
+	)
 
 	if loan_disbursement:
-		filters["loan_disbursement"] = loan_disbursement
+		query = query.where(LoanDemand.loan_disbursement == loan_disbursement)
 
-	amount = frappe.db.get_value("Loan Demand", filters, [{"SUM": "paid_amount"}]) or 0
+	amount = query.run()[0][0] or 0
 
 	return flt(amount, precision)
+
 
 def get_accrued_interest(
 	loan, posting_date, interest_type="Normal Interest", last_demand_date=None, loan_disbursement=None


### PR DESCRIPTION

The old style:
```py
[{"SUM": "paid_amount"}]
```
does not work properly anymore because Query Builder now expects real field metadata, and "SUM" is not a field. That’s why getting:
```py
AttributeError: 'NoneType' object has no attribute 'fieldtype'
```
<img width="5760" height="2736" alt="image" src="https://github.com/user-attachments/assets/b9b8a7cf-f831-4d5b-8032-cd3254a1b457" />



<br>
<br>
<br>

So I converted the function to the Query Builder style.
