### PR TITLE
feat: Add loan restructure charges table for individual charge handling

### DIFF
--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -608,6 +608,7 @@ def make_credit_note(
 	si.set_posting_time = 1
 	si.posting_date = posting_date
 	si.value_date = value_date
+	si.debit_to = frappe.db.get_value("Sales Invoice", sales_invoice, "debit_to")
 
 	rate = 0
 	income_account = ""

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -578,7 +578,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "total_charges_payable",
+   "depends_on": "eval: (doc.repayment_type == \"Charges Waiver\" || doc.repayment_type == \"Charges Capitalization\") && doc.loan_restructure",
    "fieldname": "charges",
    "fieldtype": "Data",
    "label": "Charges",
@@ -588,7 +588,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-25 15:45:20.994676",
+ "modified": "2026-03-27 10:23:03.742260",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -38,7 +38,6 @@
   "interest_payable",
   "payable_amount",
   "total_charges_payable",
-  "charges",
   "column_break_9",
   "shortfall_amount",
   "payable_principal_amount",
@@ -576,19 +575,12 @@
    "hidden": 1,
    "label": "Is Invoice generated",
    "read_only": 1
-  },
-  {
-   "depends_on": "eval: (doc.repayment_type == \"Charges Waiver\" || doc.repayment_type == \"Charges Capitalization\") && doc.loan_restructure",
-   "fieldname": "charges",
-   "fieldtype": "Data",
-   "label": "Charges",
-   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-27 10:23:03.742260",
+ "modified": "2026-03-30 07:46:26.499215",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -38,6 +38,7 @@
   "interest_payable",
   "payable_amount",
   "total_charges_payable",
+  "charges",
   "column_break_9",
   "shortfall_amount",
   "payable_principal_amount",
@@ -575,12 +576,19 @@
    "hidden": 1,
    "label": "Is Invoice generated",
    "read_only": 1
+  },
+  {
+   "depends_on": "total_charges_payable",
+   "fieldname": "charges",
+   "fieldtype": "Data",
+   "label": "Charges",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-17 11:01:14.744467",
+ "modified": "2026-03-25 15:45:20.994676",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -125,10 +125,10 @@ class LoanRepayment(LoanController):
 
 		charges = None
 		if self.get("payable_charges"):
-			if self.repayment_type == "Charge Payment":
+			if self.repayment_type == "Charge Payment" or (self.repayment_type in ("Charges Waiver", "Charges Capitalization") and self.loan_restructure):
 				charges = [d.get("charge_code") for d in self.get("payable_charges")]
 			else:
-				frappe.throw(_("Payable Charges can only be added if Charge Payment"))
+				frappe.throw(_("Payable Charges can only be added if Charge Payment, or for Charges Waiver/Capitalization during Loan Restructure"))
 
 		amounts = calculate_amounts(
 			self.against_loan,
@@ -1495,7 +1495,7 @@ class LoanRepayment(LoanController):
 		amounts = self.update_amounts_for_write_off_recovery(loan_status, amounts)
 		amount_paid = self.amount_paid
 
-		if self.repayment_type == "Charge Payment":
+		if self.repayment_type == "Charge Payment" or (self.repayment_type in ("Charges Waiver", "Charges Capitalization") and self.loan_restructure):
 			amount_paid = self.allocate_charges(amount_paid, amounts.get("unpaid_demands"))
 		else:
 			amount_paid = self.allocate_amount_against_demands(loan_status, amounts, amount_paid)
@@ -1723,24 +1723,15 @@ class LoanRepayment(LoanController):
 		else:
 			allocation_order = self.get_allocation_order("Collection Offset Sequence for Standard Asset")
 
-		if self.repayment_type in ["Charges Waiver", "Charges Capitalization"] and self.loan_restructure and self.charges:
-			charges_demands = [d for d in amounts.get("unpaid_demands") if d.demand_type == "Charges" and d.demand_subtype == self.charges]
-
-			# Apply allocation order only for these specific charges
-			amount_paid = self.apply_allocation_order(
-				allocation_order, amount_paid, charges_demands, status=loan_status
-			)
-		else:
-			# Normal allocation for all demands
-			amount_paid = self.apply_allocation_order(
-				allocation_order, amount_paid, amounts.get("unpaid_demands"), status=loan_status
-			)
-
 		if self.shortfall_amount:
 			if self.amount_paid > self.shortfall_amount:
 				self.principal_amount_paid = self.shortfall_amount
 			else:
 				self.principal_amount_paid = self.amount_paid
+
+		amount_paid = self.apply_allocation_order(
+			allocation_order, amount_paid, amounts.get("unpaid_demands"), status=loan_status
+		)
 
 		for payment in self.repayment_details:
 			if payment.demand_subtype == "Interest":

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1700,40 +1700,6 @@ class LoanRepayment(LoanController):
 	def allocate_amount_against_demands(self, loan_status, amounts, amount_paid):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-		# # For Charges Waiver and Charges Capitalization, we need to allocate to specific charges
-		# if self.repayment_type in ["Charges Waiver", "Charges Capitalization"]:
-		# 	# Get only charges demands
-		# 	charges_demands = [d for d in amounts.get("unpaid_demands") if d.demand_type == "Charges"]
-
-		# 	# If specific charges are specified, filter them
-		# 	if hasattr(self, 'charges') and self.charges:
-		# 		specific_charges = self.charges if isinstance(self.charges, list) else [self.charges]
-		# 		charges_demands = [d for d in charges_demands if d.demand_subtype in specific_charges]
-
-		# 	# Allocate amount to these specific charges
-		# 	for demand in charges_demands:
-		# 		if amount_paid > 0:
-		# 			if amount_paid >= demand.outstanding_amount:
-		# 				paid_amount = demand.outstanding_amount
-		# 			else:
-		# 				paid_amount = amount_paid
-
-		# 			self.append(
-		# 				"repayment_details",
-		# 				{
-		# 					"loan_demand": demand.name,
-		# 					"paid_amount": paid_amount,
-		# 					"demand_type": "Charges",
-		# 					"demand_subtype": demand.demand_subtype,
-		# 					"sales_invoice": demand.sales_invoice,
-		# 				},
-		# 			)
-
-		# 			self.total_charges_paid += paid_amount
-		# 			amount_paid -= paid_amount
-
-		# 	return amount_paid
-
 		if loan_status == "Written Off":
 			allocation_order = self.get_allocation_order(
 				"Collection Offset Sequence for Written Off Asset"

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -54,7 +54,6 @@ class LoanRepayment(LoanController):
 		applicant_type: DF.Literal["Employee", "Member", "Customer"]
 		bank_account: DF.Link | None
 		bulk_repayment_log: DF.Link | None
-		charges: DF.Data | None
 		clearance_date: DF.Date | None
 		company: DF.Link | None
 		cost_center: DF.Link | None

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -54,6 +54,7 @@ class LoanRepayment(LoanController):
 		applicant_type: DF.Literal["Employee", "Member", "Customer"]
 		bank_account: DF.Link | None
 		bulk_repayment_log: DF.Link | None
+		charges: DF.Data | None
 		clearance_date: DF.Date | None
 		company: DF.Link | None
 		cost_center: DF.Link | None
@@ -1699,6 +1700,40 @@ class LoanRepayment(LoanController):
 	def allocate_amount_against_demands(self, loan_status, amounts, amount_paid):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
+		# # For Charges Waiver and Charges Capitalization, we need to allocate to specific charges
+		# if self.repayment_type in ["Charges Waiver", "Charges Capitalization"]:
+		# 	# Get only charges demands
+		# 	charges_demands = [d for d in amounts.get("unpaid_demands") if d.demand_type == "Charges"]
+
+		# 	# If specific charges are specified, filter them
+		# 	if hasattr(self, 'charges') and self.charges:
+		# 		specific_charges = self.charges if isinstance(self.charges, list) else [self.charges]
+		# 		charges_demands = [d for d in charges_demands if d.demand_subtype in specific_charges]
+
+		# 	# Allocate amount to these specific charges
+		# 	for demand in charges_demands:
+		# 		if amount_paid > 0:
+		# 			if amount_paid >= demand.outstanding_amount:
+		# 				paid_amount = demand.outstanding_amount
+		# 			else:
+		# 				paid_amount = amount_paid
+
+		# 			self.append(
+		# 				"repayment_details",
+		# 				{
+		# 					"loan_demand": demand.name,
+		# 					"paid_amount": paid_amount,
+		# 					"demand_type": "Charges",
+		# 					"demand_subtype": demand.demand_subtype,
+		# 					"sales_invoice": demand.sales_invoice,
+		# 				},
+		# 			)
+
+		# 			self.total_charges_paid += paid_amount
+		# 			amount_paid -= paid_amount
+
+		# 	return amount_paid
+
 		if loan_status == "Written Off":
 			allocation_order = self.get_allocation_order(
 				"Collection Offset Sequence for Written Off Asset"
@@ -1722,15 +1757,24 @@ class LoanRepayment(LoanController):
 		else:
 			allocation_order = self.get_allocation_order("Collection Offset Sequence for Standard Asset")
 
+		if self.repayment_type in ["Charges Waiver", "Charges Capitalization"] and self.loan_restructure and self.charges:
+			charges_demands = [d for d in amounts.get("unpaid_demands") if d.demand_type == "Charges" and d.demand_subtype == self.charges]
+
+			# Apply allocation order only for these specific charges
+			amount_paid = self.apply_allocation_order(
+				allocation_order, amount_paid, charges_demands, status=loan_status
+			)
+		else:
+			# Normal allocation for all demands
+			amount_paid = self.apply_allocation_order(
+				allocation_order, amount_paid, amounts.get("unpaid_demands"), status=loan_status
+			)
+
 		if self.shortfall_amount:
 			if self.amount_paid > self.shortfall_amount:
 				self.principal_amount_paid = self.shortfall_amount
 			else:
 				self.principal_amount_paid = self.amount_paid
-
-		amount_paid = self.apply_allocation_order(
-			allocation_order, amount_paid, amounts.get("unpaid_demands"), status=loan_status
-		)
 
 		for payment in self.repayment_details:
 			if payment.demand_subtype == "Interest":

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.json
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.json
@@ -51,7 +51,6 @@
   "interest_overdue",
   "unaccrued_interest",
   "penalty_overdue",
-  "charges_overdue",
   "column_break_jvss",
   "adjusted_interest_amount",
   "adjusted_unaccrued_interest",
@@ -59,17 +58,16 @@
   "interest_waiver_amount",
   "unaccrued_interest_waiver",
   "penal_interest_waiver",
-  "other_charges_waiver",
   "column_break_ujcs",
   "balance_interest_amount",
   "balance_unaccrued_interest",
   "balance_penalty_amount",
-  "balance_charges",
   "column_break_x8or",
   "treatment_of_normal_interest",
   "unaccrued_interest_treatment",
   "treatment_of_penal_interest",
-  "treatment_of_other_charges",
+  "section_break_ulrx",
+  "loan_restructure_charges",
   "loan_restructure_details_section",
   "new_rate_of_interest",
   "repayment_start_date",
@@ -185,12 +183,6 @@
    "options": "Company:company:default_currency"
   },
   {
-   "fieldname": "other_charges_waiver",
-   "fieldtype": "Currency",
-   "label": "Other Charges Waiver",
-   "options": "Company:company:default_currency"
-  },
-  {
    "fieldname": "total_overdue_amount",
    "fieldtype": "Currency",
    "label": "Total Overdue Amount",
@@ -208,13 +200,6 @@
    "fieldname": "interest_overdue",
    "fieldtype": "Currency",
    "label": "Interest Overdue",
-   "options": "Company:company:default_currency",
-   "read_only": 1
-  },
-  {
-   "fieldname": "charges_overdue",
-   "fieldtype": "Currency",
-   "label": "Charges Overdue",
    "options": "Company:company:default_currency",
    "read_only": 1
   },
@@ -335,13 +320,6 @@
    "options": "Capitalize\nCarry Forward"
   },
   {
-   "default": "Capitalize",
-   "fieldname": "treatment_of_other_charges",
-   "fieldtype": "Select",
-   "label": "Charges Treatment",
-   "options": "Capitalize\nCarry Forward"
-  },
-  {
    "default": "Add To First EMI",
    "fieldname": "treatment_of_normal_interest",
    "fieldtype": "Select",
@@ -389,13 +367,6 @@
   },
   {
    "fieldname": "balance_penalty_amount",
-   "fieldtype": "Currency",
-   "label": "Balance Amount",
-   "options": "Company:company:default_currency",
-   "read_only": 1
-  },
-  {
-   "fieldname": "balance_charges",
    "fieldtype": "Currency",
    "label": "Balance Amount",
    "options": "Company:company:default_currency",
@@ -538,12 +509,22 @@
    "hidden": 1,
    "label": "Is NPA",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_ulrx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "loan_restructure_charges",
+   "fieldtype": "Table",
+   "label": "Loan Restructure Charges",
+   "options": "Loan Restructure Charges"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-12 11:55:29.308410",
+ "modified": "2026-03-27 10:03:31.735055",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure",

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -760,7 +760,7 @@ class LoanRestructure(AccountsController):
 					"Charges Waiver",
 					charge.other_charges_waiver,
 					restructure_name=self.name,
-					charges=charge.charge
+					charge_code=charge.charge
 				)
 
 			if charge.treatment_of_other_charges == "Capitalize" and flt(charge.balance_charges) > 0:
@@ -770,7 +770,7 @@ class LoanRestructure(AccountsController):
 					"Charges Capitalization",
 					charge.balance_charges,
 					restructure_name=self.name,
-					charges=charge.charge
+					charge_code=charge.charge
 				)
 
 	def set_principal_adjustment_on_restructure(self):
@@ -812,7 +812,7 @@ def create_loan_repayment(
 	is_write_off_waiver=0,
 	payment_account=None,
 	loan_disbursement=None,
-	charges=None,
+	charge_code=None,
 ):
 	repayment = frappe.new_doc("Loan Repayment")
 	repayment.offset_based_on_npa = 1
@@ -825,7 +825,13 @@ def create_loan_repayment(
 	repayment.is_write_off_waiver = is_write_off_waiver
 	repayment.payment_account = payment_account
 	repayment.loan_disbursement = loan_disbursement
-	repayment.charges = charges
+
+	if charge_code and waiver_amount > 0:
+		repayment.append("payable_charges", {
+			"charge_code": charge_code,
+			"amount": waiver_amount
+		})
+
 	repayment.save()
 	repayment.submit()
 	return repayment

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -540,13 +540,16 @@ class LoanRestructure(AccountsController):
 			overdue = flt(charge.get("charges_overdue"), precision)
 			capitalize_amount = flt(charge.get("capitalize_amount"), precision)
 
+			if capitalize_amount < 0:
+				frappe.throw(_("Capitalize amount for charge {0} cannot be negative").format(charge.charge))
+
 			if capitalize_amount > overdue:
 				frappe.throw(_("Capitalize amount for charge {0} cannot exceed overdue amount {1}").format(
 					charge.charge, overdue
 				))
 
 			charge.charges_waiver_amount = flt(overdue - capitalize_amount, precision)
-			charge.balance_charges = flt(overdue - capitalize_amount, precision)
+			charge.balance_charges = flt(capitalize_amount, precision)
 
 	def update_restructured_loan_details(self):
 		if not self.new_rate_of_interest:

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -416,7 +416,7 @@ class LoanRestructure(AccountsController):
 			frappe.throw(_("Interest Waiver Amount cannot be greater than overdue interest"))
 
 		for charge in self.get("loan_restructure_charges"):
-			if flt(charge.other_charges_waiver) > flt(charge.charges_overdue):
+			if flt(charge.charges_waiver_amount) > flt(charge.charges_overdue):
 				frappe.throw(_("Waiver amount for charge {0} cannot exceed overdue amount {1}").format(
 					charge.charge, charge.charges_overdue
 				))
@@ -441,7 +441,8 @@ class LoanRestructure(AccountsController):
 				merged_charges[charge_type] = {
 					"charge": charge_type,
 					"charges_overdue": 0,
-					"other_charges_waiver": 0,
+					"capitalize_amount": 0,
+					"charges_waiver_amount": 0,
 					"balance_charges": 0,
 					"treatment_of_other_charges": "Capitalize" if self.restructure_type == "Normal Restructure" else "Carry Forward",
 				}
@@ -536,9 +537,16 @@ class LoanRestructure(AccountsController):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
 		for charge in self.get("loan_restructure_charges"):
-			overdue = flt(charge.get("charges_overdue"))
-			waiver = flt(charge.get("other_charges_waiver"))
-			charge.balance_charges = flt(overdue - waiver, precision)
+			overdue = flt(charge.get("charges_overdue"), precision)
+			capitalize_amount = flt(charge.get("capitalize_amount"), precision)
+
+			if capitalize_amount > overdue:
+				frappe.throw(_("Capitalize amount for charge {0} cannot exceed overdue amount {1}").format(
+					charge.charge, overdue
+				))
+
+			charge.charges_waiver_amount = flt(overdue - capitalize_amount, precision)
+			charge.balance_charges = flt(overdue - capitalize_amount, precision)
 
 	def update_restructured_loan_details(self):
 		if not self.new_rate_of_interest:
@@ -753,22 +761,22 @@ class LoanRestructure(AccountsController):
 
 	def make_waiver_and_capitalization_for_charges(self):
 		for charge in self.get("loan_restructure_charges"):
-			if flt(charge.other_charges_waiver) > 0:
+			if flt(charge.charges_waiver_amount) > 0:
 				create_loan_repayment(
 					self.loan,
 					self.restructure_date,
 					"Charges Waiver",
-					charge.other_charges_waiver,
+					charge.charges_waiver_amount,
 					restructure_name=self.name,
 					charge_code=charge.charge
 				)
 
-			if charge.treatment_of_other_charges == "Capitalize" and flt(charge.balance_charges) > 0:
+			if flt(charge.capitalize_amount) > 0 and charge.treatment_of_other_charges == "Capitalize":
 				create_loan_repayment(
 					self.loan,
 					self.restructure_date,
 					"Charges Capitalization",
-					charge.balance_charges,
+					charge.capitalize_amount,
 					restructure_name=self.name,
 					charge_code=charge.charge
 				)

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -28,18 +28,20 @@ class LoanRestructure(AccountsController):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from lending.loan_management.doctype.loan_restructure_charges.loan_restructure_charges import (
+			LoanRestructureCharges,
+		)
+
 		adjusted_interest_amount: DF.Currency
 		adjusted_unaccrued_interest: DF.Currency
 		amended_from: DF.Link | None
 		applicant: DF.DynamicLink | None
 		applicant_type: DF.Literal["Employee", "Member", "Customer"]
 		available_security_deposit: DF.Currency
-		balance_charges: DF.Currency
 		balance_interest_amount: DF.Currency
 		balance_penalty_amount: DF.Currency
 		balance_principal: DF.Currency
 		balance_unaccrued_interest: DF.Currency
-		charges_overdue: DF.Currency
 		company: DF.Link | None
 		completed_tenure: DF.Int
 		current_restructure_count: DF.Int
@@ -51,6 +53,7 @@ class LoanRestructure(AccountsController):
 		loan_disbursement: DF.Link | None
 		loan_product: DF.Link | None
 		loan_repayment: DF.Link | None
+		loan_restructure_charges: DF.Table[LoanRestructureCharges]
 		moratorium_end_date: DF.Date | None
 		new_loan_amount: DF.Currency
 		new_monthly_repayment_amount: DF.Currency
@@ -62,7 +65,6 @@ class LoanRestructure(AccountsController):
 		old_rate_of_interest: DF.Percent
 		old_repayment_frequency: DF.Data | None
 		old_tenure: DF.Int
-		other_charges_waiver: DF.Currency
 		penal_interest_waiver: DF.Currency
 		penalty_overdue: DF.Currency
 		pending_principal_amount: DF.Currency
@@ -80,7 +82,6 @@ class LoanRestructure(AccountsController):
 		total_overdue_amount: DF.Currency
 		total_principal_paid: DF.Currency
 		treatment_of_normal_interest: DF.Literal["Capitalize", "Add To First EMI"]
-		treatment_of_other_charges: DF.Literal["Capitalize", "Carry Forward"]
 		treatment_of_penal_interest: DF.Literal["Capitalize", "Carry Forward"]
 		unaccrued_interest: DF.Currency
 		unaccrued_interest_treatment: DF.Literal["Capitalize", "Add To First EMI"]
@@ -95,6 +96,7 @@ class LoanRestructure(AccountsController):
 		self.update_overdue_amounts()
 		self.allocate_security_deposit()
 		self.validate_waiver_amount()
+		self.fetch_charges_details()
 		self.calculate_balance_amounts()
 		self.set_missing_values()
 		self.validate_repayment_start_date()
@@ -185,7 +187,6 @@ class LoanRestructure(AccountsController):
 		self.balance_penalty_amount = flt(
 			flt(self.penalty_overdue) - flt(self.penal_interest_waiver), precision
 		)
-		self.balance_charges = flt(flt(self.charges_overdue) - flt(self.other_charges_waiver), precision)
 
 	def validate_repayment_start_date(self):
 		if getdate(self.repayment_start_date) < getdate(self.restructure_date):
@@ -239,8 +240,9 @@ class LoanRestructure(AccountsController):
 			):
 				self.new_loan_amount += flt(self.balance_penalty_amount)
 
-			if self.treatment_of_other_charges == "Capitalize":
-				self.new_loan_amount += flt(self.balance_charges)
+			for charge in self.get("loan_restructure_charges"):
+				if charge.treatment_of_other_charges == "Capitalize" and charge.balance_charges > 0:
+					self.new_loan_amount += flt(charge.balance_charges)
 
 		self.new_loan_amount = flt(self.new_loan_amount, 2)
 
@@ -365,7 +367,6 @@ class LoanRestructure(AccountsController):
 		self.principal_overdue = flt(amounts.get("payable_principal_amount"), precision)
 		self.interest_overdue = flt(amounts.get("interest_amount"), precision)
 		self.penalty_overdue = flt(amounts.get("penalty_amount"), precision)
-		self.charges_overdue = flt(amounts.get("total_charges_payable"), precision)
 		self.unaccrued_interest = flt(
 			flt(amounts.get("unaccrued_interest"), precision)
 			+ flt(amounts.get("unbooked_interest"), precision),
@@ -376,6 +377,8 @@ class LoanRestructure(AccountsController):
 			self.unaccrued_interest = 0
 
 		self.available_security_deposit = flt(amounts.get("available_security_deposit"), precision)
+
+		self.fetch_charges_details(amounts.get("unpaid_demands", []))
 
 	def cancel_repayment_schedule(self):
 
@@ -412,8 +415,11 @@ class LoanRestructure(AccountsController):
 		):
 			frappe.throw(_("Interest Waiver Amount cannot be greater than overdue interest"))
 
-		if flt(self.other_charges_waiver) > flt(self.charges_overdue):
-			frappe.throw(_("Other Charges Waiver cannot be greater than overdue charges"))
+		for charge in self.get("loan_restructure_charges"):
+			if flt(charge.other_charges_waiver) > flt(charge.charges_overdue):
+				frappe.throw(_("Waiver amount for charge {0} cannot exceed overdue amount {1}").format(
+					charge.charge, charge.charges_overdue
+				))
 
 		if flt(self.penal_interest_waiver) > flt(self.penalty_overdue):
 			frappe.throw(_("Penalty Waiver cannot be greater than overdue penalty interest"))
@@ -422,6 +428,117 @@ class LoanRestructure(AccountsController):
 			self.unaccrued_interest
 		) - flt(self.adjusted_unaccrued_interest):
 			frappe.throw(_("Unaccrued Interest Waiver cannot be greater than overdue amount"))
