### PR TITLE
feat: Disbursement Analysis Report

### DIFF
--- a/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.js
+++ b/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.js
@@ -1,0 +1,120 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["Disbursement Analysis Report"] = {
+	filters: [
+		{
+			"fieldname":"company",
+			"label": __("Company"),
+			"fieldtype": "Link",
+			"options": "Company",
+			"default": frappe.defaults.get_user_default("Company"),
+			"reqd": 1
+		},
+		{
+			"fieldname":"applicant_type",
+			"label": __("Applicant Type"),
+			"fieldtype": "Select",
+			"options": ["Customer", "Employee"],
+			"reqd": 1,
+			"default": "Customer",
+			on_change: function() {
+				frappe.query_report.set_filter_value('applicant', "");
+				frappe.query_report.set_filter_value('loan_product', "");
+				frappe.query_report.set_filter_value('loan', "");
+				frappe.query_report.set_filter_value('loan_disbursement', "");
+				frappe.query_report.refresh();
+			}
+		},
+		{
+			"fieldname": "applicant",
+			"label": __("Applicant"),
+			"fieldtype": "Dynamic Link",
+			"get_options": function() {
+				var applicant_type = frappe.query_report.get_filter_value('applicant_type');
+				var applicant = frappe.query_report.get_filter_value('applicant');
+				if(applicant && !applicant_type) {
+					frappe.throw(__("Please select Applicant Type first"));
+				}
+				return applicant_type;
+			},
+			"get_query": function() {
+				let applicant_type = frappe.query_report.get_filter_value('applicant_type');
+				let company = frappe.query_report.get_filter_value('company');
+
+				if (applicant_type === "Employee") {
+					return {
+						filters: {
+							company: company
+						}
+					};
+				}
+				return {};
+			},
+			on_change: function() {
+				frappe.query_report.set_filter_value('loan_product', "");
+				frappe.query_report.set_filter_value('loan', "");
+				frappe.query_report.refresh();
+			}
+		},
+		{
+			"fieldname":"loan_product",
+			"label": __("Loan Product"),
+			"fieldtype": "Link",
+			"options": "Loan Product",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: {
+						company: company,
+					},
+				};
+			},
+			on_change: function() {
+				frappe.query_report.set_filter_value("loan", "");
+				frappe.query_report.set_filter_value("loan_disbursement", "");
+				frappe.query_report.refresh();
+			}
+		},
+		{
+			"fieldname":"loan",
+			"label": __("Loan"),
+			"fieldtype": "Link",
+			"options": "Loan",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				var loan_product = frappe.query_report.get_filter_value("loan_product");
+				return {
+					filters: {
+						company: company,
+						docstatus: 1,
+						loan_product: loan_product || undefined,
+					},
+				};
+			},
+			on_change: function() {
+				frappe.query_report.set_filter_value("loan_disbursement", "");
+				frappe.query_report.refresh();
+			}
+		},
+		{
+			"fieldname":"loan_disbursement",
+			"label": __("Loan Disbursement"),
+			"fieldtype": "Link",
+			"options": "Loan Disbursement",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				var loan = frappe.query_report.get_filter_value("loan");
+				var loan_product = frappe.query_report.get_filter_value("loan_product");
+				return {
+					filters: {
+						company: company,
+						docstatus: 1,
+						against_loan: loan || undefined,
+						loan_product: loan_product || undefined,
+					},
+				};
+			},
+		},
+	],
+};

--- a/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.json
+++ b/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.json
@@ -1,0 +1,32 @@
+{
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2026-06-08 10:39:49.087475",
+ "disable_prepared_report_automation": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "generate_csv": 0,
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2026-06-08 10:39:49.087475",
+ "modified_by": "Administrator",
+ "module": "Loan Management",
+ "name": "Disbursement Analysis Report",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Loan Disbursement",
+ "report_name": "Disbursement Analysis Report",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "Loan Manager"
+  }
+ ],
+ "timeout": 0
+}

--- a/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.py
+++ b/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe import _
+
+
+def execute(filters: dict | None = None):
+	"""Return columns and data for the report.
+
+	This is the main entry point for the report. It accepts the filters as a
+	dictionary and should return columns and data. It is called by the framework
+	every time the report is refreshed or a filter is updated.
+	"""
+	columns = get_columns()
+	data = get_data()
+
+	return columns, data
+
+
+def get_columns() -> list[dict]:
+	"""Return columns for the report.
+
+	One field definition per column, just like a DocType field definition.
+	"""
+	return [
+		{
+			"label": _("Column 1"),
+			"fieldname": "column_1",
+			"fieldtype": "Data",
+		},
+		{
+			"label": _("Column 2"),
+			"fieldname": "column_2",
+			"fieldtype": "Int",
+		},
+	]
+
+
+def get_data() -> list[list]:
+	"""Return data for the report.
+
+	The report data is a list of rows, with each row being a list of cell values.
+	"""
+	return [
+		["Row 1", 1],
+		["Row 2", 2],
+	]

