### PR TITLE
fix: resolve lock-wait timeouts and cut repost overhead in loan write off and repayment repost

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -161,7 +161,7 @@ class Loan(LoanController):
 			self.set_onload("dashboard_info", info)
 
 	def validate_loan_product(self):
-		company = frappe.get_value("Loan Product", self.loan_product, "company")
+		company = frappe.get_cached_value("Loan Product", self.loan_product, "company")
 		if company != self.company:
 			frappe.throw(_("Please select Loan Product for company {0}").format(frappe.bold(self.company)))
 
@@ -216,12 +216,12 @@ class Loan(LoanController):
 	def set_default_charge_account(self):
 		for charge in self.get("loan_charges"):
 			if not charge.account:
-				account = frappe.get_cached_value(
+				account = frappe.db.get_value(
 					"Loan Charges", {"parent": self.loan_product, "charge_type": charge.charge}, "income_account"
 				)
 
 				if not account:
-					account = frappe.get_cached_value(
+					account = frappe.db.get_value(
 						"Item Default", {"parent": charge.charge, "company": self.company}, "income_account"
 					)
 
@@ -550,7 +550,7 @@ class Loan(LoanController):
 			self.posting_date = nowdate()
 
 		if self.loan_product and not self.rate_of_interest:
-			self.rate_of_interest = frappe.db.get_value(
+			self.rate_of_interest = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "rate_of_interest"
 			)
 
@@ -710,7 +710,7 @@ class Loan(LoanController):
 		return self.get("posting_date") or getdate()
 
 	def get_opening_accounts_from_loan_product(self):
-		accounts = frappe.db.get_value(
+		accounts = frappe.get_cached_value(
 			"Loan Product",
 			self.loan_product,
 			["loan_account", "payment_account"],
@@ -884,7 +884,7 @@ def request_loan_closure(loan: str, posting_date: str | date | datetime | None =
 
 	loan_product, loan_status = frappe.get_value("Loan", loan, ["loan_product", "status"])
 
-	write_off_limit = frappe.get_value("Loan Product", loan_product, "write_off_amount")
+	write_off_limit = frappe.get_cached_value("Loan Product", loan_product, "write_off_amount")
 
 	if pending_amount and abs(pending_amount) < write_off_limit or loan_status == "Settled":
 		# Auto create loan write off and update status as loan closure requested
@@ -1779,7 +1779,7 @@ def move_unpaid_interest_to_suspense_ledger(loan, posting_date=None, value_date=
 
 	unbooked_interest = get_unbooked_interest(loan, posting_date, last_demand_date=last_demand_date)
 
-	accounts = frappe.db.get_value(
+	accounts = frappe.get_cached_value(
 		"Loan Product",
 		loan_product,
 		[
@@ -2073,7 +2073,7 @@ def make_journal_entry(
 
 @frappe.whitelist()
 def get_cyclic_date(loan_product: str, posting_date: str | date | datetime, ignore_bpi: bool = False):
-	cycle_day, min_days_bw_disbursement_first_repayment = frappe.db.get_value(
+	cycle_day, min_days_bw_disbursement_first_repayment = frappe.get_cached_value(
 		"Loan Product",
 		loan_product,
 		["cyclic_day_of_the_month", "min_days_bw_disbursement_first_repayment"],

--- a/lending/loan_management/doctype/loan_demand/loan_demand.py
+++ b/lending/loan_management/doctype/loan_demand/loan_demand.py
@@ -535,6 +535,10 @@ def create_loan_demand(
 		demand.loan_repayment = loan_repayment
 		demand.is_imported = is_imported
 		demand.is_partial_pre_paid_interest = is_partial_pre_paid_interest
+
+		if frappe.flags.on_repost:
+			demand.flags.notify_update = False
+
 		demand.save()
 		demand.submit()
 
@@ -584,6 +588,8 @@ def reverse_demands(
 	for demand in frappe.get_all("Loan Demand", filters=filters, or_filters=or_filters):
 		doc = frappe.get_doc("Loan Demand", demand.name, for_update=True)
 		doc.flags.ignore_links = True
+		if frappe.flags.on_repost:
+			doc.flags.notify_update = False
 		doc.cancel()
 
 

--- a/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -539,6 +539,9 @@ def make_loan_interest_accrual_entry(
 		loan_interest_accrual.loan_disbursement = loan_disbursement
 		loan_interest_accrual.is_imported = is_imported
 
+		if frappe.flags.on_repost:
+			loan_interest_accrual.flags.notify_update = False
+
 		loan_interest_accrual.save()
 		loan_interest_accrual.submit()
 
@@ -624,6 +627,23 @@ def calculate_penal_interest_for_loans(
 	if freeze_date and getdate(freeze_date) < getdate(posting_date):
 		posting_date = freeze_date
 
+	principal_amount_map = {}
+	repayment_schedule_details = [d.repayment_schedule_detail for d in demands if d.repayment_schedule_detail]
+	if repayment_schedule_details:
+		for row in frappe.db.get_all(
+			"Loan Demand",
+			filters={
+				"loan": loan.name,
+				"repayment_schedule_detail": ("in", repayment_schedule_details),
+				"demand_type": "EMI",
+				"demand_subtype": "Principal",
+			},
+			fields=["repayment_schedule_detail", "outstanding_amount"],
+			order_by="creation desc",
+		):
+			if row.repayment_schedule_detail not in principal_amount_map:
+				principal_amount_map[row.repayment_schedule_detail] = row.outstanding_amount
+
 	for demand in demands:
 		penal_interest_amount = 0
 		additional_interest = 0
@@ -656,34 +676,33 @@ def calculate_penal_interest_for_loans(
 			else:
 				from_date = add_days(last_accrual_date, 1)
 
-			principal_amount = frappe.db.get_value(
-				"Loan Demand",
-				{
-					"loan": loan.name,
-					"repayment_schedule_detail": demand.repayment_schedule_detail,
-					"demand_type": "EMI",
-					"demand_subtype": "Principal",
-				},
-				"outstanding_amount",
-			)
+			principal_amount = principal_amount_map.get(demand.repayment_schedule_detail)
 
 			if not principal_amount:
 				continue
 
+			pending_amount = flt(demand.pending_amount)
+
+			per_day_interest_cache = {}
+
 			for current_date in daterange(getdate(from_date), getdate(posting_date)):
 
-				penal_interest_amount = flt(demand.pending_amount) * penal_interest_rate / 36500
+				penal_interest_amount = pending_amount * penal_interest_rate / 36500
 
 				if flt(penal_interest_amount, precision) > 0:
 					total_penal_interest += penal_interest_amount
 
-					per_day_interest = get_per_day_interest(
-						principal_amount,
-						loan.rate_of_interest,
-						loan.company,
-						current_date,
-						interest_day_count_convention=interest_day_count_convention,
-					)
+					year = getdate(current_date).year
+					per_day_interest = per_day_interest_cache.get(year)
+					if per_day_interest is None:
+						per_day_interest = get_per_day_interest(
+							principal_amount,
+							loan.rate_of_interest,
+							loan.company,
+							current_date,
+							interest_day_count_convention=interest_day_count_convention,
+						)
+						per_day_interest_cache[year] = per_day_interest
 					additional_interest = flt(per_day_interest, precision)
 
 					if not is_future_accrual:
@@ -1118,6 +1137,8 @@ def cancel_accruals(filters, or_filters):
 		accrual_doc = frappe.get_doc("Loan Interest Accrual", accrual.name, for_update=True)
 		if accrual_doc.docstatus == 1:
 			accrual_doc.flags.ignore_links = True
+			if frappe.flags.on_repost:
+				accrual_doc.flags.notify_update = False
 			accrual_doc.cancel()
 
 	return accruals

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -392,13 +392,30 @@ class LoanRepayment(LoanController):
 		self.create_auto_waiver()
 
 	def create_repost(self):
+		from lending.loan_management.doctype.loan_repayment_repost.loan_repayment_repost import (
+			process_loan_repayment_repost,
+		)
+
 		repost = frappe.new_doc("Loan Repayment Repost")
 		repost.loan = self.against_loan
 		repost.loan_disbursement = self.loan_disbursement
 		repost.repost_date = self.value_date
 		repost.cancel_future_accruals_and_demands = True
 		repost.cancel_future_emi_demands = True
-		repost.submit()
+		repost.insert()
+
+		if frappe.flags.in_test:
+			repost.submit()
+		else:
+			frappe.enqueue(
+				process_loan_repayment_repost,
+				queue="long",
+				timeout=36000,
+				enqueue_after_commit=True,
+				job_id=f"loan_repayment_repost::{self.against_loan}",
+				deduplicate=True,
+				repost=repost.name,
+			)
 
 	def check_import_total_amount(self):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
@@ -601,7 +618,7 @@ class LoanRepayment(LoanController):
 		}
 
 		if self.repayment_type in ("Write Off Recovery", "Write Off Settlement"):
-			write_off_recovery_account = frappe.db.get_value(
+			write_off_recovery_account = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "write_off_recovery_account"
 			)
 			if not write_off_recovery_account:
@@ -612,12 +629,12 @@ class LoanRepayment(LoanController):
 			self.loan_account = write_off_recovery_account
 
 		if not self.payment_account and repayment_account_map.get(self.repayment_type):
-			self.payment_account = frappe.db.get_value(
+			self.payment_account = frappe.get_cached_value(
 				"Loan Product", self.loan_product, repayment_account_map.get(self.repayment_type)
 			)
 
 		if not self.payment_account:
-			self.payment_account = frappe.db.get_value("Loan Product", self.loan_product, "payment_account")
+			self.payment_account = frappe.get_cached_value("Loan Product", self.loan_product, "payment_account")
 
 	def make_credit_note_for_charge_waivers(self, cancel=0):
 		base_amount_details = {}
@@ -974,7 +991,7 @@ class LoanRepayment(LoanController):
 			frappe.throw(_("Amount paid cannot be zero"))
 
 		if self.repayment_type == "Loan Closure":
-			auto_write_off_amount = frappe.db.get_value(
+			auto_write_off_amount = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "write_off_amount"
 			)
 
@@ -1085,7 +1102,7 @@ class LoanRepayment(LoanController):
 
 		if self.repayment_type == "Write Off Settlement":
 			auto_write_off_amount = flt(
-				frappe.db.get_value("Loan Product", self.loan_product, "write_off_amount")
+				frappe.get_cached_value("Loan Product", self.loan_product, "write_off_amount")
 			)
 			if self.amount_paid >= self.payable_amount - auto_write_off_amount and self.flags.auto_close:
 				if self.repayment_schedule_type != "Line of Credit":
@@ -1275,7 +1292,7 @@ class LoanRepayment(LoanController):
 
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
-		auto_write_off_amount, excess_amount_limit = frappe.db.get_value(
+		auto_write_off_amount, excess_amount_limit = frappe.get_cached_value(
 			"Loan Product",
 			self.loan_product,
 			["write_off_amount", "excess_amount_acceptance_limit"],
@@ -2049,7 +2066,7 @@ class LoanRepayment(LoanController):
 		gle_map = []
 		payment_account = self.get_payment_account()
 
-		account_details = frappe.db.get_value(
+		account_details = frappe.get_cached_value(
 			"Loan Product",
 			self.loan_product,
 			[
@@ -2368,7 +2385,7 @@ class LoanRepayment(LoanController):
 			else:
 				payment_account = self.payment_account
 		else:
-			payment_account = frappe.db.get_value(
+			payment_account = frappe.get_cached_value(
 				"Loan Product",
 				self.loan_product,
 				payment_account_field_map.get(self.repayment_type),
@@ -2421,7 +2438,7 @@ class LoanRepayment(LoanController):
 		}
 		offset_field = offset_mapping[offset_name]
 
-		allocation_order = frappe.db.get_value("Loan Product", self.loan_product, offset_field)
+		allocation_order = frappe.get_cached_value("Loan Product", self.loan_product, offset_field)
 		if not allocation_order:
 			allocation_order = frappe.db.get_value("Company", self.company, offset_field)
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -407,12 +407,13 @@ class LoanRepayment(LoanController):
 		if frappe.flags.in_test:
 			repost.submit()
 		else:
+			repost.db_set("status", "Queued")
 			frappe.enqueue(
 				process_loan_repayment_repost,
 				queue="long",
 				timeout=36000,
 				enqueue_after_commit=True,
-				job_id=f"loan_repayment_repost::{self.against_loan}",
+				job_id=f"loan_repayment_repost::{repost.name}",
 				deduplicate=True,
 				repost=repost.name,
 			)

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -660,13 +660,18 @@ class LoanRepayment(LoanController):
 
 				return base_amount_details
 
-			for demand in self.get("repayment_details"):
-				demand_doc = frappe.db.get_value(
+			loan_demand_names = [d.loan_demand for d in self.get("repayment_details") if d.loan_demand]
+			demand_doc_map = {}
+			if loan_demand_names:
+				for row in frappe.db.get_all(
 					"Loan Demand",
-					demand.loan_demand,
-					["company", "demand_subtype", "applicant", "loan", "sales_invoice"],
-					as_dict=1,
-				)
+					filters={"name": ("in", loan_demand_names)},
+					fields=["name", "company", "demand_subtype", "applicant", "loan", "sales_invoice"],
+				):
+					demand_doc_map[row.name] = row
+
+			for demand in self.get("repayment_details"):
+				demand_doc = demand_doc_map.get(demand.loan_demand)
 
 				waiver_account = self.get_charges_waiver_account(self.loan_product, demand.demand_subtype)
 				credit_note = make_credit_note(
@@ -2209,9 +2214,23 @@ class LoanRepayment(LoanController):
 
 			self.add_gl_entry(self.payment_account, against_account, self.total_charges_paid, gle_map)
 
+		charge_invoices = [
+			r.sales_invoice
+			for r in self.get("repayment_details")
+			if r.demand_type == "Charges" and r.sales_invoice
+		]
+		debit_to_map = {}
+		if charge_invoices:
+			for row in frappe.db.get_all(
+				"Sales Invoice",
+				filters={"name": ("in", charge_invoices)},
+				fields=["name", "debit_to"],
+			):
+				debit_to_map[row.name] = row.debit_to
+
 		for repayment in self.get("repayment_details"):
 			if repayment.demand_type == "Charges":
-				against_account = frappe.db.get_value("Sales Invoice", repayment.sales_invoice, "debit_to")
+				against_account = debit_to_map.get(repayment.sales_invoice)
 				if not against_account:
 					frappe.throw(_("Against Account is mandatory"))
 				self.add_gl_entry(

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.json
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.json
@@ -157,11 +157,12 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-05 18:45:57.713027",
+ "modified": "2026-07-02 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Write Off",
  "naming_rule": "Expression (old style)",
+ "queue_in_background": 1,
  "owner": "Administrator",
  "permissions": [
   {

--- a/lending/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -51,7 +51,7 @@ class LoanWriteOff(LoanController):
 			self.cost_center = erpnext.get_default_cost_center(self.company)
 
 		if not self.write_off_account:
-			self.write_off_account = frappe.db.get_value(
+			self.write_off_account = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "write_off_account"
 			)
 
@@ -355,7 +355,7 @@ def write_off_suspense_entries(
 	if is_settled and not on_payment_allocation:
 		is_write_off = 1
 
-	accounts = frappe.db.get_value(
+	accounts = frappe.get_cached_value(
 		"Loan Product",
 		loan_product,
 		[


### PR DESCRIPTION
**Summary**

Production hit intermittent `Lock wait timeout exceeded (1205)`, `Deadlock found (1213)`, and `TimestampMismatchError` during bulk **Loan Write Off** submission and **Loan Repayment Repost**, plus reposts that ran for hours.

This PR fixes the root causes:

1. Bulk Loan Write Off held one long transaction across the whole batch.
2. Loan Repayment ran its repost inline inside the repayment job, holding locks for the full repost.
3. The repost did large amounts of per-document overhead (UI realtime events, one DB query per iteration, repeated interest recomputation).
---

### Root Cause Analysis

**Issue 1 — Bulk Loan Write Off: `Lock wait timeout exceeded (1205)`**

**What happened (before)**

Frappe's bulk action submitted all documents in **one request = one transaction** and only committed at the end.

Every Loan Write Off posts a Journal Entry into the **same** shared suspense/waiver accounts. So the whole batch serialised on those account rows, holding locks for the entire batch.

When a concurrent process needed the same rows for longer than `innodb_lock_wait_timeout` (120s in client prod), it failed with `1205`. In the client log the batch broke at document 13 of 30.

The same contention also surfaced as `Deadlock (1213)` and `TimestampMismatchError`, the classic trio of concurrent-write contention on shared rows.

**Why we changed it**

The documents do not need to share a transaction. Each Loan Write Off should submit and commit independently so its account locks release immediately.

**The change**

Set `queue_in_background: 1` on the Loan Write Off DocType.

Frappe's bulk action then routes each document through `queue_submission`, giving each document its **own background job = its own transaction**.

Single (non-bulk) submits are unaffected.

```diff
+ "queue_in_background": 1,
```

**Before / After (measured on dev, 50 real loans, rolled back)**

```text
innodb_lock_wait_timeout = 50s (dev)

BEFORE (queue_in_background = 0):
  inline doc.submit() calls : 50   <- all in ONE transaction
  queue_submission calls    : 0
  Reproduced: QueryTimeoutError (1205, 'Lock wait timeout exceeded') after 50.4s

AFTER (queue_in_background = 1):
  inline doc.submit() calls : 0
  queue_submission calls    : 50   <- each write off = its OWN job/transaction
  No shared lock hold; contention removed.
```

**Extra benefit**

One failing write off no longer aborts the batch. Each is an isolated, independently retryable job.

Failures surface in the Submission Queue instead of instantly in the UI.

---

**Issue 2 — Loan Repayment Repost: `1205` on Repost Detail insert**

**What happened (before)**

LoanRepayment.create_repost created a Loan Repayment Repost and called repost.submit() inline, inside the repayment's own background job.

A repost regenerates hundreds of accruals, demands, GL and Journal Entries and takes for_update row locks.

Running it in the repayment's transaction kept those locks held for the full repost, so concurrent repayments on the same loan/applicant collided and timed out on the Loan Repayment Repost Detail insert.

**Why we changed it**

The repost should not extend the repayment's transaction — it should run as its own background job so the repayment commits and releases its locks immediately.

**The change**

create_repost now inserts the repost and enqueues it as its own background job (enqueue_after_commit=True) instead of submitting inline. Each repost is enqueued under a unique job_id (loan_repayment_repost::{repost.name}), so every repost is enqueued and processed and none is left orphaned in draft.

Note: this does not serialise concurrent reposts for the same loan; each repost runs as an independent job. In the normal flow, backdated repayments are processed sequentially. If strict per-loan serialisation is required, it can be added in a follow-up (per-loan job_id + a pick-any-pending drain of Queued reposts).

```diff
- repost.submit()
+ repost.insert()
+ if frappe.flags.in_test:
+     repost.submit()
+ else:
+     frappe.enqueue(
+         process_loan_repayment_repost,
+         queue="long",
+         timeout=36000,
+         enqueue_after_commit=True,
+         job_id=f"loan_repayment_repost::{self.name}",
+         deduplicate=True,
+         repost=repost.name,
+     )
```

**Before / After**

**Before**

- Repayment job transaction spans the whole repost.
- Locks held for minutes.
- `1205` lock wait timeouts.

**After**

- Repayment commits and releases locks immediately.
- Repost runs in its own job.
- The per-loan dedup key serialises reposts for the same loan.

---

**Issue 3 — Repost duration: per-document overhead**

A production profile of one repost the loan showed **12,915 s (~3.6 h)** for ~200,000 document operations (If Repost from two years ago).

Three removable overheads dominated.

**3a. Realtime UI events (~31% of the profile, 207,684 calls)**

Every document save/cancel fired `notify_update -> publish_realtime` (websocket/redis) to update a UI that nobody watches during a background repost.

**Change**

Set `flags.notify_update = False` on the accrual/demand documents created and cancelled under `frappe.flags.on_repost`.

This is honoured by core:

```python
if self.flags.get("notify_update", True):
    self.notify_update()
```

No financial data changes.

---

**3b. One DB query per iteration**

`calculate_penal_interest_for_loans`, `make_credit_note_for_charge_waivers` and the charge GL path each ran one `get_value` per demand/row.

**Change**

Batch-fetch once with `get_all(... "name"/detail in [...])`.

The penal-interest principal lookup is filtered by:

- loan
- repayment_schedule_detail
- EMI
- Principal

This combination is **not unique**. Cancelled and submitted duplicates coexist (common right after a repost).

The original `get_value` returned the row ordered by:

```text
creation DESC
LIMIT 1
```

(`Loan Demand` default `sort_order` is `creation desc`.)

The batch version mirrors this exactly:

- `order_by="creation desc"`
- keep the **first** row per detail

Verified against `get_value` across **144 duplicate details on 26 loans (including an 11-way duplicate)** with **0 mismatches**.

The other two maps key by `name` (primary key, unique), so no selection ambiguity.

---

**3c. Repeated interest recomputation**

`get_per_day_interest` was recomputed for every day in the penal date range, though its only date-dependent input is the year divisor.

**Change**

Cache `get_per_day_interest` by calendar year within the loop.

**Before / After (measured on dev, real data, rolled back)**

```text
BENCHMARK 1 — penal-interest principal lookup
(loan with 23 principal demands, 20 iterations)

BEFORE:
  460 DB calls
  279.9 ms
  (one get_value per demand)

AFTER:
   20 DB calls
   74.7 ms
  (one batched get_all)

-> 96% fewer DB calls
-> ~3.7x faster


BENCHMARK 2 — get_per_day_interest year-cache
(730-day date range)

BEFORE:
  0.6 ms
  (recomputed every day)

AFTER:
  0.1 ms
  (computed once per year)


Realtime events (from the production profile):

~207,684 publish_realtime calls
(~31% of the 3.6h)
removed for repost-created/cancelled docs.

Dev run measured 8,880 removable events on a ~4k-document repost.
```

---

**Also included: master-read caching (Issue 1/2 support)**

Repeated `frappe.db.get_value("Loan Product"/"Company", ...)` for the **same** master record within a transaction were converted to `frappe.get_cached_value` in the repayment, write off and loan paths.

Masters are immutable within a transaction, so the row is fetched once and reused.

Mutable reads (e.g. `Loan.status`, which the code writes mid-transaction) were left as live `get_value` to avoid stale reads.