### PR TITLE
feat: Add Loan doctypes to ignore list during Journal Entry cancellation

### DIFF
--- a/lending/hooks.py
+++ b/lending/hooks.py
@@ -158,6 +158,9 @@ doc_events = {
 	"Custom Field": {
 		"before_insert": "lending.overrides.custom_field.update_dimensions",
 	},
+	"Journal Entry": {
+		"on_cancel": "lending.overrides.journal_entry.add_ignore_linked_doctypes_for_jv",
+	},
 }
 
 accounting_dimension_doctypes = [

--- a/lending/overrides/journal_entry.py
+++ b/lending/overrides/journal_entry.py
@@ -1,0 +1,7 @@
+def add_ignore_linked_doctypes_for_jv(doc, method):
+	existing = getattr(doc, 'ignore_linked_doctypes', ())
+	lending_doctypes = ("Loan", "Loan Transfer", "Loan Interest Accrual")
+	if existing:
+		doc.ignore_linked_doctypes = existing + lending_doctypes
+	else:
+		doc.ignore_linked_doctypes = lending_doctypes


### PR DESCRIPTION
Adds Loan-related doctypes to the ignore list when cancelling Journal Entries. This allows Journal Entries linked to Loans to be cancelled without being blocked by link validation.