### PR TITLE
fix: cancel and unlink loan related documents on cancel and delete of a loan

### DIFF
--- a/lending/hooks.py
+++ b/lending/hooks.py
@@ -248,6 +248,19 @@ update_gl_dict_with_app_based_fields = ["lending.overrides.gl_entry.update_value
 
 # ignore_links_on_delete = ["Communication", "ToDo"]
 
+ignore_links_on_delete = [
+	"Bulk Repayment Log",
+	"Days Past Due Log",
+	"Loan Freeze Log",
+	"Loan Limit Change Log",
+	"Loan NPA Log",
+	"Loan Restructure Limit Log",
+	"Process Loan Classification",
+	"Process Loan Demand",
+	"Process Loan Interest Accrual",
+	"Process Loan Security Shortfall",
+]
+
 # Request Events
 # ----------------
 # before_request = ["lending.utils.before_request"]

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -427,6 +427,7 @@ class Loan(LoanController):
 	def on_cancel(self):
 		self.cancel_and_delete_repayment_schedule()
 		self.cancel_loan_security_assignment()
+		self.cancel_process_loan_documents()
 		self.ignore_linked_doctypes = [
 			"GL Entry",
 			"Payment Ledger Entry",
@@ -446,6 +447,17 @@ class Loan(LoanController):
 
 		if self.is_imported:
 			self.make_gl_entries(cancel=1)
+
+	def on_trash(self):
+		if not frappe.db.get_single_value("Accounts Settings", "delete_linked_ledger_entries"):
+			return
+
+		frappe.db.delete("GL Entry", {"voucher_type": self.doctype, "voucher_no": self.name})
+		frappe.db.delete("GL Entry", {"against_voucher_type": self.doctype, "against_voucher": self.name})
+		frappe.db.delete("Payment Ledger Entry", {"voucher_type": self.doctype, "voucher_no": self.name})
+		frappe.db.delete(
+			"Payment Ledger Entry", {"against_voucher_type": self.doctype, "against_voucher_no": self.name}
+		)
 
 	# nosemgrep
 	def set_status(self):
@@ -628,6 +640,23 @@ class Loan(LoanController):
 				fields=["name"],
 			):
 				doc = frappe.get_doc("Loan Security Assignment", assignment.name)
+				doc.cancel()
+
+	def cancel_process_loan_documents(self):
+		process_doctypes = [
+			"Process Loan Demand",
+			"Process Loan Classification",
+			"Process Loan Interest Accrual",
+			"Process Loan Security Shortfall",
+		]
+		for doctype in process_doctypes:
+			for name in frappe.get_all(
+				doctype,
+				filters={"loan": self.name, "docstatus": 1},
+				pluck="name",
+			):
+				doc = frappe.get_doc(doctype, name)
+				doc.flags.ignore_links = True
 				doc.cancel()
 
 	def make_gl_entries(self, cancel=0, adv_adj=0):

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3519,3 +3519,71 @@ class TestLoan(LendingTestSuite):
 		self.assertFalse(frappe.db.exists("Loan Disbursement", {"against_loan": loan.name, "is_imported": 1}))
 		self.assertFalse(frappe.db.exists("Loan Interest Accrual", {"loan": loan.name, "is_imported": 1}))
 		self.assertFalse(frappe.db.exists("Loan Demand", {"loan": loan.name, "is_imported": 1}))
+
+	def test_cancel_loan_cancels_process_loan_documents(self):
+		posting_date = "2025-01-30"
+		loan = create_loan(
+			self.applicant2,
+			"Term Loan Product 1",
+			12000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date=posting_date,
+			posting_date=add_months(posting_date, -1),
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date=add_months(posting_date, -1),
+			repayment_start_date=posting_date,
+		)
+		process_loan_interest_accrual_for_loans(
+			posting_date=posting_date, loan=loan.name, company="_Test Company"
+		)
+		process_daily_loan_demands(posting_date=posting_date, loan=loan.name)
+
+		process_doctypes = ["Process Loan Demand", "Process Loan Interest Accrual"]
+
+		for doctype in process_doctypes:
+			self.assertTrue(
+				frappe.db.exists(doctype, {"loan": loan.name, "docstatus": 1}),
+				msg=f"Expected a submitted {doctype} for the loan",
+			)
+
+		for demand in frappe.get_all("Loan Demand", filters={"loan": loan.name, "docstatus": 1}, pluck="name"):
+			frappe.get_doc("Loan Demand", demand).cancel()
+		for accrual in frappe.get_all(
+			"Loan Interest Accrual", filters={"loan": loan.name, "docstatus": 1}, pluck="name"
+		):
+			frappe.get_doc("Loan Interest Accrual", accrual).cancel()
+		for disbursement in frappe.get_all(
+			"Loan Disbursement", filters={"against_loan": loan.name, "docstatus": 1}, pluck="name"
+		):
+			frappe.get_doc("Loan Disbursement", disbursement).cancel()
+
+		loan.load_from_db()
+		loan.cancel()
+
+		for doctype in process_doctypes:
+			self.assertFalse(
+				frappe.db.exists(doctype, {"loan": loan.name, "docstatus": 1}),
+				msg=f"{doctype} left in Submitted state after loan cancellation",
+			)
+
+		for doctype, fieldname in (
+			("Loan Demand", "loan"),
+			("Loan Interest Accrual", "loan"),
+			("Loan Disbursement", "against_loan"),
+			("Loan Repayment Schedule", "loan"),
+		):
+			for name in frappe.get_all(doctype, filters={fieldname: loan.name}, pluck="name"):
+				frappe.delete_doc(doctype, name, force=True)
+
+		frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 1)
+		try:
+			frappe.delete_doc("Loan", loan.name)
+		finally:
+			frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 0)
+		self.assertFalse(frappe.db.exists("Loan", loan.name))

