### PR TITLE
fix: Update sanctioned limit on shortfall

### DIFF
--- a/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
+++ b/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
@@ -187,6 +187,10 @@ def check_for_ltv_shortfall(process_loan_security_shortfall, loan=None, applican
 				applicant=applicant,
 			)
 
+			sanctioned_limit = frappe.db.get_value("Sanctioned Loan Amount", {"applicant": applicant}, "name")
+			if sanctioned_limit:
+				frappe.db.set_value("Sanctioned Loan Amount", sanctioned_limit, "sanctioned_amount_limit", security_value)
+
 
 def create_loan_security_shortfall(
 	loan_amount,

--- a/lending/loan_management/doctype/loan_security_shortfall/test_loan_security_shortfall.py
+++ b/lending/loan_management/doctype/loan_security_shortfall/test_loan_security_shortfall.py
@@ -166,3 +166,7 @@ class TestLoanSecurityShortfall(unittest.TestCase):
 
 		self.assertTrue(shortfall_details)
 		self.assertEqual(flt(shortfall_details.shortfall_amount), 100000)
+
+		# Test Customer Sanctioned Limit
+		sanctioned_limit = frappe.db.get_value("Sanctioned Loan Amount", {"applicant": customer}, "sanctioned_amount_limit")
+		self.assertEqual(flt(sanctioned_limit), 400000)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loan security shortfall processing now updates sanctioned loan amount limits when shortfalls are detected at customer level.

* **Tests**
  * Enhanced test validation to verify sanctioned loan amount updates during security shortfall scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->