+
+	def get_charges_details(self, unpaid_demands):
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
+		charges_demands = [d for d in unpaid_demands if d.get("demand_type") == "Charges"]
+
+		merged_charges = {}
+		for demand in charges_demands:
+			charge_type = demand.get("demand_subtype")
+			if charge_type not in merged_charges:
+				merged_charges[charge_type] = {
+					"charge": charge_type,
+					"charges_overdue": 0,
+					"other_charges_waiver": 0,
+					"balance_charges": 0,
+					"treatment_of_other_charges": "Capitalize" if self.restructure_type == "Normal Restructure" else "Carry Forward",
+				}
+			merged_charges[charge_type]["charges_overdue"] += flt(demand.get("outstanding_amount"), precision)
+			merged_charges[charge_type]["balance_charges"] += flt(demand.get("outstanding_amount"), precision)
+
+		charges_details = []
+		for charge_data in merged_charges.values():
+			charges_details.append(charge_data)
+
+		return charges_details
+
+	def fetch_charges_details(self, unpaid_demands=None):
+		if self.restructure_type != "Normal Restructure":
+			return
+
+		if unpaid_demands is None:
+			return
+
+		current_charges = self.get_charges_details(unpaid_demands)
+
+		existing_charges_map = {}
+		for charge_row in self.get("loan_restructure_charges"):
+			existing_charges_map[charge_row.charge] = charge_row
+
+		processed_charges = set()
+
+		for charge_detail in current_charges:
+			charge_type = charge_detail.get("charge")
+			processed_charges.add(charge_type)
+
+			if charge_type in existing_charges_map:
+				existing_row = existing_charges_map[charge_type]
+
+				if existing_row.get("charges_overdue") != charge_detail.get("charges_overdue"):
+					existing_row.charges_overdue = charge_detail.get("charges_overdue")
+			else:
+				self.append("loan_restructure_charges", charge_detail)
+
+		charges_to_remove = []
+		for charge_row in self.get("loan_restructure_charges"):
+			if charge_row.get("charge") not in processed_charges:
+				charges_to_remove.append(charge_row)
+
+		for charge_row in charges_to_remove:
+			self.remove(charge_row)
+
+		self.validate_charges_total(unpaid_demands)
+		self.calculate_balance_charges()
+
+	def validate_charges_total(self, unpaid_demands):
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
+		charges_demands = [d for d in unpaid_demands if d.get("demand_type") == "Charges"]
+
+		actual_map = {}
+		for demand in charges_demands:
+			charge_type = demand.get("demand_subtype")
+			if charge_type not in actual_map:
+				actual_map[charge_type] = 0
+			actual_map[charge_type] += flt(demand.get("outstanding_amount"), precision)
+
+		table_map = {}
+		for charge_row in self.get("loan_restructure_charges"):
+			charge_type = charge_row.get("charge")
+			if not charge_type:
+				continue
+
+			charges_overdue = flt(charge_row.get("charges_overdue"), precision)
+			table_map[charge_type] = table_map.get(charge_type, 0) + charges_overdue
+
+		for charge_type, table_total in table_map.items():
+			if charge_type not in actual_map:
+				frappe.throw(_("Charge {0} does not exist in unpaid demands").format(charge_type))
+
+			actual_total = actual_map.get(charge_type)
+
+			if flt(table_total, precision) != flt(actual_total, precision):
+				frappe.throw(_(
+					"Total overdue amount for charge {0} is {1}, but table shows {2}. "
+					"Please remove the duplicate charges and refresh the page."
+				).format(charge_type, actual_total, table_total))
+
+		for charge_type, actual_total in actual_map.items():
+			if charge_type not in table_map:
+				frappe.throw(_(
+					"Charge {0} with overdue amount {1} is missing from the charges table. "
+					"Please refresh the page to get latest charges."
+				).format(charge_type, actual_total))
+
+	def calculate_balance_charges(self):
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
+		for charge in self.get("loan_restructure_charges"):
+			overdue = flt(charge.get("charges_overdue"))
+			waiver = flt(charge.get("other_charges_waiver"))
+			charge.balance_charges = flt(overdue - waiver, precision)
 
 	def update_restructured_loan_details(self):
 		if not self.new_rate_of_interest:
