### PR TITLE
fix: Round amount comparisons in loan repayment to avoid floating point errors

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -212,6 +212,8 @@ class LoanRepayment(LoanController):
 		if self.flags.from_bulk_payment:
 			return
 
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
 		reversed_accruals = []
 
 		if self.get("prepayment_charges") and loan_accounting_enabled(self.company):
@@ -227,13 +229,13 @@ class LoanRepayment(LoanController):
 
 		on_settlement_or_closure = False
 
-		if self.principal_amount_paid > 0 and self.principal_amount_paid >= self.pending_principal_amount:
+		if flt(self.principal_amount_paid, precision) > 0 and flt(self.principal_amount_paid, precision) >= flt(self.pending_principal_amount, precision):
 			on_settlement_or_closure = True
 
 		if self.repayment_type in ("Advance Payment", "Pre Payment"):
 			reversed_accruals += self.reverse_future_accruals_and_demands(on_settlement_or_closure=on_settlement_or_closure)
 
-		if self.principal_amount_paid < self.pending_principal_amount:
+		if flt(self.principal_amount_paid, precision) < flt(self.pending_principal_amount, precision):
 			if (
 				self.is_term_loan
 				and self.repayment_type in ("Advance Payment", "Pre Payment")
@@ -263,7 +265,7 @@ class LoanRepayment(LoanController):
 					self.process_reschedule()
 
 		if self.repayment_type not in ("Advance Payment", "Pre Payment") or (
-			self.principal_amount_paid >= self.pending_principal_amount
+			flt(self.principal_amount_paid, precision) >= flt(self.pending_principal_amount, precision)
 		):
 			self.book_interest_accrued_not_demanded()
 			if self.is_term_loan:


### PR DESCRIPTION
**Issue:**
When a loan repayment pays off the exact pending principal amount, sometimes the comparison principal_amount_paid < pending_principal_amount becomes True instead of False due to floating point precision errors.

Example:

principal_amount_paid: 14.059999999999945 (due to floating point math)
pending_principal_amount: 14.06 (exact)

Comparison: 14.059999999999945 < 14.06 → True (should be False)

This causes the system to wrongly create a Loan Restructure document, which then fails validation.

<img width="5735" height="1894" alt="image" src="https://github.com/user-attachments/assets/b8f06194-bedd-4ab2-acba-c26710136175" />


**Fix:**
Round both amounts to the same precision (2 decimal places) before comparing them. This ensures amounts that are mathematically equal are treated as equal.