--- a/lending/loan_management/doctype/process_loan_classification/process_loan_classification.py
+++ b/lending/loan_management/doctype/process_loan_classification/process_loan_classification.py
@@ -77,6 +77,9 @@ class ProcessLoanClassification(Document):
 					enqueue_after_commit=True,
 				)
 
+	def on_cancel(self):
+		self.ignore_linked_doctypes = ["Days Past Due Log"]
+
 
 def process_loan_classification_batch(
 	open_loans,

--- a/lending/loan_management/doctype/process_loan_demand/process_loan_demand.py
+++ b/lending/loan_management/doctype/process_loan_demand/process_loan_demand.py
@@ -41,6 +41,9 @@ class ProcessLoanDemand(Document):
 			process_loan_demand=self.name,
 		)
 
+	def on_cancel(self):
+		self.ignore_linked_doctypes = ["Loan Demand"]
+
 
 def process_daily_loan_demands(posting_date=None, loan_product=None, loan=None):
 	loan_process = frappe.new_doc("Process Loan Demand")

--- a/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/process_loan_interest_accrual/process_loan_interest_accrual.py
@@ -46,6 +46,9 @@ class ProcessLoanInterestAccrual(Document):
 			loan_disbursement=self.loan_disbursement,
 		)
 
+	def on_cancel(self):
+		self.ignore_linked_doctypes = ["Loan Interest Accrual"]
+
 
 def schedule_accrual():
 	for company in frappe.get_all("Company", {"is_group": 0}, pluck="name"):

--- a/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.py
+++ b/lending/loan_management/doctype/process_loan_security_shortfall/process_loan_security_shortfall.py
@@ -32,6 +32,9 @@ class ProcessLoanSecurityShortfall(Document):
 	def on_submit(self):
 		check_for_ltv_shortfall(self.name)
 
+	def on_cancel(self):
+		self.ignore_linked_doctypes = ["Loan Security Shortfall"]
+
 
 def create_process_loan_security_shortfall():
 	if check_for_secured_loans():


### PR DESCRIPTION
**Problem**

A submitted Process Loan Demand could not be cancelled from the UI when linked Loan Demand records still pointed to it. Because it stayed in the Submitted state, the related Loan could not be deleted either. On a public bench this could not be fixed manually, as console access is not available.

**Changes**

**On cancel**
- Process Loan Demand, Process Loan Classification, Process Loan Interest Accrual and Process Loan Security Shortfall now ignore their linked child documents on cancel, so each one can be cancelled.
- When a Loan is cancelled, the above process documents for that loan are cancelled as well, so they are not left behind.

**On delete (unlink)**
- Loan log and process documents are added to `ignore_links_on_delete`, so they no longer block deletion of a loan. They are unlinked instead of being bulk deleted, which follows the framework convention used in Frappe, ERPNext, HRMS and India Compliance, and avoids timeouts on loans with many records.
- Core transactions (disbursement, repayment, demand and so on) are not unlinked, so they still need to be removed first. This keeps the data consistent and does not silently drop financial records.
- On delete, only the loan's own ledger entries are removed, gated by the Accounts Settings "Delete linked ledger entries" option, the same way ERPNext and India Compliance handle it.