### PR TITLE
fix: correct interest calculation for Full Settlement and Write Off Settlement to exclude unbooked interest

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3167,7 +3167,7 @@ class TestLoan(IntegrationTestCase):
 		loan_partner = "Test Loan Partner 1"
 
 		if not frappe.db.exists("Loan Partner", loan_partner):
-			partner = create_loan_partner(
+			create_loan_partner(
 				"Test Loan Partner 1",
 				"Test Loan Partner 1",
 				partner_loan_share_percentage=80,
@@ -3179,7 +3179,6 @@ class TestLoan(IntegrationTestCase):
 				type_of_fldg_applicable="Fixed Deposit Only",
 				fldg_fixed_deposit_percentage=10,
 			)
-			partner.submit()
 
 		posting_date = "2025-01-27"
 		loan = create_loan(

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -264,7 +264,7 @@ class LoanRepayment(LoanController):
 			update_installment_counts(self.against_loan, loan_disbursement=self.loan_disbursement)
 
 		if self.repayment_type == "Full Settlement":
-			if frappe.flags.in_test:
+			if not frappe.flags.in_test:
 				job_name = frappe.enqueue(self.post_write_off_settlements, enqueue_after_commit=True)
 				self.db_set("full_settlement_job", job_name)
 			else:
@@ -683,7 +683,7 @@ class LoanRepayment(LoanController):
 		self.flags.ignore_links = True
 
 		if self.repayment_type == "Full Settlement":
-			if not frappe.flags.in_test:
+			if frappe.flags.in_test:
 				self.cancel_linked_repayments_and_write_off()
 			else:
 				frappe.enqueue(self.cancel_linked_repayments_and_write_off, enqueue_after_commit=True)

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -264,7 +264,7 @@ class LoanRepayment(LoanController):
 			update_installment_counts(self.against_loan, loan_disbursement=self.loan_disbursement)
 
 		if self.repayment_type == "Full Settlement":
-			if not frappe.flags.in_test:
+			if frappe.flags.in_test:
 				job_name = frappe.enqueue(self.post_write_off_settlements, enqueue_after_commit=True)
 				self.db_set("full_settlement_job", job_name)
 			else:

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -683,7 +683,7 @@ class LoanRepayment(LoanController):
 		self.flags.ignore_links = True
 
 		if self.repayment_type == "Full Settlement":
-			if frappe.flags.in_test:
+			if not frappe.flags.in_test:
 				self.cancel_linked_repayments_and_write_off()
 			else:
 				frappe.enqueue(self.cancel_linked_repayments_and_write_off, enqueue_after_commit=True)
@@ -2928,9 +2928,14 @@ def calculate_amounts(
 	# update values for closure
 	if payment_type in ("Loan Closure", "Full Settlement", "Write Off Settlement"):
 		amounts["payable_principal_amount"] = amounts["pending_principal_amount"]
-		amounts["interest_amount"] = (
-			amounts["interest_amount"] + amounts["unbooked_interest"] + amounts["unaccrued_interest"]
-		)
+
+		if payment_type in ("Full Settlement", "Write Off Settlement"):
+			amounts["interest_amount"] = amounts["interest_amount"]
+		else:
+			amounts["interest_amount"] = (
+				amounts["interest_amount"] + amounts["unbooked_interest"] + amounts["unaccrued_interest"]
+			)
+
 		amounts["penalty_amount"] = amounts["penalty_amount"] + amounts["unbooked_penalty"]
 		amounts["payable_amount"] = (
 			amounts["payable_principal_amount"]

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -3,6 +3,7 @@
 
 
 import traceback
+from datetime import date, datetime
 
 import frappe
 from frappe import _
@@ -2885,13 +2886,13 @@ def get_all_demands(loans, posting_date):
 
 @frappe.whitelist()
 def calculate_amounts(
-	against_loan,
-	posting_date,
-	payment_type="",
-	with_loan_details=False,
-	charges=None,
-	loan_disbursement=None,
-	for_update=False,
+	against_loan: str,
+	posting_date: str | date | datetime,
+	payment_type: str | None = None,
+	with_loan_details: bool = False,
+	charges: list[str] | None = None,
+	loan_disbursement: str | None = None,
+	for_update: bool = False,
 ):
 	amounts = init_amounts()
 

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1302,6 +1302,61 @@ class TestLoanRepayment(IntegrationTestCase):
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Settled")
 
+	def test_full_settlement_creates_waiver_and_write_off(self):
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			2000000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date="2024-08-05",
+			posting_date="2024-07-05",
+			rate_of_interest=22,
+			applicant_type="Customer",
+		)
+
+		loan.submit()
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-07-05", repayment_start_date="2024-08-05"
+		)
+
+		process_daily_loan_demands(posting_date="2024-09-05", loan=loan.name)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2024-09-05", company="_Test Company"
+		)
+
+		repayment_entry_1 = create_repayment_entry(
+			loan.name, "2024-09-05 17:24:18", 374378.00, repayment_type="Normal Repayment"
+		)
+		repayment_entry_1.submit()
+		repayment_entry_1.cancel()
+
+		repayment_entry_2 = create_repayment_entry(
+			loan.name, "2024-09-05 17:24:18", 1000000, repayment_type="Full Settlement"
+		)
+		repayment_entry_2.submit()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Settled")
+
+		loan_repayment = frappe.db.get_value(
+			"Loan Repayment",
+			{"repayment_type": "Interest Waiver", "against_loan": loan.name, "docstatus": 1},
+			"name",
+		)
+		self.assertTrue(loan_repayment, "Interest waiver entry not created")
+
+		loan_writer_off = frappe.db.get_value(
+			"Loan Write Off",
+			{"loan": loan.name, "docstatus": 1},
+			"name",
+		)
+		self.assertTrue(loan_writer_off, "Loan write off entry not created")
+
+
 	def test_loan_auto_closure_with_charge_under_limit(self):
 		frappe.db.set_value("Loan Product", "Term Loan Product 4", "write_off_amount", 1000)
 

--- a/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
@@ -251,7 +251,7 @@ class TestLoanRepaymentSchedule(IntegrationTestCase):
 	def test_pre_payment_restructure_with_loan_partner_and_bpi(self):
 		loan_partner = "Test Loan Partner 1"
 		if not frappe.db.exists("Loan Partner", loan_partner):
-			partner = create_loan_partner(
+			create_loan_partner(
 				"Test Loan Partner 1",
 				"Test Loan Partner 1",
 				partner_loan_share_percentage=80,
@@ -263,7 +263,6 @@ class TestLoanRepaymentSchedule(IntegrationTestCase):
 				type_of_fldg_applicable="Fixed Deposit Only",
 				fldg_fixed_deposit_percentage=10,
 			)
-			partner.submit()
 
 		loan = create_loan(
 			"_Test Customer 1",


### PR DESCRIPTION
**Issue:**
When processing Full Settlement or Write Off Settlement transactions, calculate_amounts() was adding unbooked_interest and unaccrued_interest to the payable interest amount. However, these amounts are later reversed during on_submit() via reverse_loan_interest_accruals(). This mismatch caused validation errors because the system expected payment for interest that would ultimately be reversed.

https://github.com/frappe/lending/blob/3f032c91a7c052892ad1002191b0248fe8cda8e5/lending/loan_management/doctype/loan_repayment/loan_repayment.py#L295-L304

**Fix:**
Modified calculate_amounts() to handle interest calculation differently based on payment type:

Full Settlement & Write Off Settlement: Only include demanded interest (unbooked/unaccrued interest excluded since they will be reversed)