### PR TITLE
fix: Add validations for Full Settlement backdating and post-settlement repayments

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -940,6 +940,7 @@ class LoanRepayment(LoanController):
 				"against_loan": self.against_loan,
 				"repayment_type": "Full Settlement",
 				"docstatus": 1,
+				"value_date": ("<=", get_datetime(self.value_date)),
 			}
 
 			if self.repayment_schedule_type == "Line of Credit" and self.loan_disbursement:

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -911,6 +911,42 @@ class LoanRepayment(LoanController):
 		]:
 			frappe.throw(_("Repayment cannot be made for closed loan"))
 
+		if self.repayment_type == "Full Settlement":
+			last_repayment = frappe.db.get_value(
+				"Loan Repayment",
+				{
+					"against_loan": self.against_loan,
+					"docstatus": 1,
+					"name": ("!=", self.name or ""),
+				},
+				["name", "value_date"],
+				as_dict=True,
+				order_by="value_date desc",
+			)
+			if last_repayment and get_datetime(self.value_date) < get_datetime(last_repayment.value_date):
+				frappe.throw(
+					_(
+						"Full Settlement cannot be backdated. The value date {0} cannot be earlier than the last repayment value date {1} ({2})."
+					).format(get_datetime(self.value_date), get_datetime(last_repayment.value_date), last_repayment.name)
+				)
+
+		elif self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver"):
+			existing_full_settlement = frappe.db.get_value(
+				"Loan Repayment",
+				{
+					"against_loan": self.against_loan,
+					"repayment_type": "Full Settlement",
+					"docstatus": 1,
+				},
+				"name",
+			)
+			if existing_full_settlement:
+				frappe.throw(
+					_(
+						"Loan {0}: Cannot post {1} after Full Settlement. Only Interest, Penalty, or Charges Waiver can be posted after a Full Settlement."
+					).format(self.against_loan, self.repayment_type)
+				)
+
 		if loan_status == "Written Off":
 			if (
 				self.repayment_type not in ("Write Off Recovery", "Write Off Settlement")

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -912,17 +912,22 @@ class LoanRepayment(LoanController):
 			frappe.throw(_("Repayment cannot be made for closed loan"))
 
 		if self.repayment_type == "Full Settlement":
+			filters = {
+				"against_loan": self.against_loan,
+				"docstatus": 1,
+			}
+
+			if self.repayment_schedule_type == "Line of Credit" and self.loan_disbursement:
+				filters["loan_disbursement"] = self.loan_disbursement
+
 			last_repayment = frappe.db.get_value(
 				"Loan Repayment",
-				{
-					"against_loan": self.against_loan,
-					"docstatus": 1,
-					"name": ("!=", self.name or ""),
-				},
+				filters,
 				["name", "value_date"],
 				as_dict=True,
 				order_by="value_date desc",
 			)
+
 			if last_repayment and get_datetime(self.value_date) < get_datetime(last_repayment.value_date):
 				frappe.throw(
 					_(
@@ -931,15 +936,21 @@ class LoanRepayment(LoanController):
 				)
 
 		elif self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver"):
+			filters = {
+				"against_loan": self.against_loan,
+				"repayment_type": "Full Settlement",
+				"docstatus": 1,
+			}
+
+			if self.repayment_schedule_type == "Line of Credit" and self.loan_disbursement:
+				filters["loan_disbursement"] = self.loan_disbursement
+
 			existing_full_settlement = frappe.db.get_value(
 				"Loan Repayment",
-				{
-					"against_loan": self.against_loan,
-					"repayment_type": "Full Settlement",
-					"docstatus": 1,
-				},
+				filters,
 				"name",
 			)
+
 			if existing_full_settlement:
 				frappe.throw(
 					_(

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1945,3 +1945,61 @@ class TestLoanRepayment(IntegrationTestCase):
 		self.assertEqual(payable_charge, 200)
 
 		frappe.db.set_value("Company", "_Test Company", "enable_loan_accounting", 0)
+
+	def test_full_settlement_cannot_be_backdated(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			repayment_start_date="2025-08-05",
+			posting_date="2025-07-05",
+			rate_of_interest=10,
+			applicant_type="Customer",
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-07-05", repayment_start_date="2025-08-05"
+		)
+
+		process_daily_loan_demands(posting_date="2025-09-05", loan=loan.name)
+
+		create_repayment_entry(
+			loan.name, "2025-09-10", 34314.00, repayment_type="Normal Repayment"
+		).submit()
+
+		with self.assertRaises(frappe.ValidationError):
+			create_repayment_entry(
+				loan.name, "2025-09-06", 100000, repayment_type="Full Settlement"
+			)
+
+	def test_no_repayment_after_full_settlement_except_waivers(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			repayment_start_date="2025-08-05",
+			posting_date="2025-07-05",
+			rate_of_interest=10,
+			applicant_type="Customer",
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2025-07-05", repayment_start_date="2025-08-05"
+		)
+
+		process_daily_loan_demands(posting_date="2025-09-05", loan=loan.name)
+
+		create_repayment_entry(
+			loan.name, "2025-09-05", 100000, repayment_type="Full Settlement"
+		).submit()
+
+		with self.assertRaises(frappe.ValidationError):
+			create_repayment_entry(
+				loan.name, "2025-09-06", 5000, repayment_type="Normal Repayment"
+			)


### PR DESCRIPTION
- Full Settlement cannot be backdated
- Only waivers allowed after Full Settlement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevents backdating of Full Settlement loan repayments by disallowing a settlement date earlier than the latest submitted repayment for the same loan/disbursement.
  * Blocks posting of new repayment types after a Full Settlement has been submitted (except allowed waiver types: interest, penalty, charges), avoiding conflicting entries.

* **Tests**
  * Added integration tests verifying Full Settlement date constraints and the waiver-type exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->