@@ -635,23 +752,26 @@ class LoanRestructure(AccountsController):
 			)
 
 	def make_waiver_and_capitalization_for_charges(self):
-		if self.balance_charges and self.treatment_of_other_charges == "Capitalize":
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Charges Capitalization",
-				self.balance_charges,
-				restructure_name=self.name,
-			)
+		for charge in self.get("loan_restructure_charges"):
+			if flt(charge.other_charges_waiver) > 0:
+				create_loan_repayment(
+					self.loan,
+					self.restructure_date,
+					"Charges Waiver",
+					charge.other_charges_waiver,
+					restructure_name=self.name,
+					charges=charge.charge
+				)
 
-		if self.other_charges_waiver:
-			create_loan_repayment(
-				self.loan,
-				self.restructure_date,
-				"Charges Waiver",
-				self.other_charges_waiver,
-				restructure_name=self.name,
-			)
+			if charge.treatment_of_other_charges == "Capitalize" and flt(charge.balance_charges) > 0:
+				create_loan_repayment(
+					self.loan,
+					self.restructure_date,
+					"Charges Capitalization",
+					charge.balance_charges,
+					restructure_name=self.name,
+					charges=charge.charge
+				)
 
 	def set_principal_adjustment_on_restructure(self):
 		if flt(self.principal_overdue) > 0 and flt(self.principal_adjusted) == 0:
