### PR TITLE
fix: run long loan repayment reposts in background with status tracking

### DIFF
--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -158,7 +158,7 @@ class LoanDemand(LoanController):
 			fields = ["additional_interest_accrued", "additional_interest_receivable"]
 
 		accrual_account, receivable_account = frappe.db.get_value(
-			"Loan Product", self.loan_product, fields
+			"Loan Product", self.loan_product, fields, cache=True
 		)
 
 		if not accrual_account:
@@ -181,7 +181,10 @@ class LoanDemand(LoanController):
 
 		if self.demand_type == "BPI":
 			receivable_account, accrual_account = frappe.db.get_value(
-				"Loan Product", self.loan_product, ["interest_receivable_account", "interest_accrued_account"]
+				"Loan Product",
+				self.loan_product,
+				["interest_receivable_account", "interest_accrued_account"],
+				cache=True,
 			)
 
 			gl_entries = self.add_gl_entries(

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -185,7 +185,7 @@ class LoanInterestAccrual(LoanController):
 
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-		cost_center = frappe.db.get_value("Loan", self.loan, "cost_center")
+		cost_center = frappe.db.get_value("Loan", self.loan, "cost_center", cache=True)
 		account_details = frappe.db.get_value(
 			"Loan Product",
 			self.loan_product,
@@ -198,6 +198,7 @@ class LoanInterestAccrual(LoanController):
 				"additional_interest_accrued",
 			],
 			as_dict=1,
+			cache=True,
 		)
 
 		if self.interest_type == "Normal Interest":
@@ -614,6 +615,10 @@ def calculate_penal_interest_for_loans(
 	grace_period_days = cint(
 		frappe.get_value("Loan Product", loan_product, "grace_period_in_days", cache=True)
 	)
+	# Constant for the loan; fetch once instead of re-reading it for every day in the loop below.
+	interest_day_count_convention = frappe.get_cached_value(
+		"Company", loan.company, "interest_day_count_convention"
+	)
 	total_penal_interest = 0
 
 	if freeze_date and getdate(freeze_date) < getdate(posting_date):
@@ -673,7 +678,11 @@ def calculate_penal_interest_for_loans(
 					total_penal_interest += penal_interest_amount
 
 					per_day_interest = get_per_day_interest(
-						principal_amount, loan.rate_of_interest, loan.company, current_date
+						principal_amount,
+						loan.rate_of_interest,
+						loan.company,
+						current_date,
+						interest_day_count_convention=interest_day_count_convention,
 					)
 					additional_interest = flt(per_day_interest, precision)
 

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
@@ -13,6 +13,7 @@
   "delete_gl_entries",
   "column_break_bmnx",
   "repost_date",
+  "status",
   "cancel_future_accruals_and_demands",
   "ignore_on_cancel_amount_update",
   "cancel_future_emi_demands",
@@ -26,6 +27,16 @@
   {
    "fieldname": "section_break_kcrv",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Draft\nQueued\nIn Process\nCompleted\nCancelled",
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",
@@ -120,11 +131,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-26 11:46:37.007942",
+ "modified": "2026-06-29 18:09:41.593259",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Repost",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -141,7 +152,29 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [
+  {
+   "color": "Red",
+   "title": "Draft"
+  },
+  {
+   "color": "Yellow",
+   "title": "Queued"
+  },
+  {
+   "color": "Orange",
+   "title": "In Process"
+  },
+  {
+   "color": "Green",
+   "title": "Completed"
+  },
+  {
+   "color": "Red",
+   "title": "Cancelled"
+  }
+ ]
 }

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -2,10 +2,11 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.utils import add_days, cint, flt, getdate
+from frappe.utils import add_days, add_months, cint, flt, getdate
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 	calculate_amounts,
@@ -41,6 +42,7 @@ class LoanRepaymentRepost(Document):
 		loan_disbursement: DF.Link | None
 		repayment_entries: DF.Table[LoanRepaymentRepostDetail]
 		repost_date: DF.Date
+		status: DF.Literal["Draft", "Queued", "In Process", "Completed", "Cancelled"]
 	# end: auto-generated types
 
 	def validate(self):
@@ -69,11 +71,29 @@ class LoanRepaymentRepost(Document):
 				},
 			)
 
+	def submit(self):
+		# Run long reposts (over 6 months) in the background to avoid request timeouts.
+		if not frappe.flags.in_test and getdate(self.repost_date) < add_months(getdate(), -6):
+			frappe.msgprint(
+				_(
+					"This repost covers more than 6 months and has been enqueued as a background job. "
+					"Track its progress on the Status field. If it fails while processing, the system "
+					"adds a comment with the error and the document stays in Draft."
+				)
+			)
+			self.db_set("status", "Queued")
+			self.queue_action("submit", queue="long")
+		else:
+			self.db_set("status", "In Process")
+			self._submit()
+
 	def on_submit(self):
 		# Reposting from a past date regenerates potentially hundreds of accruals, demands,
 		# GL entries and Journal Entries in a single transaction.  Multiply the per-transaction
 		# write limit (default 200 000) by 4 so large reposts don't hit TooManyWritesError.
 		frappe.db.MAX_WRITES_PER_TRANSACTION *= 4
+
+		self.db_set("status", "In Process")
 
 		if self.clear_demand_allocation_before_repost:
 			self.clear_demand_allocation()
@@ -81,6 +101,11 @@ class LoanRepaymentRepost(Document):
 		self.trigger_on_cancel_events()
 		self.cancel_demands()
 		self.trigger_on_submit_events()
+
+		self.db_set("status", "Completed")
+
+	def on_cancel(self):
+		self.db_set("status", "Cancelled")
 
 	def cancel_demands(self):
 		from lending.loan_management.doctype.loan_demand.loan_demand import reverse_demands

--- a/lending/patches.txt
+++ b/lending/patches.txt
@@ -49,3 +49,4 @@ lending.patches.v1_0.update_value_date_in_pending_doctypes
 lending.patches.v16_0.add_enable_loan_accounting_field
 lending.patches.v16_0.update_is_invoice_generated_field
 lending.patches.v16_0.add_cancel_gl_queue_settings_in_company
+lending.patches.v16_0.update_status_in_loan_repayment_repost

--- a/lending/patches/v16_0/update_status_in_loan_repayment_repost.py
+++ b/lending/patches/v16_0/update_status_in_loan_repayment_repost.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Loan Repayment Repost", "status"):
+		return
+
+	repost = frappe.qb.DocType("Loan Repayment Repost")
+
+	frappe.qb.update(repost).set(repost.status, "Completed").where(repost.docstatus == 1).run()
+
+	frappe.qb.update(repost).set(repost.status, "Cancelled").where(repost.docstatus == 2).run()
+
+	(
+		frappe.qb.update(repost)
+		.set(repost.status, "Draft")
+		.where((repost.docstatus == 0) & (repost.status.isnull() | (repost.status == "")))
+		.run()
+	)


### PR DESCRIPTION
A Loan Repayment Repost creates one accrual and demand per day from the repost date up to today. For a date more than a few months back this can run for a long time, so when it is submitted from the form or the Data Import tool it can hit the request timeout and fail part way through.

This change submits a repost that covers more than 6 months as a background job on the long queue. Shorter reposts still run inline so the user gets an instant result.

**Status field**

Because a background submit only marks the document as Submitted once the worker finishes, the form would otherwise stay in Draft with no sign that work is happening. 


**Small performance touch ups**

A few Loan and Loan Product lookups that repeat for every demand and accrual during a repost are now cached. The repost output is unchanged.