### PR TITLE
feat: improve loan dashboard connections

### DIFF
--- a/lending/loan_management/doctype/loan/loan_dashboard.py
+++ b/lending/loan_management/doctype/loan/loan_dashboard.py
@@ -8,33 +8,55 @@ def get_data():
 		},
 		"transactions": [
 			{
+				"label": "Schedule & Disbursement",
 				"items": [
 					"Loan Repayment Schedule",
-					"Loan Security Assignment",
-					"Loan Security Shortfall",
 					"Loan Disbursement",
 					"Loan Demand",
-				]
+				],
 			},
 			{
+				"label": "Repayment",
 				"items": [
 					"Loan Repayment",
 					"Loan Interest Accrual",
-					"Loan Write Off",
-					"Loan Restructure",
 					"Loan Refund",
-					"Loan Freeze Log",
-				]
+					"Loan Repayment Repost",
+				],
 			},
 			{
+				"label": "Security",
 				"items": [
+					"Loan Security Assignment",
+					"Loan Security Shortfall",
+					"Loan Security Deposit",
 					"Loan Security Release",
+				],
+			},
+			{
+				"label": "Adjustments",
+				"items": [
+					"Loan Restructure",
+					"Loan Write Off",
+					"Loan Adjustment",
+					"Loan Balance Adjustment",
+				],
+			},
+			{
+				"label": "Logs",
+				"items": [
 					"Days Past Due Log",
 					"Loan NPA Log",
+					"Loan Freeze Log",
+					"Loan Limit Change Log",
+				],
+			},
+			{
+				"label": "Accounting",
+				"items": [
 					"Journal Entry",
 					"Sales Invoice",
-					"Loan Limit Change Log",
-				]
+				],
 			},
 		],
 	}

--- a/lending/loan_management/doctype/loan_application/loan_application_dashboard.py
+++ b/lending/loan_management/doctype/loan_application/loan_application_dashboard.py
@@ -3,7 +3,7 @@ def get_data():
 		"fieldname": "loan_application",
 		"transactions": [
 			{
-				"label": "Loan",
+				"label": "Loan & Security",
 				"items": ["Loan", "Loan Security Assignment"],
 			},
 		],

--- a/lending/loan_management/doctype/loan_application/loan_application_dashboard.py
+++ b/lending/loan_management/doctype/loan_application/loan_application_dashboard.py
@@ -2,6 +2,9 @@ def get_data():
 	return {
 		"fieldname": "loan_application",
 		"transactions": [
-			{"items": ["Loan", "Loan Security Assignment"]},
+			{
+				"label": "Loan",
+				"items": ["Loan", "Loan Security Assignment"],
+			},
 		],
 	}

--- a/lending/loan_management/doctype/loan_demand/loan_demand_dashboard.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand_dashboard.py
@@ -3,7 +3,7 @@ def get_data():
 		"fieldname": "loan_demand",
 		"transactions": [
 			{
-				"label": "Repayment",
+				"label": "Accrual",
 				"items": ["Loan Interest Accrual"],
 			},
 		],

--- a/lending/loan_management/doctype/loan_demand/loan_demand_dashboard.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand_dashboard.py
@@ -1,0 +1,10 @@
+def get_data():
+	return {
+		"fieldname": "loan_demand",
+		"transactions": [
+			{
+				"label": "Repayment",
+				"items": ["Loan Interest Accrual"],
+			},
+		],
+	}

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement_dashboard.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement_dashboard.py
@@ -3,7 +3,20 @@ def get_data():
 		"fieldname": "loan_disbursement",
 		"transactions": [
 			{
-				"items": ["Loan Security Deposit", "Loan Repayment Schedule"],
+				"label": "Schedule",
+				"items": ["Loan Repayment Schedule", "Loan Security Deposit"],
+			},
+			{
+				"label": "Repayment",
+				"items": ["Loan Demand", "Loan Interest Accrual", "Loan Repayment", "Bulk Repayment Log"],
+			},
+			{
+				"label": "Adjustments",
+				"items": ["Loan Restructure", "Loan Write Off", "Loan Adjustment", "Loan Repayment Repost"],
+			},
+			{
+				"label": "Logs",
+				"items": ["Days Past Due Log"],
 			},
 		],
 	}

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -78,7 +78,8 @@
   "column_break_uxwo",
   "loan_partner_payment_ratio",
   "loan_partner_share_percentage",
