### PR TITLE
chore: add version-16 to release config

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - version-1
+      - version-16
 jobs:
   release:
     name: Release

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,5 @@
 {
-	"branches": ["version-1"],
+	"branches": ["version-1", "version-16"],
 	"plugins": [
 		"@semantic-release/commit-analyzer", {
 			"preset": "angular",


### PR DESCRIPTION
The release workflow and semantic-release config only listed version-1, so merges into version-16 did not trigger an automatic release or version bump. This adds version-16 alongside version-1 in both files so releases run for both branches.