@@ -692,6 +812,7 @@ def create_loan_repayment(
 	is_write_off_waiver=0,
 	payment_account=None,
 	loan_disbursement=None,
+	charges=None,
 ):
 	repayment = frappe.new_doc("Loan Repayment")
 	repayment.offset_based_on_npa = 1
@@ -704,6 +825,7 @@ def create_loan_repayment(
 	repayment.is_write_off_waiver = is_write_off_waiver
 	repayment.payment_account = payment_account
 	repayment.loan_disbursement = loan_disbursement
+	repayment.charges = charges
 	repayment.save()
 	repayment.submit()
 	return repayment

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -235,8 +235,8 @@ class TestLoanRestructure(IntegrationTestCase):
 			restructure_date="2024-04-11",
 			interest_waiver_amount=500,
 			loan_restructure_charges=[
-				{"charge": "Processing Fee", "other_charges_waiver": 500, "treatment_of_other_charges": "Capitalize"},
-				{"charge": "Documentation Charge", "other_charges_waiver": 0, "treatment_of_other_charges": "Capitalize"},
+				{"charge": "Processing Fee", "capitalize_amount": 6000, "treatment_of_other_charges": "Capitalize"},
+				{"charge": "Documentation Charge", "capitalize_amount": 2500, "treatment_of_other_charges": "Capitalize"},
 			],
 		)
 		loan_restructure.status = "Approved"