-  "loan_partner_repayment_schedule_type"
+  "loan_partner_repayment_schedule_type",
+  "connections_tab"
  ],
  "fields": [
   {
@@ -575,12 +576,18 @@
    "hidden": 1,
    "label": "Is Invoice generated",
    "read_only": 1
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-30 07:46:26.499215",
+ "modified": "2026-06-16 13:58:07.513924",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment_dashboard.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment_dashboard.py
@@ -3,9 +3,12 @@ def get_data():
 		"fieldname": "loan_repayment",
 		"transactions": [
 			{
-				"items": [
-					"Loan Restructure",
-				]
+				"label": "Repayment",
+				"items": ["Loan Demand"],
+			},
+			{
+				"label": "Adjustments",
+				"items": ["Loan Restructure"],
 			},
 		],
 	}

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment_dashboard.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment_dashboard.py
@@ -3,7 +3,7 @@ def get_data():
 		"fieldname": "loan_repayment",
 		"transactions": [
 			{
-				"label": "Repayment",
+				"label": "Demand",
 				"items": ["Loan Demand"],
 			},
 			{

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.json
@@ -56,7 +56,8 @@
   "partner_loan_share_percentage",
   "partner_repayment_schedule_type",
   "co_lender_schedule_section",
-  "colender_schedule"
+  "colender_schedule",
+  "connections_tab"
  ],
  "fields": [
   {
@@ -382,13 +383,19 @@
    "fieldname": "disbursement_charges",
    "fieldtype": "Currency",
    "label": "Disbursement Charges"
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-21 12:13:00.031037",
+ "modified": "2026-06-16 08:42:20.244122",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Schedule",

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule_dashboard.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule_dashboard.py
@@ -3,7 +3,7 @@ def get_data():
 		"fieldname": "loan_repayment_schedule",
 		"transactions": [
 			{
-				"label": "Repayment",
+				"label": "Demand & Accrual",
 				"items": ["Loan Demand", "Loan Interest Accrual"],
 			},
 		],

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule_dashboard.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule_dashboard.py
@@ -1,0 +1,10 @@
+def get_data():
+	return {
+		"fieldname": "loan_repayment_schedule",
+		"transactions": [
+			{
+				"label": "Repayment",
+				"items": ["Loan Demand", "Loan Interest Accrual"],
+			},
+		],
+	}


### PR DESCRIPTION
Improves the dashboard connections on loan documents so users can find related records easily, without having to search for them each time.

The connection cards are now grouped into clear sections, the missing doctypes have been added, and a Connections tab is shown on the key documents.

**Changes**

**Loan**
- Connection cards are grouped section-wise: Schedule & Disbursement, Repayment, Security, Adjustments, Logs, and Accounting.
- Added the missing linked doctypes: Loan Security Deposit, Loan Adjustment, Loan Balance Adjustment, and Loan Repayment Repost.

**Loan Disbursement**
- Added all the doctypes that link to it, grouped into sections (Schedule, Repayment, Adjustments, Logs).

**Loan Repayment**
- Added Loan Demand and grouped the cards (Demand, Adjustments).
- Added a Connections tab so the dashboard shows in its own tab.

**Loan Repayment Schedule**
- Added a dashboard (Demand & Accrual) and a Connections tab.

**Loan Demand**
- Added a dashboard (Accrual).

**Loan Application**
- Applied the same grouped style (Loan & Security).