--- a/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.py
+++ b/lending/loan_management/report/disbursement_analysis_report/disbursement_analysis_report.py
@@ -1,48 +1,148 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe import _
+from frappe.query_builder import DocType
+from frappe.query_builder.functions import Coalesce
 
 
-def execute(filters: dict | None = None):
-	"""Return columns and data for the report.
-
-	This is the main entry point for the report. It accepts the filters as a
-	dictionary and should return columns and data. It is called by the framework
-	every time the report is refreshed or a filter is updated.
-	"""
+def execute(filters=None):
 	columns = get_columns()
-	data = get_data()
-
+	data = get_data(filters)
 	return columns, data
 
 
-def get_columns() -> list[dict]:
-	"""Return columns for the report.
-
-	One field definition per column, just like a DocType field definition.
-	"""
+def get_columns():
 	return [
 		{
-			"label": _("Column 1"),
-			"fieldname": "column_1",
+			"label": _("Loan Account"),
+			"fieldname": "loan_account",
+			"fieldtype": "Link",
+			"options": "Loan",
+			"width": 180,
+		},
+		{
+			"label": _("Loan Disbursement ID"),
+			"fieldname": "loan_disbursement_id",
+			"fieldtype": "Link",
+			"options": "Loan Disbursement",
+			"width": 180,
+		},
+		{
+			"label": _("Applicant"),
+			"fieldname": "applicant",
+			"fieldtype": "Dynamic Link",
+			"options": "applicant_type",
+			"width": 150,
+		},
+		{
+			"label": _("Applicant Type"),
+			"fieldname": "applicant_type",
 			"fieldtype": "Data",
+			"width": 120,
 		},
 		{
-			"label": _("Column 2"),
-			"fieldname": "column_2",
+			"label": _("Tranche Number"),
+			"fieldname": "tranche_number",
 			"fieldtype": "Int",
+			"width": 120,
+		},
+		{
+			"label": _("Interest Rate"),
+			"fieldname": "interest_rate",
+			"fieldtype": "Percent",
+			"width": 120,
+		},
+		{
+			"label": _("Maturity Date"),
+			"fieldname": "maturity_date",
+			"fieldtype": "Date",
+			"width": 130,
+		},
+		{
+			"label": _("Disbursement Date"),
+			"fieldname": "disbursement_date",
+			"fieldtype": "Date",
+			"width": 130,
+		},
+		{
+			"label": _("Disbursed Amount"),
+			"fieldname": "disbursed_amount",
+			"fieldtype": "Currency",
+			"width": 140,
+		},
+		{
+			"label": _("Charge Type"),
+			"fieldname": "charge_type",
+			"fieldtype": "Data",
+			"width": 200,
+		},
+		{
+			"label": _("Charge Amount"),
+			"fieldname": "charge_amount",
+			"fieldtype": "Currency",
+			"width": 140,
 		},
 	]
 
 
-def get_data() -> list[list]:
-	"""Return data for the report.
+def get_data(filters):
+	LoanDisbursement = DocType("Loan Disbursement")
+	Loan = DocType("Loan")
+	LoanDisbursementCharge = DocType("Loan Disbursement Charge")
+	LoanRepaymentSchedule = DocType("Loan Repayment Schedule")
 
-	The report data is a list of rows, with each row being a list of cell values.
-	"""
-	return [
-		["Row 1", 1],
-		["Row 2", 2],
-	]
+	# Subquery to get maturity date from repayment schedule
+	maturity_date_subquery = (
+		frappe.qb.from_(LoanRepaymentSchedule)
+		.select(LoanRepaymentSchedule.maturity_date)
+		.where(LoanRepaymentSchedule.loan_disbursement == LoanDisbursement.name)
+		.where(LoanRepaymentSchedule.docstatus == 1)
+		.where(LoanRepaymentSchedule.status.isin(["Active", "Closed"]))
+		.limit(1)
+	)
+
+	query = (
+		frappe.qb.from_(LoanDisbursement)
+		.left_join(Loan)
+		.on(LoanDisbursement.against_loan == Loan.name)
+		.left_join(LoanDisbursementCharge)
+		.on(LoanDisbursementCharge.parent == LoanDisbursement.name)
+		.select(
+			Loan.name.as_("loan_account"),
+			LoanDisbursement.name.as_("loan_disbursement_id"),
+			Loan.applicant.as_("applicant"),
+			Loan.applicant_type.as_("applicant_type"),
+			LoanDisbursement.tranche_number.as_("tranche_number"),
+			Loan.rate_of_interest.as_("interest_rate"),
+			maturity_date_subquery.as_("maturity_date"),
+			LoanDisbursement.disbursement_date.as_("disbursement_date"),
+			LoanDisbursement.disbursed_amount.as_("disbursed_amount"),
+			Coalesce(LoanDisbursementCharge.charge, "").as_("charge_type"),
+			Coalesce(LoanDisbursementCharge.amount, 0).as_("charge_amount"),
+		)
+		.where(LoanDisbursement.docstatus == 1)
+	)
+
+	if filters.get("company"):
+		query = query.where(LoanDisbursement.company == filters.get("company"))
+	if filters.get("applicant_type"):
+		query = query.where(Loan.applicant_type == filters.get("applicant_type"))
+	if filters.get("applicant"):
+		query = query.where(Loan.applicant == filters.get("applicant"))
+	if filters.get("loan_product"):
+		query = query.where(Loan.loan_product == filters.get("loan_product"))
+	if filters.get("loan"):
+		query = query.where(Loan.name == filters.get("loan"))
+	if filters.get("loan_disbursement"):
+		query = query.where(LoanDisbursement.name == filters.get("loan_disbursement"))
+
+	query = query.orderby(
+		LoanDisbursement.against_loan,
+		LoanDisbursement.disbursement_date,
+		LoanDisbursement.tranche_number,
+		LoanDisbursement.creation,
+	)
+
+	return query.run(as_dict=True)

