### PR TITLE
test: skip original GL entries in repost posting date check

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -227,11 +227,30 @@ class TestLoanRepaymentRepost(LendingTestSuite):
 
 		repayment_entry.load_from_db()
 
+		# After a repost, only the entries the repost generates (reversals + regenerated
+		# bookings) should carry the current posting date.
+		#
+		# This must hold regardless of the Immutable Ledger setting:
+		#   - Immutable Ledger OFF: the original entries are cancelled, so only repost
+		#     entries remain non-cancelled.
+		#   - Immutable Ledger ON:  the original entries are kept non-cancelled at their
+		#     original date by design, so they must be excluded from this check.
+		#
+		# We therefore exclude the original GL entries (captured before the repost) by name.
+		original_gl_entries = [d.name for d in repayments_1]
+
 		repayments_2 = frappe.db.get_all(
 			"GL Entry",
-			{"voucher_type": "Loan Repayment", "voucher_no": repayment_entry.name, "is_cancelled": 0},
-			["posting_date"]
+			{
+				"voucher_type": "Loan Repayment",
+				"voucher_no": repayment_entry.name,
+				"is_cancelled": 0,
+				"name": ("not in", original_gl_entries),
+			},
+			["posting_date"],
 		)
+
+		self.assertTrue(repayments_2, "Repost should have generated new GL entries")
 
 		for repayment_2 in repayments_2:
 			self.assertEqual(


### PR DESCRIPTION
The repost GL entry test checked that every non-cancelled GL entry of the repayment has the current posting date. This only held when Immutable Ledger was disabled.

With Immutable Ledger enabled, the original GL entries are kept non-cancelled at their original date by design, so the test failed for them.

The test now excludes the original entries (captured before the repost) and checks the current posting date only on the entries the repost generates. This passes with Immutable Ledger both enabled and disabled.