@@ -591,7 +591,7 @@ def create_loan_restructure(
 				"loan_restructure_charges",
 				{
 					"charge": charge.get("charge"),
-					"other_charges_waiver": charge.get("other_charges_waiver"),
+					"capitalize_amount": charge.get("capitalize_amount"),
 					"treatment_of_other_charges": charge.get("treatment_of_other_charges"),
 				},
 			)

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from collections import Counter
+
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Sum
@@ -105,7 +107,6 @@ class TestLoanRestructure(IntegrationTestCase):
 			restructure_date="2024-04-11",
 			interest_waiver_amount=500,
 			penal_waiver_amount=10,
-			other_charges_waiver=0,
 		)
 
 		loan_restructure.status = "Approved"
@@ -117,7 +118,7 @@ class TestLoanRestructure(IntegrationTestCase):
 			pluck="name",
 		)
 
-		self.assertEqual(len(repayments), 7)
+		self.assertEqual(len(repayments), 8)
 
 	def test_clears_principal_overdue_demands_on_normal_restructure(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
@@ -154,7 +155,6 @@ class TestLoanRestructure(IntegrationTestCase):
 			restructure_date="2024-04-11",
 			interest_waiver_amount=500,
 			penal_waiver_amount=10,
-			other_charges_waiver=0,
 		)
 
 		loan_restructure.status = "Approved"
