### PR TITLE
Loan Application fixes

### DIFF
--- a/lending/loan_management/doctype/loan_application/loan_application.js
+++ b/lending/loan_management/doctype/loan_application/loan_application.js
@@ -223,8 +223,7 @@ frappe.ui.form.on('Loan Application', {
 									};
 									if (customer.customer_primary_contact) {
 										frappe.db.get_doc("Contact", customer.customer_primary_contact).then((contact) => {
-											frm.set_value("first_name", customer.first_name);
-											frm.set_value("last_name", customer.last_name);
+											frm.set_value("applicant_name", contact.first_name);
 										});
 									}
 								});

--- a/lending/loan_management/doctype/loan_application/loan_application.json
+++ b/lending/loan_management/doctype/loan_application/loan_application.json
@@ -17,7 +17,6 @@
   "column_break_2",
   "company",
   "posting_date",
-  "status",
   "applicant_address_details_section",
   "address_line_1",
   "address_line_2",
@@ -29,6 +28,7 @@
   "co_applicants_section",
   "co_applicants",
   "section_break_4",
+  "status",
   "loan_product",
   "loan_amount",
   "rate_of_interest",
@@ -83,12 +83,11 @@
   },
   {
    "fieldname": "status",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
    "options": "Open\nApproved\nRejected",
-   "permlevel": 1,
-   "read_only": 1
+   "permlevel": 1
   },
   {
    "fieldname": "company",
@@ -339,7 +338,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-23 16:47:00.869101",
+ "modified": "2026-04-02 16:03:38.065821",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Application",

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -67,7 +67,7 @@ class LoanApplication(Document):
 		repayment_method: DF.Literal["", "Repay Fixed Amount per Period", "Repay Over Number of Periods"]
 		repayment_periods: DF.Int
 		state: DF.Data | None
-		status: DF.Data | None
+		status: DF.Literal["Open", "Approved", "Rejected"]
 		total_payable_amount: DF.Currency
 		total_payable_interest: DF.Currency
 		zip_code: DF.Int


### PR DESCRIPTION
- fetch first_name from contact instead of customer
- set as applicant_name in loan_application instead of first_name(this field does not exist)
- removed setting of last_name as this field does not exist in Loan Application
- reverted status field from data field to select field, removed read_only flag as it needs to be updated for application to progress
- moved status field to loan info section as it was getting hidden because of summary card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loan Application status field converted to dropdown with predefined options (Open, Approved, Rejected) and is now fully editable
  * Applicant name field now populated from contact information when a matching customer with primary contact is identified
  * Form layout adjusted with status field repositioned for improved workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->