### PR TITLE
Add pledge tracking fields to store folio and reference numbers

### DIFF
--- a/lending/loan_management/doctype/pledge/pledge.json
+++ b/lending/loan_management/doctype/pledge/pledge.json
@@ -85,6 +85,36 @@
    "fieldtype": "Data",
    "label": "Loan Security Name",
    "read_only": 1
+  },
+  {
+   "fieldname": "rta",
+   "fieldtype": "Data",
+   "label": "RTA",
+   "read_only": 1
+  },
+  {
+   "fieldname": "lien_ref_no",
+   "fieldtype": "Data",
+   "label": "Lien Ref No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "lien_subref_no",
+   "fieldtype": "Data",
+   "label": "Lien Subref No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "folio_no",
+   "fieldtype": "Data",
+   "label": "Folio Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amc",
+   "fieldtype": "Data",
+   "label": "AMC Name",
+   "read_only": 1
   }
  ],
  "istable": 1,


### PR DESCRIPTION
When a security is pledged, we need to store the folio number and reference numbers for the same. 
Same information is passed when pledging is successful and is needed to invoke/revoke the pledging as well./

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Five new read-only fields are now available in Pledge records: RTA, Lien Reference Number, Lien Sub-Reference Number, Folio Number, and AMC. Users can view these fields in the Pledge form and they will appear in reports, lists, and other system interfaces throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->