### PR TITLE
fix: align CI and tests

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -12,7 +12,7 @@ pip install frappe-bench
 
 LENDING_BRANCH=${BRANCH_TO_CLONE:-develop}
 
-if [[ "$LENDING_BRANCH" == "version-1" || "$LENDING_BRANCH" == "version-1-hotfix" ]]; then
+if [[ "$LENDING_BRANCH" == "version-1" || "$LENDING_BRANCH" == "version-1-hotfix" || "$LENDING_BRANCH" == "version-2-beta" ]]; then
     FRAPPE_BRANCH="version-15"
     ERPNEXT_BRANCH="version-15"
 else

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -15,13 +15,16 @@ LENDING_BRANCH=${BRANCH_TO_CLONE:-develop}
 if [[ "$LENDING_BRANCH" == "version-1" || "$LENDING_BRANCH" == "version-1-hotfix" || "$LENDING_BRANCH" == "version-2-beta" ]]; then
     FRAPPE_BRANCH="version-15"
     ERPNEXT_BRANCH="version-15"
+    PAYMENTS_BRANCH="version-15"
 else
     FRAPPE_BRANCH="develop"
     ERPNEXT_BRANCH="develop"
+    PAYMENTS_BRANCH="develop"
 fi
 
 echo "Using Frappe branch: $FRAPPE_BRANCH"
 echo "Using ERPNext branch: $ERPNEXT_BRANCH"
+echo "Using Payments branch: $PAYMENTS_BRANCH"
 echo "Using Lending branch: $LENDING_BRANCH"
 
 git clone https://github.com/frappe/frappe --branch $FRAPPE_BRANCH --depth 1
@@ -54,7 +57,7 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app payments
+bench get-app https://github.com/frappe/payments --branch $PAYMENTS_BRANCH
 bench get-app https://github.com/frappe/erpnext --branch $ERPNEXT_BRANCH --resolve-deps
 bench setup requirements --dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,14 @@ jobs:
           BRANCH_TO_CLONE: ${{ env.LENDING_BRANCH }}
 
       - name: Run Tests
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app lending --total-builds ${{ strategy.job-total }} --build-number ${{ matrix.container }}
+        run: |
+          cd ~/frappe-bench/
+          bench --site test_site run-parallel-tests --app lending --total-builds ${{ strategy.job-total }} --build-number ${{ matrix.container }} --with-coverage
+          if [ -f coverage.xml ] && [ ! -f sites/coverage.xml ]; then
+            mv coverage.xml sites/coverage.xml
+          fi
         env:
           TYPE: server
-          CAPTURE_COVERAGE: True
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4

--- a/lending/loan_management/doctype/bulk_repayment_log/test_bulk_repayment_log.py
+++ b/lending/loan_management/doctype/bulk_repayment_log/test_bulk_repayment_log.py
@@ -2,28 +2,14 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests.utils import FrappeTestCase
 
-# On IntegrationTestCase, the doctype test records and all
+# On FrappeTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-class UnitTestBulkRepaymentLog(UnitTestCase):
-	"""
-	Unit tests for BulkRepaymentLog.
-	Use this class for testing individual functions and methods.
-	"""
-
-	pass
-
-
-class IntegrationTestBulkRepaymentLog(IntegrationTestCase):
-	"""
-	Integration tests for BulkRepaymentLog.
-	Use this class for testing interactions between multiple components.
-	"""
-
+class TestBulkRepaymentLog(FrappeTestCase):
 	pass

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -73,7 +73,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoan(IntegrationTestCase):
+class TestLoan(FrappeTestCase):
 	def setUp(self):
 		set_loan_settings_in_company()
 		create_loan_accounts()

