### PR TITLE
fix: recalculate penal interest during loan repayment repost

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -262,18 +262,18 @@ class LoanRepaymentRepost(Document):
 
 			frappe.get_doc(
 				{
-					"doctype": "Process Loan Interest Accrual",
+					"doctype": "Process Loan Demand",
 					"loan": self.loan,
-					"posting_date": add_days(entry.posting_date, -1),
+					"posting_date": entry.posting_date,
 					"loan_disbursement": self.loan_disbursement,
 				}
 			).submit()
 
 			frappe.get_doc(
 				{
-					"doctype": "Process Loan Demand",
+					"doctype": "Process Loan Interest Accrual",
 					"loan": self.loan,
-					"posting_date": entry.posting_date,
+					"posting_date": add_days(entry.posting_date, -1),
 					"loan_disbursement": self.loan_disbursement,
 				}
 			).submit()

--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -9,6 +9,9 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import calcul
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
+from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+	process_loan_interest_accrual_for_loans,
+)
 from lending.tests.test_utils import (
 	create_loan,
 	create_repayment_entry,
@@ -125,3 +128,55 @@ class TestLoanRepaymentRepost(IntegrationTestCase):
 		)
 		for demand in demands:
 			self.assertEqual(demand.outstanding_amount, 0)
+
+	def test_penal_interest_regenerated_after_reposting_repayment(self):
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			500000,
+			"Repay Over Number of Periods",
+			12,
+			"Customer",
+			repayment_start_date="2024-05-05",
+			posting_date="2024-04-01",
+			penalty_charges_rate=25,
+
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-04-01", repayment_start_date="2024-05-05"
+		)
+
+		process_daily_loan_demands(posting_date="2024-05-05", loan=loan.name)
+
+		process_loan_interest_accrual_for_loans(
+			posting_date="2024-05-10", loan=loan.name, company="_Test Company"
+		)
+
+		create_repayment_entry(loan.name, "2024-05-11", 47523.00).submit()
+
+		frappe.get_doc(
+			{
+				"doctype": "Loan Repayment Repost",
+				"loan": loan.name,
+				"repost_date": "2024-05-05",
+				"cancel_future_emi_demands": 1,
+				"cancel_future_accruals_and_demands": 1,
+			}
+		).submit()
+
+		penal_interest = frappe.db.exists(
+			"Loan Interest Accrual",
+			{
+				"loan": loan.name,
+				"posting_date": "2024-05-10",
+				"interest_type": "Penal Interest",
+				"docstatus": 1,
+			},
+		)
+
+		self.assertTrue(penal_interest, "Penal interest should exist after repost")


### PR DESCRIPTION
**Issue:**

When reposting a loan repayment (e.g., from 2024-05-05 to 2024-05-11), penal interest for the period between these dates was being cancelled but not recreated. This happened even though normal interest was properly recalculated.

**Root Cause:**
In `Loan Repayment Repost.trigger_on_submit_events()`, the execution order was:
1. Process Loan Interest Accrual (calculates penal interest)
2. Process Loan Demand (creates demands)

However, penal interest calculation in `calculate_penal_interest_for_loans()` requires unpaid demands to exist. Since demands were being created after interest accrual, no penal interest could be calculated.

**Fix:**
Reversed the execution order in `trigger_on_submit_events()` to ensure demands exist before interest accrual:

1. Process Loan Demand
2. Process Loan Interest Accrual