### PR TITLE
feat: add post restructure charge support without existing demand

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1857,14 +1857,18 @@ class LoanRepayment(LoanController):
 	def allocate_charges(self, amount_paid, demands):
 		paid_charges = {}
 		for charge in self.get("payable_charges"):
-			paid_charges[charge.charge_code] = charge.amount
+			paid_charges[charge.charge_code] = paid_charges.get(charge.charge_code, 0) + flt(charge.amount)
 
 		for demand in demands:
 			if amount_paid > 0 and paid_charges.get(demand.demand_subtype, 0) > 0:
-				if amount_paid > paid_charges.get(demand.demand_subtype, 0):
-					paid_amount = paid_charges.get(demand.demand_subtype, 0)
-				else:
-					paid_amount = amount_paid
+				paid_amount = min(
+					flt(amount_paid),
+					flt(paid_charges.get(demand.demand_subtype, 0)),
+					flt(demand.outstanding_amount),
+				)
+
+				if paid_amount <= 0:
+					continue
 
 				self.append(
 					"repayment_details",
@@ -1878,6 +1882,9 @@ class LoanRepayment(LoanController):
 				)
 
 				self.total_charges_paid += paid_amount
+				paid_charges[demand.demand_subtype] = flt(
+					paid_charges.get(demand.demand_subtype, 0) - paid_amount
+				)
 				amount_paid -= paid_amount
 
 		return amount_paid

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -279,6 +279,7 @@ class LoanRestructure(AccountsController):
 			self.restructure_loan()
 
 			if self.restructure_type == "Normal Restructure":
+				self.make_post_restructure_charge_demands()
 				self.update_totals()
 				self.update_security_deposit_amount()
 				self.update_restructure_count()
@@ -466,7 +467,8 @@ class LoanRestructure(AccountsController):
 
 		existing_charges_map = {}
 		for charge_row in self.get("loan_restructure_charges"):
-			existing_charges_map[charge_row.charge] = charge_row
+			if not charge_row.is_post_restructure_charge:
+				existing_charges_map[charge_row.charge] = charge_row
 
 		processed_charges = set()
 
@@ -484,6 +486,8 @@ class LoanRestructure(AccountsController):
 
 		charges_to_remove = []
 		for charge_row in self.get("loan_restructure_charges"):
+			if charge_row.is_post_restructure_charge:
+				continue
 			if charge_row.get("charge") not in processed_charges:
 				charges_to_remove.append(charge_row)
 
@@ -507,6 +511,8 @@ class LoanRestructure(AccountsController):
 
 		table_map = {}
 		for charge_row in self.get("loan_restructure_charges"):
+			if charge_row.is_post_restructure_charge:
+				continue
 			charge_type = charge_row.get("charge")
 			if not charge_type:
 				continue
@@ -537,6 +543,12 @@ class LoanRestructure(AccountsController):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
 		for charge in self.get("loan_restructure_charges"):
+			if charge.is_post_restructure_charge:
+				charge.charges_overdue = 0
+				charge.charges_waiver_amount = 0
+				charge.balance_charges = flt(charge.restructure_charge_amount, precision)
+				continue
+
 			overdue = flt(charge.get("charges_overdue"), precision)
 			capitalize_amount = flt(charge.get("capitalize_amount"), precision)
 
@@ -764,6 +776,8 @@ class LoanRestructure(AccountsController):
 
 	def make_waiver_and_capitalization_for_charges(self):
 		for charge in self.get("loan_restructure_charges"):