@@ -172,6 +172,88 @@ class TestLoanRestructure(IntegrationTestCase):
 		).run()[0][0]
 
 		self.assertEqual(flt(total_outstanding), 0)
+
+	def test_loan_restructure_charges_waiver_and_capitalization(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			22,
+			repayment_start_date="2024-04-05",
+			posting_date="2024-02-20",
+			rate_of_interest=8.5,
+			applicant_type="Customer",
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-02-20", repayment_start_date="2024-04-05"
+		)
+
+		process_daily_loan_demands(loan=loan.name, posting_date="2024-04-05")
+
+		sales_invoice = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": "_Test Customer 1",
+				"company": "_Test Company",
+				"loan": loan.name,
+				"posting_date": "2024-02-20",
+				"value_date": "2024-02-20",
+				"posting_time": "00:06:10",
+				"set_posting_time": 1,
+				"debit_to": "Processing Fee Receivable Account - _TC",
+				"items":
+				[
+					{"item_code": "Processing Fee", "qty": 1, "rate": 4000},
+					{"item_code": "Documentation Charge", "qty": 1, "rate": 3000},
+				],
+			}
+		)
+		sales_invoice.submit()
+
+		sales_invoice = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": "_Test Customer 1",
+				"company": "_Test Company",
+				"loan": loan.name,
+				"posting_date": "2024-02-20",
+				"value_date": "2024-02-20",
+				"posting_time": "00:06:10",
+				"set_posting_time": 1,
+				"items": [{"item_code": "Processing Fee", "qty": 1, "rate": 2000}],
+			}
+		)
+		sales_invoice.submit()
+
+		loan_restructure = create_loan_restructure(
+			loan=loan.name,
+			restructure_date="2024-04-11",
+			interest_waiver_amount=500,
+			loan_restructure_charges=[
+				{"charge": "Processing Fee", "other_charges_waiver": 500, "treatment_of_other_charges": "Capitalize"},
+				{"charge": "Documentation Charge", "other_charges_waiver": 0, "treatment_of_other_charges": "Capitalize"},
+			],
+		)
+		loan_restructure.status = "Approved"
+		loan_restructure.save()
+
+		repayments = frappe.db.get_all(
+			"Loan Repayment",
+			filters={"loan_restructure": loan_restructure.name, "docstatus": 1},
+			pluck="repayment_type",
+		)
+
+		self.assertEqual(len(repayments), 7)
+
+		counts = Counter(repayments)
+
+		self.assertEqual(counts.get("Charges Capitalization", 0), 2)
+		self.assertEqual(counts.get("Charges Waiver", 0), 1)
 
 	def test_unaccrued_interest_capitalization_gl_entries(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
@@ -485,11 +567,10 @@ def create_loan_restructure(
 	interest_waiver_amount=None,
 	unaccrued_interest_waiver=None,
 	penal_waiver_amount=None,
-	other_charges_waiver=None,
 	treatment_of_normal_interest="Capitalize",
 	unaccrued_interest_treatment="Capitalize",
 	treatment_of_penal_interest="Capitalize",
-	treatment_of_other_charges="Capitalize",
+	loan_restructure_charges=None,
 ):
 
 	doc = frappe.new_doc("Loan Restructure")
@@ -499,12 +580,22 @@ def create_loan_restructure(
 	doc.interest_waiver_amount = interest_waiver_amount
 	doc.unaccrued_interest_waiver = unaccrued_interest_waiver
 	doc.penal_interest_waiver = penal_waiver_amount
-	doc.other_charges_waiver = other_charges_waiver
 	doc.restructure_type = "Normal Restructure"
 	doc.treatment_of_normal_interest = treatment_of_normal_interest
 	doc.unaccrued_interest_treatment = unaccrued_interest_treatment
 	doc.treatment_of_penal_interest = treatment_of_penal_interest
-	doc.treatment_of_other_charges = treatment_of_other_charges
+
+	if loan_restructure_charges:
+		for charge in loan_restructure_charges:
+			doc.append(
+				"loan_restructure_charges",
+				{
+					"charge": charge.get("charge"),
+					"other_charges_waiver": charge.get("other_charges_waiver"),
+					"treatment_of_other_charges": charge.get("treatment_of_other_charges"),
+				},
+			)
+
 	doc.submit()
 
 	return doc

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
@@ -8,7 +8,8 @@
  "field_order": [
   "charge",
   "charges_overdue",
-  "other_charges_waiver",
+  "capitalize_amount",
+  "charges_waiver_amount",
   "balance_charges",
   "treatment_of_other_charges"
  ],
@@ -29,13 +30,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "other_charges_waiver",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Other Charges Waiver",
-   "options": "Company:company:default_currency"
-  },
-  {
    "default": "Capitalize",
    "fieldname": "treatment_of_other_charges",
    "fieldtype": "Select",
@@ -50,13 +44,28 @@
    "label": "Balance Charges",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "capitalize_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Capitalize Amount",
+   "options": "Company:company:default_currency"
+  },
+  {
+   "fieldname": "charges_waiver_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Charges Waiver Amount",
+   "options": "Company:company:default_currency",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-27 10:23:47.092859",
+ "modified": "2026-03-31 10:41:26.403909",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure Charges",

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
@@ -1,0 +1,68 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-03-25 14:06:08.168755",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "charge",
+  "charges_overdue",
+  "other_charges_waiver",
+  "balance_amount",
+  "treatment_of_other_charges"
+ ],
+ "fields": [
+  {
+   "fieldname": "charge",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Charge",
+   "options": "Item"
+  },
+  {
+   "fieldname": "charges_overdue",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Charges Overdue",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "other_charges_waiver",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Other Charges Waiver",
+   "options": "Company:company:default_currency"
+  },
+  {
+   "fieldname": "balance_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Balance Amount",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "treatment_of_other_charges",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Charges Treatment"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-03-25 14:27:47.415248",
+ "modified_by": "Administrator",
+ "module": "Loan Management",
+ "name": "Loan Restructure Charges",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
@@ -10,8 +10,7 @@
   "charges_overdue",
   "other_charges_waiver",
   "balance_charges",
-  "treatment_of_other_charges",
-  "loan_demand"
+  "treatment_of_other_charges"
  ],
  "fields": [
   {
@@ -51,20 +50,13 @@
    "label": "Balance Charges",
    "options": "Company:company:default_currency",
    "read_only": 1
-  },
-  {
-   "fieldname": "loan_demand",
-   "fieldtype": "Link",
-   "label": "Loan Demand",
-   "options": "Loan Demand",
-   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-25 15:34:00.226606",
+ "modified": "2026-03-27 10:23:47.092859",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure Charges",

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
@@ -9,8 +9,9 @@
   "charge",
   "charges_overdue",
   "other_charges_waiver",
-  "balance_amount",
-  "treatment_of_other_charges"
+  "balance_charges",
+  "treatment_of_other_charges",
+  "loan_demand"
  ],
  "fields": [
   {
@@ -36,25 +37,34 @@
    "options": "Company:company:default_currency"
   },
   {
-   "fieldname": "balance_amount",
+   "default": "Capitalize",
+   "fieldname": "treatment_of_other_charges",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Charges Treatment",
+   "options": "Capitalize\nCarry Forward"
+  },
+  {
+   "fieldname": "balance_charges",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Balance Amount",
+   "label": "Balance Charges",
    "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
-   "fieldname": "treatment_of_other_charges",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "label": "Charges Treatment"
+   "fieldname": "loan_demand",
+   "fieldtype": "Link",
+   "label": "Loan Demand",
+   "options": "Loan Demand",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-25 14:27:47.415248",
+ "modified": "2026-03-25 15:34:00.226606",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure Charges",

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
@@ -14,14 +14,15 @@ class LoanRestructureCharges(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		balance_amount: DF.Currency
+		balance_charges: DF.Currency
 		charge: DF.Link | None
 		charges_overdue: DF.Currency
+		loan_demand: DF.Link | None
 		other_charges_waiver: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		treatment_of_other_charges: DF.Literal[None]
+		treatment_of_other_charges: DF.Literal["Capitalize", "Carry Forward"]
 	# end: auto-generated types
 
 	pass

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
@@ -17,7 +17,6 @@ class LoanRestructureCharges(Document):
 		balance_charges: DF.Currency
 		charge: DF.Link | None
 		charges_overdue: DF.Currency
-		loan_demand: DF.Link | None
 		other_charges_waiver: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
@@ -15,9 +15,10 @@ class LoanRestructureCharges(Document):
 		from frappe.types import DF
 
 		balance_charges: DF.Currency
+		capitalize_amount: DF.Currency
 		charge: DF.Link | None
 		charges_overdue: DF.Currency
-		other_charges_waiver: DF.Currency
+		charges_waiver_amount: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class LoanRestructureCharges(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		balance_amount: DF.Currency
+		charge: DF.Link | None
+		charges_overdue: DF.Currency
+		other_charges_waiver: DF.Currency
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		treatment_of_other_charges: DF.Literal[None]
+	# end: auto-generated types
+
+	pass


### PR DESCRIPTION
**Issue**

Earlier, when handling charges during loan restructure, we had only four fields in the Loan Restructure document: `charges_overdue`, `other_charges_waiver`, `balance_charges`, and `treatment_of_other_charges`. This meant we could only see the total amount of all charges combined. For example, if a loan had both Processing Fee (₹8,000) and Documentation Charge (₹1,000), we would only see ₹9,000 as total charges overdue. We couldn't see how much was from each charge type.

**This created several issues:**
- If there were multiple demands for the same charge type (like three separate invoices for Documentation Charge), they would appear as separate entries, making it hard to manage
- We couldn't apply different treatments to different charges (e.g., capitalize Processing Fee but waive off Documentation Charge)
- When creating loan restructure, we had to manually track which charges were being waived or capitalized
- The data sent through APIs was not granular enough for external systems to understand individual charge breakdown
- Most importantly, when posting accounting entries for charges waiver or capitalization, the system would post a single consolidated entry. For example, if we waived ₹2,000 across multiple charges, it would create one loan repayment entry combining all charges, making it difficult to track which specific charge was waived

**Fix**

We introduced a new child table called **Loan Restructure Charges** that shows each charge type separately. Now when you open a loan restructure document, you'll see a table listing all unpaid charges with their individual details.

For example, instead of seeing just "Total Charges: ₹9,000", you'll now see:
- Processing Fee: ₹8,000 (with option to capitalize)
- Documentation Charge: ₹1,000 (with option to capitalize)

If there were multiple demands for Documentation Charge (say ₹500, ₹300, and ₹200), they now get automatically combined into a single row showing ₹1,000. This makes it much cleaner and easier to understand.

When you create a new loan restructure, the system automatically fetches all unpaid charges and groups them by charge type.

**Key Change in Logic:**
Instead of having a separate waiver field, we now have a **capitalize amount** field for each charge. The system automatically calculates the waiver amount as the remaining balance. This means:
- If you want to capitalize a charge, you simply enter the amount you want to capitalize
- The remaining amount automatically goes to waiver
- If you don't enter any capitalize amount, the entire charge amount automatically goes to waiver (default behavior)

The system then validates that the capitalize amount does not exceed the overdue amount and calculates the balance for each charge automatically.

<img width="5760" height="2736" alt="image" src="https://github.com/user-attachments/assets/7e060469-2d52-40eb-b2b7-bd82c0eef58d" />


Now, when the restructure is approved, the system creates separate loan repayment entries for each charge type:
- One entry for the capitalized amount (if any)
- One entry for the waived amount (remaining balance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loan Restructure form adds a per-charge table for managing individual charge waiver/capitalization and generates matching repayment entries.
  * New editable "Loan Restructure Charges" table available in the UI for line-item charge handling.

* **Refactor**
  * Replaced aggregate charge fields with granular, line-item charge management for clearer restructure workflows.

* **Bug Fixes / Validation**
  * Credit notes now inherit the original invoice’s debit account.
  * Charge repayment validation and allocation enforce restructure-specific rules.

* **Tests**
  * Added integration tests covering charge waiver and capitalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->