### PR TITLE
fix: preserve repayment_type before building GL entries on repost

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -370,6 +370,9 @@ class LoanRepaymentRepost(Document):
 			repayment_doc.set("pending_principal_amount", flt(pending_principal_amount, precision))
 			repayment_doc.run_method("before_validate")
 
+			if is_security_deposit_adjustment:
+				repayment_doc.repayment_type = "Security Deposit Adjustment"
+
 			repayment_doc.allocate_amounts(amounts)
 
 			if repayment_doc.repayment_type in ("Advance Payment", "Pre Payment") and (
@@ -428,14 +431,6 @@ class LoanRepaymentRepost(Document):
 						doc.make_gl_entries()
 
 					frappe.db.set_value("Loan", self.loan, "written_off_amount", write_off_amount)
-
-			if is_security_deposit_adjustment:
-				frappe.db.set_value(
-					"Loan Repayment",
-					entry.loan_repayment,
-					"repayment_type",
-					"Security Deposit Adjustment",
-				)
 
 			repayment_doc.flags.from_repost = False
 			frappe.flags.on_repost = False


### PR DESCRIPTION
**Summary**

Loan Repayment Repost can rebuild GL entries for a **Security Deposit Adjustment** repayment against the wrong account, with the wrong `voucher_subtype`.

**Cause**

During repost, `repayment_doc.run_method("before_validate")` runs before GL entries are rebuilt. If anything in that hook changes `repayment_type` away from `"Security Deposit Adjustment"`, the GL entries get built with the new (wrong) type — since both the debit account (`get_payment_account()`) and `voucher_subtype` are derived directly from `repayment_type` at that point.

The code already tried to correct this, but only by resetting the field on the document **after** GL entries were already created — too late to fix the GL data itself.

**Fix**

Re-assert `repayment_type = "Security Deposit Adjustment"` right after `before_validate`, before GL entries are built, so they're created correctly the first time. Removed the now-redundant post-submit fixup.

**Verified**

- Reproduced wrong account + wrong `voucher_subtype` on the old code.
- Confirmed correct account + `voucher_subtype` with the fix, including a full repost run (cancel + resubmit).