--- a/lending/loan_management/report/disbursement_analysis_report/test_disbursement_analysis_report.py
+++ b/lending/loan_management/report/disbursement_analysis_report/test_disbursement_analysis_report.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from lending.loan_management.report.disbursement_analysis_report.disbursement_analysis_report import (
+	execute,
+	get_columns,
+	get_data,
+)
+from lending.tests.test_utils import create_loan, make_loan_disbursement_entry
+from lending.tests.utils import LendingTestSuite
+
+
+class TestDisbursementAnalysisReport(LendingTestSuite):
+	def test_disbursement_analysis_report_returns_expected_rows(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		disb = make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+			loan_disbursement_charges=[{"charge": "Processing Fee", "amount": 5000}],
+		)
+
+		columns, data = execute(
+			{"company": "_Test Company", "loan": loan.name, "loan_disbursement": disb.name}
+		)
+
+		self.assertTrue(data)
+		self.assertEqual(columns[0].get("fieldname"), "loan_account")
+
+		row = data[0]
+		self.assertEqual(row.get("loan_account"), loan.name)
+		self.assertEqual(row.get("loan_disbursement_id"), disb.name)
+		self.assertEqual(row.get("applicant"), "_Test Loan Customer")
+		self.assertEqual(row.get("applicant_type"), "Customer")
+		self.assertEqual(row.get("interest_rate"), 10)
+		self.assertEqual(row.get("disbursed_amount"), 100000)
+		self.assertEqual(row.get("charge_type"), "Processing Fee")
+		self.assertEqual(row.get("charge_amount"), 5000)
+		self.assertIsNotNone(row.get("maturity_date"))
+
+	def test_disbursement_analysis_report_assigns_tranche_numbers_in_order(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-08-05",
+			posting_date="2024-07-01",
+			rate_of_interest=10,
+		)
+		loan.submit()
+
+		# Created out of chronological order; report should reflect tranche sequencing by date.
+		make_loan_disbursement_entry(
+			loan.name, 50000, disbursement_date="2024-07-15", repayment_start_date="2024-08-05"
+		)
+		make_loan_disbursement_entry(
+			loan.name, 30000, disbursement_date="2024-07-20", repayment_start_date="2024-08-05"
+		)
+		make_loan_disbursement_entry(
+			loan.name, 20000, disbursement_date="2024-07-10", repayment_start_date="2024-08-05"
+		)
+
+		columns, data = execute({"company": "_Test Company", "loan": loan.name})
+
+		# Ordered by disbursement_date, so tranche numbers should ascend 1, 2, 3.
+		tranche_numbers = [row.get("tranche_number") for row in data]
+		self.assertEqual(tranche_numbers, [1, 2, 3])
+
+		disbursement_dates = [row.get("disbursement_date") for row in data]
+		self.assertEqual(disbursement_dates, sorted(disbursement_dates))
+
+	def test_disbursement_analysis_report_filters_by_applicant_type(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+		)
+
+		data = get_data({"company": "_Test Company", "applicant_type": "Customer", "loan": loan.name})
+		self.assertTrue(data)
+		self.assertTrue(all(row.get("applicant_type") == "Customer" for row in data))
+
+		# No Employee applicants exist for this loan, so the result set should be empty.
+		empty = get_data(
+			{"company": "_Test Company", "applicant_type": "Employee", "loan": loan.name}
+		)
+		self.assertEqual(empty, [])
+
+	def test_disbursement_analysis_report_defines_columns(self):
+		columns = get_columns()
+		fieldnames = [c.get("fieldname") for c in columns]
+		self.assertIn("loan_account", fieldnames)
+		self.assertIn("tranche_number", fieldnames)
+		self.assertIn("disbursed_amount", fieldnames)
+		self.assertIn("charge_amount", fieldnames)


### PR DESCRIPTION
Adds a new **Disbursement Analysis Report** that gives a tranche-wise view of all loan disbursements, building on the tranche-number feature from #1211. It lets users analyze how a loan was disbursed across sequential tranches, along with the charges applied to each disbursement.

<img width="5760" height="2736" alt="image" src="https://github.com/user-attachments/assets/8137d9e7-3576-4acb-9cf3-e5f02444ca2a" />