### PR TITLE
fix: update get_payment_entry import path after ERPNext refactor

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -24,7 +24,7 @@ from frappe.utils import (
 from frappe.utils.caching import redis_cache
 
 import erpnext
-from erpnext.accounts.doctype.journal_entry.journal_entry import get_payment_entry
+from erpnext.accounts.doctype.journal_entry.mapper import get_payment_entry
 from erpnext.accounts.general_ledger import process_gl_map
 
 from lending.loan_management.controllers.loan_controller import LoanController


### PR DESCRIPTION
ERPNext moved `get_payment_entry` from `journal_entry.py` to a new
`journal_entry/mapper.py`. The old import in loan.py broke module loading,
causing `migrate` and CI `install lending` to fail.

Updated the import to the new path. Same function, no behavior change.