### PR TITLE
fix: initialize value_date before calculate_amounts call in loan repayment

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -117,6 +117,11 @@ class LoanRepayment(LoanController):
 			self.check_import_total_amount()
 			return
 
+		self.posting_date = get_datetime()
+
+		if not self.value_date:
+			self.value_date = get_datetime()
+
 		charges = None
 		if self.get("payable_charges"):
 			if self.repayment_type == "Charge Payment":
@@ -797,11 +802,6 @@ class LoanRepayment(LoanController):
 
 	def set_missing_values(self, amounts):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
-
-		self.posting_date = get_datetime()
-
-		if not self.value_date:
-			self.value_date = get_datetime()
 
 		if not self.cost_center:
 			self.cost_center = erpnext.get_default_cost_center(self.company)


### PR DESCRIPTION
**Issue:**
Loan Repayment creation was failing with FrappeTypeError after introducing type annotations for whitelisted methods.

**Error:**
Argument 'posting_date' should be of type 'str | datetime.date | datetime.datetime' but got 'NoneType'.

**Root Cause:**
In the Loan Repayment validate flow, calculate_amounts() was being called with self.value_date before it was initialized.
value_date was only being set later in set_missing_values(), causing None to be passed.

This issue was previously hidden because there was no strict type validation. After introducing type annotations and Pydantic validation, passing None now raises an exception.

Fix:
Initialize posting_date and value_date before calling calculate_amounts() in validate().