+			if charge.is_post_restructure_charge:
+				continue
 			if flt(charge.charges_waiver_amount) > 0:
 				create_loan_repayment(
 					self.loan,
@@ -787,6 +801,28 @@ class LoanRestructure(AccountsController):
 	def set_principal_adjustment_on_restructure(self):
 		if flt(self.principal_overdue) > 0 and flt(self.principal_adjusted) == 0:
 			self.principal_adjusted = flt(self.principal_overdue)
+
+	def make_post_restructure_charge_demands(self):
+		from lending.loan_management.doctype.loan_disbursement.loan_disbursement import (
+			make_sales_invoice_for_charge,
+		)
+
+		post_restructure_charges = [
+			frappe._dict(charge=charge.charge, amount=flt(charge.restructure_charge_amount))
+			for charge in self.get("loan_restructure_charges")
+			if charge.is_post_restructure_charge and flt(charge.restructure_charge_amount) > 0
+		]
+
+		if post_restructure_charges:
+			make_sales_invoice_for_charge(
+				self.loan,
+				"loan_restructure",
+				self.name,
+				self.applicant if self.applicant_type == "Customer" else None,
+				self.restructure_date,
+				self.company,
+				post_restructure_charges,
+			)
 
 	def make_loan_repayment_for_adjustment(self):
 		if self.principal_adjusted:

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -264,26 +264,6 @@ class TestLoanRestructure(IntegrationTestCase):
 		self.assertEqual(counts.get("Charges Capitalization", 0), 2)
 		self.assertEqual(counts.get("Charges Waiver", 0), 1)
 
-		processing_fee_capitalization = frappe.get_doc(
-			"Loan Repayment",
-			{
-				"loan_restructure": loan_restructure.name,
-				"docstatus": 1,
-				"repayment_type": "Charges Capitalization",
-				"amount_paid": 6000,
-			},
-		)
-
-		allocated_processing_fee_amounts = sorted(
-			[
-				flt(d.paid_amount)
-				for d in processing_fee_capitalization.get("repayment_details")
-				if d.demand_subtype == "Processing Fee"
-			]
-		)
-
-		self.assertEqual(allocated_processing_fee_amounts, [2000.0, 4000.0])
-
 	def test_unaccrued_interest_capitalization_gl_entries(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
 

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -237,10 +237,19 @@ class TestLoanRestructure(IntegrationTestCase):
 			loan_restructure_charges=[
 				{"charge": "Processing Fee", "capitalize_amount": 6000, "treatment_of_other_charges": "Capitalize"},
 				{"charge": "Documentation Charge", "capitalize_amount": 2500, "treatment_of_other_charges": "Capitalize"},
+				{"charge": "Processing Fee", "restructure_charge_amount": 3000, "is_post_restructure_charge": 1},
+				{"charge": "Documentation Charge", "restructure_charge_amount": 1000, "is_post_restructure_charge": 1}
 			],
 		)
 		loan_restructure.status = "Approved"
 		loan_restructure.save()
+
+		invoices = frappe.db.get_all(
+			"Sales Invoice",
+			filters={"loan": loan.name, "docstatus": 1, "value_date": "2024-04-11"},
+			pluck="name",
+		)
+		self.assertEqual(len(invoices), 1, "Expected 1 Sales Invoice to be created for post-restructure charges.")
 
 		repayments = frappe.db.get_all(
 			"Loan Repayment",
@@ -254,6 +263,26 @@ class TestLoanRestructure(IntegrationTestCase):
 
 		self.assertEqual(counts.get("Charges Capitalization", 0), 2)
 		self.assertEqual(counts.get("Charges Waiver", 0), 1)
+
+		processing_fee_capitalization = frappe.get_doc(
+			"Loan Repayment",
+			{
+				"loan_restructure": loan_restructure.name,
+				"docstatus": 1,
+				"repayment_type": "Charges Capitalization",
+				"amount_paid": 6000,
+			},
+		)
+
+		allocated_processing_fee_amounts = sorted(
+			[
+				flt(d.paid_amount)
+				for d in processing_fee_capitalization.get("repayment_details")
+				if d.demand_subtype == "Processing Fee"
+			]
+		)
+
+		self.assertEqual(allocated_processing_fee_amounts, [2000.0, 4000.0])
 
 	def test_unaccrued_interest_capitalization_gl_entries(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
@@ -567,6 +596,8 @@ def create_loan_restructure(
 	interest_waiver_amount=None,
 	unaccrued_interest_waiver=None,
 	penal_waiver_amount=None,
+	restructure_charge_amount=None,
+	is_post_restructure_charge=0,
 	treatment_of_normal_interest="Capitalize",
 	unaccrued_interest_treatment="Capitalize",
 	treatment_of_penal_interest="Capitalize",
@@ -591,6 +622,8 @@ def create_loan_restructure(
 				"loan_restructure_charges",
 				{
 					"charge": charge.get("charge"),
+					"is_post_restructure_charge": charge.get("is_post_restructure_charge", 0),
+					"restructure_charge_amount": charge.get("restructure_charge_amount"),
 					"capitalize_amount": charge.get("capitalize_amount"),
 					"treatment_of_other_charges": charge.get("treatment_of_other_charges"),
 				},

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.json
@@ -8,13 +8,16 @@
  "field_order": [
   "charge",
   "charges_overdue",
+  "balance_charges",
   "capitalize_amount",
   "charges_waiver_amount",
-  "balance_charges",
-  "treatment_of_other_charges"
+  "treatment_of_other_charges",
+  "restructure_charge_amount",
+  "is_post_restructure_charge"
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "charge",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -22,6 +25,15 @@
    "options": "Item"
   },
   {
+   "columns": 1,
+   "default": "0",
+   "fieldname": "is_post_restructure_charge",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Post Restructure Charge (No Existing Demand)"
+  },
+  {
+   "columns": 2,
    "fieldname": "charges_overdue",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -30,7 +42,9 @@
    "read_only": 1
   },
   {
+   "columns": 2,
    "default": "Capitalize",
+   "depends_on": "eval:doc.is_post_restructure_charge==0",
    "fieldname": "treatment_of_other_charges",
    "fieldtype": "Select",
    "in_list_view": 1,
@@ -38,6 +52,8 @@
    "options": "Capitalize\nCarry Forward"
   },
   {
+   "columns": 2,
+   "depends_on": "eval:doc.is_post_restructure_charge==0",
    "fieldname": "balance_charges",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -46,6 +62,8 @@
    "read_only": 1
   },
   {
+   "columns": 2,
+   "depends_on": "eval:doc.is_post_restructure_charge==0",
    "fieldname": "capitalize_amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -53,19 +71,31 @@
    "options": "Company:company:default_currency"
   },
   {
+   "columns": 2,
+   "depends_on": "eval:doc.is_post_restructure_charge==0",
    "fieldname": "charges_waiver_amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Charges Waiver Amount",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "columns": 2,
+   "depends_on": "eval:doc.is_post_restructure_charge==1",
+   "fieldname": "restructure_charge_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Restructure Charge Amount (No Existing Demand)",
+   "mandatory_depends_on": "eval:doc.is_post_restructure_charge==1",
+   "options": "Company:company:default_currency"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-31 10:41:26.403909",
+ "modified": "2026-05-07 15:00:12.259896",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Restructure Charges",

--- a/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
+++ b/lending/loan_management/doctype/loan_restructure_charges/loan_restructure_charges.py
@@ -19,9 +19,11 @@ class LoanRestructureCharges(Document):
 		charge: DF.Link | None
 		charges_overdue: DF.Currency
 		charges_waiver_amount: DF.Currency
+		is_post_restructure_charge: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		restructure_charge_amount: DF.Currency
 		treatment_of_other_charges: DF.Literal["Capitalize", "Carry Forward"]
 	# end: auto-generated types
 


### PR DESCRIPTION
Earlier, when someone wanted to restructure a loan, they could only add charges that already existed as unpaid demands. But in real business, some charges like processing fee or legal charges are created only at the time of restructuring. There was no way to add these charges manually because the system would always look for an existing demand. This was a problem for teams who create charges after restructure approval, not before.

**How did we fix it?**

We added two new fields in the Loan Restructure Charges table:

1. **"Post Restructure Charge (No Existing Demand)"** — a checkbox to mark charges that do not have any existing demand
2. **"Restructure Charge Amount (No Existing Demand)"** — a field to manually enter the charge amount

Now, when a user checks this box, the system understands that this charge is not from an old demand. It skips all validations that check for existing demands. When the restructure is approved, the system automatically creates a Sales Invoice for these charges. This way, the user can add any charge at the time of restructuring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-restructure charge functionality with automatic sales invoice generation when loan restructures are approved.
  * Enhanced charge allocation algorithm to better track remaining payment amounts per charge type during loan repayment, preventing invalid allocations.

* **Tests**
  * Updated test suite to validate post-restructure charge scenarios and corresponding sales invoice creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->