### PR TITLE
fix: keep loan repayment repost status in sync with the background job

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.js
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.js
@@ -1,8 +1,20 @@
 // Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Loan Repayment Repost", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Loan Repayment Repost", {
+	refresh(frm) {
+		if (["Queued", "In Process"].includes(frm.doc.status)) {
+			frm.disable_save();
+			frm.page.clear_primary_action();
+			frm.set_read_only();
+			frm.dashboard.clear_comment();
+			frm.dashboard.add_comment(
+				__("This repost is {0} in the background. Please wait for it to finish.", [
+					__(frm.doc.status),
+				]),
+				"blue",
+				true
+			);
+		}
+	},
+});

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.json
@@ -35,6 +35,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
+   "no_copy": 1,
    "options": "Draft\nQueued\nIn Process\nCompleted\nCancelled",
    "read_only": 1
   },
@@ -131,7 +132,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-29 18:09:41.593259",
+ "modified": "2026-07-01 12:48:17.881670",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment Repost",

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -72,13 +72,20 @@ class LoanRepaymentRepost(Document):
 			)
 
 	def submit(self):
+		if self.status in ("Queued", "In Process"):
+			frappe.throw(
+				_("This repost is already {0}. Wait for it to finish before submitting again.").format(
+					self.status
+				)
+			)
+
 		# Run long reposts (over 6 months) in the background to avoid request timeouts.
 		if not frappe.flags.in_test and getdate(self.repost_date) < add_months(getdate(), -6):
 			frappe.msgprint(
 				_(
 					"This repost covers more than 6 months and has been enqueued as a background job. "
 					"Track its progress on the Status field. If it fails while processing, the system "
-					"adds a comment with the error and the document stays in Draft."
+					"adds a comment with the error."
 				)
 			)
 			self.db_set("status", "Queued")
@@ -86,6 +93,20 @@ class LoanRepaymentRepost(Document):
 		else:
 			self.db_set("status", "In Process")
 			self._submit()
+
+	def _submit(self):
+		# In the background a failure leaves the committed "Queued" status stuck, so reset it to
+		# Draft. Inline failures are rolled back with the request, so leave those to the framework.
+		if not getattr(frappe.local, "job", None):
+			return super()._submit()
+
+		try:
+			super()._submit()
+		except Exception:
+			frappe.db.rollback()
+			self.db_set("status", "Draft")
+			frappe.db.commit()
+			raise
 
 	def on_submit(self):
 		# Reposting from a past date regenerates potentially hundreds of accruals, demands,

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -72,10 +72,11 @@ class LoanRepaymentRepost(Document):
 			)
 
 	def submit(self):
-		if self.status in ("Queued", "In Process"):
+		current_status = frappe.db.get_value("Loan Repayment Repost", self.name, "status")
+		if current_status in ("Queued", "In Process"):
 			frappe.throw(
 				_("This repost is already {0}. Wait for it to finish before submitting again.").format(
-					self.status
+					current_status
 				)
 			)
 
@@ -89,24 +90,16 @@ class LoanRepaymentRepost(Document):
 				)
 			)
 			self.db_set("status", "Queued")
-			self.queue_action("submit", queue="long")
+			frappe.enqueue(
+				process_loan_repayment_repost,
+				queue="long",
+				timeout=36000,
+				enqueue_after_commit=True,
+				repost=self.name,
+			)
 		else:
 			self.db_set("status", "In Process")
 			self._submit()
-
-	def _submit(self):
-		# In the background a failure leaves the committed "Queued" status stuck, so reset it to
-		# Draft. Inline failures are rolled back with the request, so leave those to the framework.
-		if not getattr(frappe.local, "job", None):
-			return super()._submit()
-
-		try:
-			super()._submit()
-		except Exception:
-			frappe.db.rollback()
-			self.db_set("status", "Draft")
-			frappe.db.commit()
-			raise
 
 	def on_submit(self):
 		# Reposting from a past date regenerates potentially hundreds of accruals, demands,
@@ -491,3 +484,18 @@ class LoanRepaymentRepost(Document):
 				loan=self.loan,
 				loan_disbursement=self.loan_disbursement,
 			)
+
+
+def process_loan_repayment_repost(repost):
+	doc = frappe.get_doc("Loan Repayment Repost", repost)
+	try:
+		doc._submit()
+	except Exception:
+		frappe.db.rollback()
+		doc.db_set("status", "Draft")
+		doc.add_comment(
+			"Comment",
+			_("The repost did not finish and has been reset to Draft:") + f"<br>{frappe.get_traceback()}",
+		)
+		frappe.db.commit()
+		raise

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -72,7 +72,9 @@ class LoanRepaymentRepost(Document):
 			)
 
 	def submit(self):
-		current_status = frappe.db.get_value("Loan Repayment Repost", self.name, "status")
+		current_status = frappe.db.get_value(
+			"Loan Repayment Repost", self.name, "status", for_update=True
+		)
 		if current_status in ("Queued", "In Process"):
 			frappe.throw(
 				_("This repost is already {0}. Wait for it to finish before submitting again.").format(
@@ -492,6 +494,10 @@ def process_loan_repayment_repost(repost):
 		doc._submit()
 	except Exception:
 		frappe.db.rollback()
+		# If the repost is already submitted (e.g. a duplicate job ran it), do not reset the
+		# status - that would overwrite a completed repost with Draft.
+		if frappe.db.get_value("Loan Repayment Repost", repost, "docstatus") == 1:
+			return
 		doc.db_set("status", "Draft")
 		doc.add_comment(
 			"Comment",

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost_list.js
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost_list.js
@@ -1,0 +1,14 @@
+frappe.listview_settings["Loan Repayment Repost"] = {
+	has_indicator_for_draft: 1,
+	get_indicator: function (doc) {
+		const colors = {
+			Draft: "red",
+			Queued: "yellow",
+			"In Process": "orange",
+			Completed: "green",
+			Cancelled: "red",
+		};
+		const status = doc.status || "Draft";
+		return [__(status), colors[status], "status,=," + status];
+	},
+};


### PR DESCRIPTION
Stop a repost from being submitted again while it is still queued or running, so the same loan is not reposted twice.

When a background repost fails, the queued status was already saved and would stay stuck. Reset it back to Draft in that case so it can be submitted again.

Show the real status on the list view and, while a repost is queued or running, make the form read only and hide the submit button so no one edits or resubmits it by mistake.