--- a/lending/loan_management/doctype/loan_accrual_repost/test_loan_accrual_repost.py
+++ b/lending/loan_management/doctype/loan_accrual_repost/test_loan_accrual_repost.py
@@ -2,16 +2,16 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
-# On IntegrationTestCase, the doctype test records and all
+# On FrappeTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-class IntegrationTestLoanAccrualRepost(IntegrationTestCase):
+class IntegrationTestLoanAccrualRepost(FrappeTestCase):
 	"""
 	Integration tests for LoanAccrualRepost.
 	Use this class for testing interactions between multiple components.

--- a/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
+++ b/lending/loan_management/doctype/loan_adjustment/test_loan_adjustment.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
@@ -21,7 +21,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanAdjustment(IntegrationTestCase):
+class TestLoanAdjustment(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
 from lending.tests.test_utils import (
 	create_loan,
@@ -13,7 +13,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanDisbursement(IntegrationTestCase):
+class TestLoanDisbursement(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/lending/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, date_diff, flt, getdate
 
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
@@ -24,7 +24,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanInterestAccrual(IntegrationTestCase):
+class TestLoanInterestAccrual(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_refund/test_loan_refund.py
+++ b/lending/loan_management/doctype/loan_refund/test_loan_refund.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
@@ -22,7 +22,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanRefund(IntegrationTestCase):
+class TestLoanRefund(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, add_months, date_diff, flt, get_datetime, getdate
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import (
@@ -31,7 +31,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanRepayment(IntegrationTestCase):
+class TestLoanRepayment(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt, get_datetime, getdate
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
@@ -24,7 +24,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanRepaymentRepost(IntegrationTestCase):
+class TestLoanRepaymentRepost(FrappeTestCase):
 	"""
 	Integration tests for LoanRepaymentRepost.
 	Use this class for testing interactions between multiple components.

--- a/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/test_loan_repayment_schedule.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, flt, get_datetime, getdate
 
 from lending.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import (
@@ -30,7 +30,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanRepaymentSchedule(IntegrationTestCase):
+class TestLoanRepaymentSchedule(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/test_loan_restructure.py
@@ -6,7 +6,7 @@ from collections import Counter
 import frappe
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Sum
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, date_diff, flt, getdate
 
 from erpnext.selling.doctype.customer.test_customer import get_customer_dict
@@ -33,7 +33,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanRestructure(IntegrationTestCase):
+class TestLoanRestructure(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt, get_datetime
 
 from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
@@ -20,7 +20,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanSecurityDeposit(IntegrationTestCase):
+class TestLoanSecurityDeposit(FrappeTestCase):
 	"""
 	Integration tests for LoanSecurityDeposit.
 	Use this class for testing interactions between multiple components.

--- a/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
+++ b/lending/loan_management/doctype/loan_write_off/test_loan_write_off.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_datetime
 
 from lending.tests.test_utils import (
@@ -14,7 +14,7 @@ from lending.tests.test_utils import (
 )
 
 
-class TestLoanWriteOff(IntegrationTestCase):
+class TestLoanWriteOff(FrappeTestCase):
 	def setUp(self):
 		master_init()
 		init_loan_products()

--- a/lending/loan_origination/doctype/loan_origination_settings/test_loan_origination_settings.py
+++ b/lending/loan_origination/doctype/loan_origination_settings/test_loan_origination_settings.py
@@ -2,16 +2,16 @@
 # See license.txt
 
 # import frappe
-from frappe.tests import IntegrationTestCase
+from frappe.tests.utils import FrappeTestCase
 
-# On IntegrationTestCase, the doctype test records and all
+# On FrappeTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
 # Use these module variables to add/remove to/from that list
 EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
 
 
-class IntegrationTestLoanOriginationSettings(IntegrationTestCase):
+class IntegrationTestLoanOriginationSettings(FrappeTestCase):
 	"""
 	Integration tests for LoanOriginationSettings.
 	Use this class for testing interactions between multiple components.


### PR DESCRIPTION
CI install script — install.sh only used Frappe/ERPNext version-15 for the old version-1 branches. This branch (version-2-beta) was falling through to develop, which caused the Python syntax error in CI. Added this branch to the version-15 list so CI now installs the correct Frappe/ERPNext version.

Test files — 14 test files used IntegrationTestCase and UnitTestCase, which only exist on develop and not on version-15. We changed all of them to use FrappeTestCase, which is the correct base class for version-15.