### PR TITLE
fix: pass salary period end date as value_date in create_repayment_entry

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2519,6 +2519,7 @@ def create_repayment_entry(
 	penalty_amount=None,
 	payroll_payable_account=None,
 	process_payroll_accounting_entry_based_on_employee=0,
+	value_date=None,
 ):
 
 	lr = frappe.get_doc(
@@ -2528,7 +2529,7 @@ def create_repayment_entry(
 			"payment_type": payment_type,
 			"company": company,
 			"posting_date": posting_date,
-			"value_date": getdate(),
+			"value_date": value_date or getdate(),
 			"applicant": applicant,
 			"penalty_amount": penalty_amount,
 			"interest_payable": interest_payable,


### PR DESCRIPTION
When a salary slip is submitted for a future payroll period (for example, July payroll submitted in June), the EMI demand whose demand_date falls within that future period was not being found during loan repayment validation. This was because value_date was hardcoded to getdate() (today's date), which is earlier than the demand_date, so get_unpaid_demands filtered it out. As a result, interest_payable was 0 and the full EMI was credited to principal with no demand settled.

Added an optional value_date parameter to create_repayment_entry() so callers can pass the correct business date.