### PR TITLE
feat: add sanctioned amount tolerance on loan product

### DIFF
--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -560,15 +560,16 @@ class Loan(LoanController):
 		)
 		if sanctioned_amount_limit:
 			total_loan_amount = get_total_loan_amount(self.applicant_type, self.applicant, self.company)
-
-		if sanctioned_amount_limit and flt(self.loan_amount) + flt(total_loan_amount) > flt(
-			sanctioned_amount_limit
-		):
-			frappe.throw(
-				_("Sanctioned Amount limit crossed for {0} {1}").format(
-					self.applicant_type, frappe.bold(self.applicant)
-				)
+			tolerance = flt(
+				frappe.db.get_value("Loan Product", self.loan_product, "sanctioned_amount_tolerance")
 			)
+
+			if flt(self.loan_amount) + flt(total_loan_amount) > flt(sanctioned_amount_limit) + tolerance:
+				frappe.throw(
+					_("Sanctioned Amount limit crossed for {0} {1}").format(
+						self.applicant_type, frappe.bold(self.applicant)
+					)
+				)
 
 	def cancel_and_delete_repayment_schedule(self):
 		schedules = frappe.db.get_all(

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -560,11 +560,14 @@ class Loan(LoanController):
 		)
 		if sanctioned_amount_limit:
 			total_loan_amount = get_total_loan_amount(self.applicant_type, self.applicant, self.company)
-			tolerance = flt(
-				frappe.db.get_value("Loan Product", self.loan_product, "sanctioned_amount_tolerance")
+			tolerance_percentage = flt(
+				frappe.db.get_value(
+					"Loan Product", self.loan_product, "sanctioned_amount_tolerance_percentage"
+				)
 			)
+			allowed_limit = flt(sanctioned_amount_limit) * (1 + tolerance_percentage / 100)
 
-			if flt(self.loan_amount) + flt(total_loan_amount) > flt(sanctioned_amount_limit) + tolerance:
+			if flt(self.loan_amount) + flt(total_loan_amount) > allowed_limit:
 				frappe.throw(
 					_("Sanctioned Amount limit crossed for {0} {1}").format(
 						self.applicant_type, frappe.bold(self.applicant)

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -370,7 +370,10 @@ class TestLoan(LendingTestSuite):
 		)
 		self.assertEqual(sanctioned_amount_limit, 1000000)
 
-		frappe.db.set_value("Loan Product", "Demand Loan", "sanctioned_amount_tolerance", 100)
+		# 0.01% tolerance on a 1,000,000 limit -> allowed limit of 1,000,100
+		frappe.db.set_value(
+			"Loan Product", "Demand Loan", "sanctioned_amount_tolerance_percentage", 0.01
+		)
 
 		# qty 4000.4 * price 500 * (1 - 50% haircut) = 1,000,100, exactly limit + tolerance -> allowed
 		at_tolerance_pledge = [{"loan_security": "Test Security 1", "qty": 4000.40}]
@@ -388,7 +391,7 @@ class TestLoan(LendingTestSuite):
 		)
 		self.assertRaises(frappe.ValidationError, loan_application.save)
 
-		frappe.db.set_value("Loan Product", "Demand Loan", "sanctioned_amount_tolerance", 0)
+		frappe.db.set_value("Loan Product", "Demand Loan", "sanctioned_amount_tolerance_percentage", 0)
 
 	def test_loan_closure(self):
 		pledge = [{"loan_security": "Test Security 1", "qty": 4000.00}]

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -345,6 +345,51 @@ class TestLoan(LendingTestSuite):
 		)
 		self.assertRaises(frappe.ValidationError, loan_application.save)
 
+	def test_sanctioned_amount_tolerance(self):
+		frappe.db.sql("DELETE FROM `tabLoan` where applicant = '_Test Loan Customer 1'")
+		frappe.db.sql("DELETE FROM `tabLoan Application` where applicant = '_Test Loan Customer 1'")
+		frappe.db.sql(
+			"DELETE FROM `tabLoan Security Assignment` where applicant = '_Test Loan Customer 1'"
+		)
+		frappe.db.delete(
+			"Sanctioned Loan Amount",
+			{"applicant": "_Test Loan Customer 1", "company": "_Test Company"},
+		)
+
+		create_loan_security_assignment(
+			applicant_type="Customer",
+			applicant=self.applicant3,
+			company="_Test Company",
+			securities=[{"loan_security": "Test Security 1", "qty": 4000.00}],
+		)
+
+		sanctioned_amount_limit = frappe.db.get_value(
+			"Sanctioned Loan Amount",
+			{"applicant": "_Test Loan Customer 1", "company": "_Test Company"},
+			"sanctioned_amount_limit",
+		)
+		self.assertEqual(sanctioned_amount_limit, 1000000)
+
+		frappe.db.set_value("Loan Product", "Demand Loan", "sanctioned_amount_tolerance", 100)
+
+		# qty 4000.4 * price 500 * (1 - 50% haircut) = 1,000,100, exactly limit + tolerance -> allowed
+		at_tolerance_pledge = [{"loan_security": "Test Security 1", "qty": 4000.40}]
+		loan_application = create_loan_application(
+			"_Test Company", self.applicant3, "Demand Loan", at_tolerance_pledge
+		)
+		self.assertTrue(frappe.db.exists("Loan Application", loan_application))
+
+		frappe.db.delete("Loan Application", {"applicant": "_Test Loan Customer 1"})
+
+		# qty 4000.8 * price 500 * (1 - 50% haircut) = 1,000,200, beyond limit + tolerance -> rejected
+		beyond_tolerance_pledge = [{"loan_security": "Test Security 1", "qty": 4000.80}]
+		loan_application = create_loan_application(
+			"_Test Company", self.applicant3, "Demand Loan", beyond_tolerance_pledge, do_not_save=True
+		)
+		self.assertRaises(frappe.ValidationError, loan_application.save)
+
+		frappe.db.set_value("Loan Product", "Demand Loan", "sanctioned_amount_tolerance", 0)
+
 	def test_loan_closure(self):
 		pledge = [{"loan_security": "Test Security 1", "qty": 4000.00}]
 

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -186,11 +186,14 @@ class LoanApplication(Document):
 
 		if sanctioned_amount_limit:
 			total_loan_amount = get_total_loan_amount(self.applicant_type, self.applicant, self.company)
-			tolerance = flt(
-				frappe.db.get_value("Loan Product", self.loan_product, "sanctioned_amount_tolerance")
+			tolerance_percentage = flt(
+				frappe.db.get_value(
+					"Loan Product", self.loan_product, "sanctioned_amount_tolerance_percentage"
+				)
 			)
+			allowed_limit = flt(sanctioned_amount_limit) * (1 + tolerance_percentage / 100)
 
-			if flt(self.loan_amount) + flt(total_loan_amount) > flt(sanctioned_amount_limit) + tolerance:
+			if flt(self.loan_amount) + flt(total_loan_amount) > allowed_limit:
 				frappe.throw(
 					_("Sanctioned Amount limit crossed for {0} {1}").format(
 						self.applicant_type, frappe.bold(self.applicant)

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -186,15 +186,16 @@ class LoanApplication(Document):
 
 		if sanctioned_amount_limit:
 			total_loan_amount = get_total_loan_amount(self.applicant_type, self.applicant, self.company)
-
-		if sanctioned_amount_limit and flt(self.loan_amount) + flt(total_loan_amount) > flt(
-			sanctioned_amount_limit
-		):
-			frappe.throw(
-				_("Sanctioned Amount limit crossed for {0} {1}").format(
-					self.applicant_type, frappe.bold(self.applicant)
-				)
+			tolerance = flt(
+				frappe.db.get_value("Loan Product", self.loan_product, "sanctioned_amount_tolerance")
 			)
+
+			if flt(self.loan_amount) + flt(total_loan_amount) > flt(sanctioned_amount_limit) + tolerance:
+				frappe.throw(
+					_("Sanctioned Amount limit crossed for {0} {1}").format(
+						self.applicant_type, frappe.bold(self.applicant)
+					)
+				)
 
 	def set_pledge_amount(self):
 		for proposed_pledge in self.proposed_pledges:

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -35,7 +35,7 @@
   "limits_section",
   "min_days_bw_disbursement_first_repayment",
   "excess_amount_acceptance_limit",
-  "sanctioned_amount_tolerance",
+  "sanctioned_amount_tolerance_percentage",
   "column_break_wwhp",
   "write_off_amount",
   "grace_period_in_days",
@@ -450,12 +450,11 @@
   },
   {
    "default": "0",
-   "description": "Allowed amount by which a new loan can exceed the applicant's sanctioned loan amount limit.",
-   "fieldname": "sanctioned_amount_tolerance",
-   "fieldtype": "Currency",
-   "label": "Sanctioned Amount Tolerance",
-   "non_negative": 1,
-   "options": "Company:company:default_currency"
+   "description": "Allowed percentage by which a new loan can exceed the applicant's sanctioned loan amount limit.",
+   "fieldname": "sanctioned_amount_tolerance_percentage",
+   "fieldtype": "Percent",
+   "label": "Sanctioned Amount Tolerance (%)",
+   "non_negative": 1
   },
   {
    "fieldname": "customer_refund_account",

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -35,6 +35,7 @@
   "limits_section",
   "min_days_bw_disbursement_first_repayment",
   "excess_amount_acceptance_limit",
+  "sanctioned_amount_tolerance",
   "column_break_wwhp",
   "write_off_amount",
   "grace_period_in_days",
@@ -448,6 +449,15 @@
    "label": "Excess Amount Acceptance Limit"
   },
   {
+   "default": "0",
+   "description": "Amount by which a new loan is allowed to exceed the applicant's sanctioned amount limit, to absorb rounding differences between LOS and Frappe. Set to 0 to disable.",
+   "fieldname": "sanctioned_amount_tolerance",
+   "fieldtype": "Currency",
+   "label": "Sanctioned Amount Tolerance",
+   "non_negative": 1,
+   "options": "Company:company:default_currency"
+  },
+  {
    "fieldname": "customer_refund_account",
    "fieldtype": "Link",
    "label": "Customer Refund Account",
@@ -535,7 +545,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-09 12:24:09.001135",
+ "modified": "2026-07-09 15:30:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_management/doctype/loan_product/loan_product.py
+++ b/lending/loan_management/doctype/loan_product/loan_product.py
@@ -68,6 +68,7 @@ class LoanProduct(Document):
 		repayment_date_on: DF.Literal["", "Start of the next month", "End of the current month"]
 		repayment_schedule_type: DF.Literal["", "Monthly as per repayment start date", "Pro-rated calendar months", "Monthly as per cycle date", "Line of Credit", "Flat Interest Rate"]
 		same_as_regular_interest_accounts: DF.Check
+		sanctioned_amount_tolerance: DF.Currency
 		security_deposit_account: DF.Link | None
 		subsidy_adjustment_account: DF.Link | None
 		suspense_collection_account: DF.Link | None

--- a/lending/loan_management/doctype/loan_product/loan_product.py
+++ b/lending/loan_management/doctype/loan_product/loan_product.py
@@ -68,7 +68,7 @@ class LoanProduct(Document):
 		repayment_date_on: DF.Literal["", "Start of the next month", "End of the current month"]
 		repayment_schedule_type: DF.Literal["", "Monthly as per repayment start date", "Pro-rated calendar months", "Monthly as per cycle date", "Line of Credit", "Flat Interest Rate"]
 		same_as_regular_interest_accounts: DF.Check
-		sanctioned_amount_tolerance: DF.Currency
+		sanctioned_amount_tolerance_percentage: DF.Percent
 		security_deposit_account: DF.Link | None
 		subsidy_adjustment_account: DF.Link | None
 		suspense_collection_account: DF.Link | None


### PR DESCRIPTION
### Problem

When a customer's securities are pledged, the system automatically sanctions a credit limit (**Sanctioned Loan Amount**) for that customer, equal to the post-haircut value of their pledged securities.

When a new loan (or loan application) is created, the system checks that:

> loan amount + customer's existing outstanding **must not exceed** the sanctioned limit.

This check was **exact, with zero tolerance**. If the requested loan was even **1 rupee** over the sanctioned limit, it was rejected with *"Sanctioned Amount limit crossed."*

In practice, the limit is often calculated in more than one place, and small **rounding differences** cause the limit to end up a few paise/rupees below the intended figure. As a result, loans that should be perfectly valid **fail at creation** and block legitimate business.

### Solution

Add a **Sanctioned Amount Tolerance (%)** field on **Loan Product** (Percent, defaults to `0`). The sanctioned-amount check now allows the total to exceed the sanctioned limit by this percentage:

```
allowed limit = sanctioned limit * (1 + tolerance % / 100)

reject only when:  loan amount + existing outstanding  >  allowed limit
```

Applied in both **Loan** and **Loan Application** creation. With tolerance `0` (default), behaviour is unchanged.

**Why a percentage and not a fixed amount:** a fixed amount does not scale with loan size. ₹100 is `0.01%` of a ₹10,00,000 loan (negligible, does not help) but `10%` of a ₹1,000 loan (far too large, could breach regulatory limits). A percentage keeps the tolerance proportionate across all loan sizes.

### Example (tolerance = 0.01%)

For a sanctioned limit of **₹10,00,000**, an 0.01% tolerance gives an allowed limit of **₹10,00,100**:

| Requested loan amount | Before (no tolerance) | After (tolerance 0.01%) |
|---|---|---|
| ₹10,00,050 | ❌ Rejected | ✅ Allowed |
| ₹10,00,100 (= allowed limit) | ❌ Rejected | ✅ Allowed |
| ₹10,00,101 | ❌ Rejected | ❌ Rejected |
| ₹10,00,200 | ❌ Rejected | ❌ Rejected |

The same 0.01% scales with the loan: on a ₹1,000 limit it allows only ₹1,000.10, so small loans are not over-exposed.

### Configuration

On the **Loan Product** form, under the **Limits** section, set **Sanctioned Amount Tolerance (%)** to the percentage you want to allow above the sanctioned limit. Leave it at `0` to keep the strict check.

<img width="4432" height="1792" alt="image" src="https://github.com/user-attachments/assets/0e38c49b-24f2-4255-b5cb-c8cc5ac01d25" />
