### PR TITLE
perf: move loan write-off waivers, suspense cancellation and classification to background job

### DIFF
--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -97,9 +97,6 @@ class LoanWriteOff(LoanController):
 			)
 
 	def on_submit(self):
-		from lending.loan_management.doctype.process_loan_classification.process_loan_classification import (
-			create_process_loan_classification,
-		)
 		from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 			process_daily_loan_demands,
 		)
@@ -108,15 +105,27 @@ class LoanWriteOff(LoanController):
 			process_daily_loan_demands(self.value_date, loan=self.loan)
 
 		self.process_unbooked_interest()
+		self.make_gl_entries()
+
+		frappe.enqueue(
+			self.process_write_off_waivers_and_classification,
+			enqueue_after_commit=True,
+			queue="long",
+		)
+
+		write_off_charges(self.loan, self.posting_date, self.value_date, self.company, on_write_off=True)
+		self.close_employee_loan()
+		self.update_outstanding_amount_and_status()
+
+	def process_write_off_waivers_and_classification(self):
+		from lending.loan_management.doctype.process_loan_classification.process_loan_classification import (
+			create_process_loan_classification,
+		)
 
 		if not self.is_settlement_write_off:
 			make_loan_waivers(self.loan, self.value_date)
 
-		self.make_gl_entries()
 		self.cancel_suspense_entries()
-		write_off_charges(self.loan, self.posting_date, self.value_date, self.company, on_write_off=True)
-		self.close_employee_loan()
-		self.update_outstanding_amount_and_status()
 
 		create_process_loan_classification(
 			posting_date=self.value_date,


### PR DESCRIPTION
**Issue**

Submitting a Loan Write Off document can take a significant amount of time when the loan has many transactions.

From profiling the `on_submit` flow, the majority of the execution time is spent in the following methods:

* `make_loan_waivers`
* `cancel_suspense_entries`


**For Example:**

* Total submit time: ~25 seconds
* `make_loan_waivers` execution: ~19–20 seconds (≈75–80%)
* `cancel_suspense_entries`: ~3–4 seconds
* Remaining operations: ~1–2 seconds

The `make_loan_waivers` method internally creates Loan Repayment documents.
When a Loan Repayment is created and submitted, several processes are triggered.

Because of this, multiple methods are executed during save and submit, which significantly increases the submission time of Loan Write Off.

**Fix:**

To improve performance, the following heavy operations are moved to a background job:

* `make_loan_waivers`
* `cancel_suspense_entries`
* `create_process_loan_classification`

The submission time is reduced by **~22 seconds**, which results in roughly a **85–90% improvement in response time** for users.