### PR TITLE
fix: serialize loan repayment reposts to stop deadlocks

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -14,9 +14,6 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 )
 from lending.loan_management.utils import update_repayment_schedule_demand_generated
 
-# Max wait for another repost's lock; 1.5x the longest observed repost run time (~4h).
-REPOST_LOCK_TIMEOUT = 21600
-
 
 class LoanRepaymentRepost(Document):
 	# begin: auto-generated types
@@ -494,7 +491,7 @@ class LoanRepaymentRepost(Document):
 def process_loan_repayment_repost(repost):
 	# Only one repost runs at a time to avoid deadlocks on shared GL/accrual rows.
 	try:
-		with frappe.db.advisory_lock("loan_repayment_repost", timeout=REPOST_LOCK_TIMEOUT):
+		with frappe.db.advisory_lock("loan_repayment_repost", timeout=21600):
 			_process_loan_repayment_repost(repost)
 	except frappe.QueryTimeoutError:
 		# Lock held far longer than any repost should take; retry once instead of failing outright.

--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -14,6 +14,9 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 )
 from lending.loan_management.utils import update_repayment_schedule_demand_generated
 
+# Max wait for another repost's lock; 1.5x the longest observed repost run time (~4h).
+REPOST_LOCK_TIMEOUT = 21600
+
 
 class LoanRepaymentRepost(Document):
 	# begin: auto-generated types
@@ -489,6 +492,16 @@ class LoanRepaymentRepost(Document):
 
 
 def process_loan_repayment_repost(repost):
+	# Only one repost runs at a time to avoid deadlocks on shared GL/accrual rows.
+	try:
+		with frappe.db.advisory_lock("loan_repayment_repost", timeout=REPOST_LOCK_TIMEOUT):
+			_process_loan_repayment_repost(repost)
+	except frappe.QueryTimeoutError:
+		# Lock held far longer than any repost should take; retry once instead of failing outright.
+		raise frappe.RetryBackgroundJobError
+
+
+def _process_loan_repayment_repost(repost):
 	doc = frappe.get_doc("Loan Repayment Repost", repost)
 	try:
 		doc._submit()
@@ -501,7 +514,8 @@ def process_loan_repayment_repost(repost):
 		doc.db_set("status", "Draft")
 		doc.add_comment(
 			"Comment",
-			_("The repost did not finish and has been reset to Draft:") + f"<br>{frappe.get_traceback()}",
+			_("The repost did not finish and has been reset to Draft:")
+			+ f"<br>{frappe.get_traceback()}",
 		)
 		frappe.db.commit()
 		raise


### PR DESCRIPTION
**Problem**

When multiple Loan Repayment Reposts ran at the same time (for example after a bulk Data Import), they often failed with database deadlock or lock-wait-timeout errors. This happened because each repost writes to the same shared GL accounts and interest accrual tables, and running several of them together caused them to block each other.

**Fix**

Only one repost now runs at a time. If a repost is submitted while another one is already running, it waits its turn instead of running in parallel. Once the first one finishes, the next one starts automatically.

**Testing**

Tested on test_site with real loan data (large repost history, multiple years old, many repayments per loan):
- Before this fix: running 25 reposts at once failed with deadlock/lock timeout errors on most of them.
- After this fix: the same 25 reposts at once completed without any deadlock or lock timeout error.