### PR TITLE
fix: Remove forced loan status update for Write Off Recovery/Settlement in Loan Repayment Repost

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -281,9 +281,6 @@ class LoanRepaymentRepost(Document):
 			repayment_doc = frappe.get_doc("Loan Repayment", entry.loan_repayment)
 			repayment_doc.flags.from_repost = True
 
-			if repayment_doc.repayment_type in ("Write Off Recovery", "Write Off Settlement"):
-				frappe.db.set_value("Loan", self.loan, "status", "Written Off")
-
 			if repayment_doc.repayment_type == "Security Deposit Adjustment":
 				is_security_deposit_adjustment = True
 			else:

--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -14,6 +14,7 @@ from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_
 )
 from lending.tests.test_utils import (
 	create_loan,
+	create_loan_write_off,
 	create_repayment_entry,
 	init_customers,
 	init_loan_products,
@@ -238,3 +239,45 @@ class TestLoanRepaymentRepost(IntegrationTestCase):
 				getdate(),
 				"Posting date of GL entries should be current date after the loan repayment repost",
 			)
+
+	def test_loan_write_off_settlement_status_after_repost(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			2500000,
+			"Repay Over Number of Periods",
+			24,
+			"Customer",
+			repayment_start_date="2024-11-05",
+			posting_date="2024-10-05",
+			rate_of_interest=25,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-10-05", repayment_start_date="2024-11-05"
+		)
+
+		process_daily_loan_demands(posting_date="2024-11-05", loan=loan.name)
+
+		create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+
+		repayment_1 = create_repayment_entry(
+			loan.name, "2025-01-05", 750000, repayment_type="Write Off Recovery"
+		)
+		repayment_1.submit()
+
+		repayment_2 = create_repayment_entry(
+			loan.name, "2025-01-06", 750000, repayment_type="Write Off Recovery"
+		)
+		repayment_2.submit()
+
+		repayment_1.cancel()
+
+		repayment_3 = create_repayment_entry(
+			loan.name, "2025-01-05", 750000, repayment_type="Write Off Settlement"
+		)
+		repayment_3.submit()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Settled")


### PR DESCRIPTION
**Issue:**
When a `Write Off Settlement` repayment is processed through the repost mechanism (`Loan Repayment Repost`), the loan status is incorrectly set to "Written Off" instead of "Settled".

**Root Cause:**
In `loan_repayment_repost.py`, there's a code block that forcibly sets the loan status to "Written Off" for both `Write Off Recovery` and `Write Off Settlement` repayment types during the repost process.

**Why this code is unnecessary:**

1. **Status is already handled in the original submission flow:**
   When a Write Off Settlement or Write Off Recovery repayment is submitted normally (not during repost), the `update_paid_amounts` method in `loan_repayment.py` already correctly determines and sets the loan status:
   https://github.com/frappe/lending/blob/d51723f988f2619743a20606265b16524f9fa20b/lending/loan_management/doctype/loan_repayment/loan_repayment.py#L1044-L1058

2. **Repost should replay, not override business logic:**
   The purpose of Loan Repayment Repost is to replay the same business logic that occurred during original submission, not to override it with different logic. When we repost:
   - We cancel existing entries
   - We recreate them in the correct order
   - The same `update_paid_amounts` method runs again during the repost submission

   Therefore, the status determination logic should be identical to the original submission.


So, remove the forced status update from `loan_repayment_repost.py` as the status is already properly handled in the original submission flow.