### PR TITLE
fix: Update lending patches for v16 migration compatibility

### DIFF
--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -9,7 +9,6 @@ execute:frappe.rename_doc("DocType", "Loan Security Pledge", "Loan Security Assi
 execute:frappe.rename_doc("DocType", "Loan Security Unpledge", "Loan Security Release", force=True)
 execute:frappe.delete_doc_if_exists("DocType", "Loan Buyback")
 lending.patches.v1_0.fix_invalid_loan_product_values #2
-lending.patches.v1_0.rename_is_accrued_to_demand_generated #2
 execute:frappe.delete_doc_if_exists("Report", "Loan Interest Report")
 
 [post_model_sync]
@@ -41,6 +40,7 @@ lending.patches.v15_0.create_accounting_dimensions_for_loan_doctypes
 lending.patches.v15_0.update_maturity_date
 lending.patches.v15_0.loan_repayment_schedule_status_patch
 lending.patches.v15_0.loan_disbursement_status_patch
+lending.patches.v1_0.rename_is_accrued_to_demand_generated #2
 lending.patches.v1_0.create_custom_field_loan_accrual_rate_for_company #rerun #2
 lending.patches.v1_0.add_index_for_custom_fields_for_JE
 lending.patches.v1_0.update_value_date_in_loan_repayment

--- a/lending/patches/v15_0/update_loan_product_accounts.py
+++ b/lending/patches/v15_0/update_loan_product_accounts.py
@@ -34,4 +34,6 @@ def execute():
 		if not doc.broken_period_interest_recovery_account:
 			doc.broken_period_interest_recovery_account = doc.interest_income_account
 
+		doc.flags.ignore_mandatory = True
+		doc.flags.ignore_validate = True
 		doc.save()

--- a/lending/patches/v1_0/rename_is_accrued_to_demand_generated.py
+++ b/lending/patches/v1_0/rename_is_accrued_to_demand_generated.py
@@ -1,7 +1,10 @@
 import frappe
-from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	if not frappe.db.has_column("Repayment Schedule", "demand_generated"):
-		rename_field("Repayment Schedule", "is_accrued", "demand_generated")
+	if frappe.db.has_column("Repayment Schedule", "is_accrued"):
+		frappe.db.sql("""
+			UPDATE `tabRepayment Schedule`
+			SET demand_generated = is_accrued
+			WHERE demand_generated IS NULL OR demand_generated = 0
+		""")


### PR DESCRIPTION
**Issue:**

1. `lending.patches.v15_0.update_loan_product_accounts` - Validation error
<img width="3635" height="1559" alt="image" src="https://github.com/user-attachments/assets/a344d49a-93f8-4e9d-9492-ac0847ac29bf" />

<img width="3566" height="1555" alt="image" src="https://github.com/user-attachments/assets/cb34c1ed-0ea0-47fd-9229-7cf7154f7f45" />
<img width="3586" height="371" alt="image" src="https://github.com/user-attachments/assets/f92177da-cf54-40dc-a8ce-90ce6fc6ad0c" />

2. `lending.patches.v1_0.rename_is_accrued_to_demand_generated` - demand_generated not found in Repayment Schedule

<img width="3594" height="1454" alt="image" src="https://github.com/user-attachments/assets/08cc339d-486b-43bd-a2ab-de61f01b3be6" />

<br>
<br>

**Fix:**

1. For `update_loan_product_accounts`: Added `ignore_mandatory` and `ignore_validate` flags to bypass validation during patch execution
2. For `rename_is_accrued_to_demand_generated`: Replaced rename logic with data migration
   - Copies `is_accrued` value to `demand_generated` only when `demand_generated` is NULL or 0
   - Preserves existing `demand_generated = 1` values


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized patch execution sequence to improve database synchronization efficiency
  * Enhanced system patch handling with improved validation control during account updates
  * Refined data field migration logic to ensure consistent value population across records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->