### PR TITLE
fix: Use get_datetime for waiver date comparison in loan write off cancellation

### DIFF
--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.utils import cint, flt, getdate
+from frappe.utils import cint, flt, get_datetime, getdate
 
 import erpnext
 
@@ -107,11 +107,14 @@ class LoanWriteOff(LoanController):
 		self.process_unbooked_interest()
 		self.make_gl_entries()
 
-		frappe.enqueue(
-			self.process_write_off_waivers_and_classification,
-			enqueue_after_commit=True,
-			queue="long",
-		)
+		if not frappe.flags.in_test:
+			frappe.enqueue(
+				self.process_write_off_waivers_and_classification,
+				enqueue_after_commit=True,
+				queue="long",
+			)
+		else:
+			self.process_write_off_waivers_and_classification()
 
 		write_off_charges(self.loan, self.posting_date, self.value_date, self.company, on_write_off=True)
 		self.close_employee_loan()
@@ -573,11 +576,12 @@ def write_off_charges(
 
 
 def get_write_off_waivers_for_cancel(loan_name, posting_date):
+	posting_datetime = get_datetime(posting_date)
 	return frappe.db.get_all(
 		"Loan Repayment",
 		filters={
 			"against_loan": loan_name,
-			"value_date": ("<=", posting_date),
+			"value_date": ("<=", posting_datetime),
 			"docstatus": 1,
 			"is_write_off_waiver": 1,
 		},

--- a/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-
+import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import get_datetime
 
 from lending.tests.test_utils import (
 	create_loan,
@@ -22,9 +23,9 @@ class TestLoanWriteOff(IntegrationTestCase):
 		loan = create_loan(
 			"_Test Customer 2",
 			"Term Loan Product 4",
-			2500000,
+			100000,
 			"Repay Over Number of Periods",
-			24,
+			4,
 			"Customer",
 			repayment_start_date="2024-11-05",
 			posting_date="2024-10-05",
@@ -36,7 +37,7 @@ class TestLoanWriteOff(IntegrationTestCase):
 		make_loan_disbursement_entry(
 			loan.name, loan.loan_amount, disbursement_date="2024-10-05", repayment_start_date="2024-11-05"
 		)
-		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=50000)
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Written Off")
 
@@ -44,8 +45,8 @@ class TestLoanWriteOff(IntegrationTestCase):
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Disbursed")
 
-		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
-		loan_write_2 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+		loan_write_1 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=50000)
+		loan_write_2 = create_loan_write_off(loan.name, "2024-11-05", write_off_amount=50000)
 
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Written Off")
@@ -57,3 +58,16 @@ class TestLoanWriteOff(IntegrationTestCase):
 		loan_write_1.cancel()
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Disbursed")
+
+		loan_repayments = frappe.db.get_all(
+			"Loan Repayment",
+			filters={
+				"against_loan": loan.name,
+				"value_date": ("<=", get_datetime("2024-11-05")),
+				"docstatus": 2,
+				"is_write_off_waiver": 1,
+			},
+			pluck="name",
+		)
+		self.assertEqual(len(loan_repayments), 2)
+


### PR DESCRIPTION
**Issue:**
When cancelling a loan write off, the system could not find the waiver entries to cancel. This happened because the waiver date comparison was not working correctly.

**Root Cause:**
- Waiver records have value_date as datetime (e.g., 2024-11-05 00:00:00)
- The filter was using getdate() which returns only date (e.g., 2024-11-05)
- It does not properly compare the datetime with a date, so no waivers were found

**Fix:**
Changed getdate() to get_datetime() in the filter so both values are datetime objects and can be compared correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date filtering in write-off waiver queries to properly handle datetime conversions, ensuring accurate result filtering in write-off operations.
  * Improved write-off waiver processing to execute more efficiently during testing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/lending/pull/1233)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->