### PR TITLE
fix: set loan_application as set_only_once since read_only does not allow setting loan_application in loan doctype

### DIFF
--- a/lending/loan_management/doctype/loan/loan.json
+++ b/lending/loan_management/doctype/loan/loan.json
@@ -132,7 +132,7 @@
    "label": "Loan Application",
    "no_copy": 1,
    "options": "Loan Application",
-   "read_only": 1
+   "set_only_once": 1
   },
   {
    "fieldname": "loan_product",
@@ -755,7 +755,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-09 14:19:18.157852",
+ "modified": "2026-04-02 16:38:23.811041",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Loan Application field is now editable once upon creation, allowing users to set the linked application while maintaining data integrity. Previously, this field was read-only and could not be modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->