### PR TITLE
fix: Correct loan status update when cancelling loan write-offs

### DIFF
--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -188,15 +188,20 @@ class LoanWriteOff(LoanController):
 
 		if cancel:
 			written_off_amount -= self.write_off_amount
+			update_values = {"written_off_amount": written_off_amount}
+
+			if write_off_count > 0:
+				update_values["status"] = "Written Off"
+			else:
+				update_values["status"] = "Disbursed"
 		else:
 			written_off_amount += self.write_off_amount
+			update_values = {"written_off_amount": written_off_amount}
 
-		update_values = {"written_off_amount": written_off_amount}
-
-		if not (self.is_settlement_write_off or cancel) or write_off_count > 1:
-			update_values["status"] = "Written Off"
-		elif not self.is_settlement_write_off:
-			update_values["status"] = "Disbursed"
+			if not self.is_settlement_write_off or write_off_count > 1:
+				update_values["status"] = "Written Off"
+			elif not self.is_settlement_write_off:
+				update_values["status"] = "Disbursed"
 
 		frappe.db.set_value("Loan", self.loan, update_values)
 

--- a/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
@@ -1,9 +1,59 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
-import unittest
+
+from frappe.tests import IntegrationTestCase
+
+from lending.tests.test_utils import (
+	create_loan,
+	create_loan_write_off,
+	init_loan_products,
+	make_loan_disbursement_entry,
+	master_init,
+)
 
 
-class TestLoanWriteOff(unittest.TestCase):
-	pass
+class TestLoanWriteOff(IntegrationTestCase):
+	def setUp(self):
+		master_init()
+		init_loan_products()
+
+	def test_loan_write_off_status_on_submit_and_cancel(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			2500000,
+			"Repay Over Number of Periods",
+			24,
+			"Customer",
+			repayment_start_date="2024-11-05",
+			posting_date="2024-10-05",
+			rate_of_interest=25,
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-10-05", repayment_start_date="2024-11-05"
+		)
+		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Written Off")
+
+		loan_write_1.cancel()
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Disbursed")
+
+		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+		loan_write_2 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Written Off")
+
+		loan_write_2.cancel()
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Written Off")
+
+		loan_write_1.cancel()
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Disbursed")

--- a/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
@@ -20,7 +20,7 @@ class TestLoanWriteOff(IntegrationTestCase):
 
 	def test_loan_write_off_status_on_submit_and_cancel(self):
 		loan = create_loan(
-			"_Test Customer 1",
+			"_Test Customer 2",
 			"Term Loan Product 4",
 			2500000,
 			"Repay Over Number of Periods",


### PR DESCRIPTION
**Issue:**
When multiple loan write-offs exist and if the last write-off is cancelled, the loan status incorrectly changes to "Disbursed" instead of remaining "Written Off".

**Root Cause:**
Code didn't properly check for remaining active write-offs during cancellation.

**Fix:**
During cancellation, check if other write-offs exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loan status transitions now correctly reflect write-off and cancellation operations.

* **Tests**
  * Added comprehensive integration tests for loan write-off workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->