### PR TITLE
fix: handle missing repayment schedule in advance payment validation

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1738,15 +1738,16 @@ class LoanRepayment(LoanController):
 				if self.loan_disbursement:
 					filters["loan_disbursement"] = self.loan_disbursement
 
-				monthly_repayment_amount = flt(
-					frappe.db.get_value(
-						"Loan Repayment Schedule",
-						filters,
-						"monthly_repayment_amount",
-					),
-					precision
+				monthly_repayment_amount = frappe.db.get_value(
+					"Loan Repayment Schedule",
+					filters,
+					"monthly_repayment_amount",
 				)
 
+				if not monthly_repayment_amount:
+					frappe.throw(_("Cannot process Advance Payment: No active Loan Repayment Schedule found for this loan"))
+
+				monthly_repayment_amount = flt(monthly_repayment_amount, precision)
 				amount_paid = flt(amount_paid, precision)
 
 				if (amount_paid < monthly_repayment_amount) or (

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1738,14 +1738,19 @@ class LoanRepayment(LoanController):
 				if self.loan_disbursement:
 					filters["loan_disbursement"] = self.loan_disbursement
 
-				monthly_repayment_amount = frappe.db.get_value(
-					"Loan Repayment Schedule",
-					filters,
-					"monthly_repayment_amount",
+				monthly_repayment_amount = flt(
+					frappe.db.get_value(
+						"Loan Repayment Schedule",
+						filters,
+						"monthly_repayment_amount",
+					),
+					precision
 				)
 
-				if (flt(amount_paid, precision) < monthly_repayment_amount) or (
-					flt(amount_paid, precision) > (2 * monthly_repayment_amount)
+				amount_paid = flt(amount_paid, precision)
+
+				if (amount_paid < monthly_repayment_amount) or (
+					amount_paid > (2 * monthly_repayment_amount)
 				):
 					frappe.throw(_("Amount for advance payment must be between one to two EMI amount"))
 

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
 from frappe.utils import add_days, add_months, date_diff, flt, get_datetime, getdate
@@ -1938,3 +1939,44 @@ class TestLoanRepayment(LendingTestSuite):
 			create_repayment_entry(
 				loan.name, "2025-09-06", 5000, repayment_type="Normal Repayment"
 			)
+
+	def test_advance_payment_no_active_schedule(self):
+		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			200000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date="2025-01-05",
+			posting_date="2024-12-26",
+			rate_of_interest=31,
+			applicant_type="Customer",
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-12-26",
+			repayment_start_date="2025-01-05",
+		)
+
+		# Deactivate the repayment schedule to simulate no active schedule
+		schedule_name = frappe.db.get_value(
+			"Loan Repayment Schedule",
+			{"loan": loan.name, "docstatus": 1, "status": "Active"},
+			"name",
+		)
+		frappe.db.set_value("Loan Repayment Schedule", schedule_name, "status", "Closed")
+
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			create_repayment_entry(
+				loan.name, "2025-01-03", paid_amount=19596, repayment_type="Advance Payment"
+			)
+
+		self.assertIn(
+			_("Cannot process Advance Payment: No active Loan Repayment Schedule found for this loan"),
+			str(ctx.exception),
+		)


### PR DESCRIPTION
## Description

Handles cases where no matching `Loan Repayment Schedule` exists during Advance Payment validation for term loans.

`frappe.db.get_value()` returns `None` when no matching repayment schedule is found, which causes invalid numeric comparisons during validation.

This change safely normalizes values using `flt()` before comparison.

## Changes

* Wrap `monthly_repayment_amount` with `flt()`
* Normalize `amount_paid` using `flt()`
* Prevent `NoneType` comparison issues during Advance Payment validation

## Before

```python id="ak7uvm"
monthly_repayment_amount = frappe.db.get_value(
    "Loan Repayment Schedule",
    filters,
    "monthly_repayment_amount",
)
```

## After

```python id="eh11ew"
monthly_repayment_amount = flt(
    frappe.db.get_value(
        "Loan Repayment Schedule",
        filters,
        "monthly_repayment_amount",
    ),
    precision,
)

amount_paid = flt(amount_paid, precision)
```

Closes #1240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened advance loan payment validation: advance payments are now rejected if there’s no active monthly EMI to compare against.
  * Validation now consistently rounds the monthly EMI and the entered payment to currency precision before checking that the amount falls between 1× and 2× the EMI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->