### PR TITLE
fix: use Charges Capitalization for post-restructure charges

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -124,14 +124,10 @@ class LoanRepayment(LoanController):
 
 		charges = None
 		if self.get("payable_charges"):
-			if self.repayment_type == "Charge Payment" or (self.repayment_type in ("Charges Waiver", "Charges Capitalization", "Principal Capitalization") and self.loan_restructure):
+			if self.repayment_type == "Charge Payment" or (self.repayment_type in ("Charges Waiver", "Charges Capitalization") and self.loan_restructure):
 				charges = [d.get("charge_code") for d in self.get("payable_charges")]
 			else:
-				frappe.throw(
-					_(
-						"Payable Charges can only be added for Charge Payment, or for Charges Waiver/Charges Capitalization/Principal Capitalization during Loan Restructure"
-					)
-				)
+				frappe.throw(_("Payable Charges can only be added if Charge Payment, or for Charges Waiver/Capitalization during Loan Restructure"))
 
 		amounts = calculate_amounts(
 			self.against_loan,
@@ -1540,14 +1536,7 @@ class LoanRepayment(LoanController):
 		amounts = self.update_amounts_for_write_off_recovery(loan_status, amounts)
 		amount_paid = self.amount_paid
 
-		if self.repayment_type == "Charge Payment" or (
-			self.repayment_type in ("Charges Waiver", "Charges Capitalization")
-			and self.loan_restructure
-		) or (
-			self.repayment_type == "Principal Capitalization"
-			and self.loan_restructure
-			and self.get("payable_charges")
-		):
+		if self.repayment_type == "Charge Payment" or (self.repayment_type in ("Charges Waiver", "Charges Capitalization") and self.loan_restructure):
 			amount_paid = self.allocate_charges(amount_paid, amounts.get("unpaid_demands"))
 		else:
 			amount_paid = self.allocate_amount_against_demands(loan_status, amounts, amount_paid)
@@ -2033,9 +2022,7 @@ class LoanRepayment(LoanController):
 				)
 			return
 
-		if self.repayment_type == "Principal Capitalization" and self.loan_restructure and not any(
-			d.sales_invoice for d in self.get("repayment_details")
-		):
+		if self.repayment_type == "Principal Capitalization" and self.loan_restructure:
 			return
 
 		if cancel:
@@ -2362,7 +2349,6 @@ class LoanRepayment(LoanController):
 			"Interest Capitalization": "loan_account",
 			"Penalty Capitalization": "loan_account",
 			"Charges Capitalization": "loan_account",
-			"Principal Capitalization": "loan_account",
 		}
 
 		if self.repayment_type in (

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -827,7 +827,7 @@ class LoanRestructure(AccountsController):
 				create_loan_repayment(
 					self.loan,
 					self.restructure_date,
-					"Principal Capitalization",
+					"Charges Capitalization",
 					sales_invoice.grand_total,
 					restructure_name=self.name,
 					charge_code=post_restructure_charges

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -252,7 +252,7 @@ class TestLoanRestructure(LendingTestSuite):
 
 		counts = Counter(repayments)
 
-		self.assertEqual(counts.get("Charges Capitalization", 0), 2)
+		self.assertEqual(counts.get("Charges Capitalization", 0), 3)
 		self.assertEqual(counts.get("Charges Waiver", 0), 1)
 
 		sales_invoice = frappe.db.get_value(


### PR DESCRIPTION
Follow-up to #1239.

When post-restructure charges are invoiced during a loan restructure, the repayment created for them was using the type "Principal Capitalization". That was not correct - these are charges, so the repayment should use "Charges Capitalization", which already handles this case in Loan Repayment.

- Loan Restructure: the auto-created repayment for post-restructure charges now uses "Charges Capitalization" instead of "Principal Capitalization".
- Loan Repayment: removed the extra "Principal Capitalization" handling added in #1239, since it is no longer needed.
