### PR TITLE
fix: do not refetch loan application values on already submitted loan

### DIFF
--- a/lending/loan_management/doctype/loan/loan.js
+++ b/lending/loan_management/doctype/loan/loan.js
@@ -15,7 +15,9 @@ frappe.ui.form.on('Loan', {
 		}
 	},
 	onload: function (frm) {
-		frm.trigger("loan_application")
+		if (frm.doc.__islocal) {
+			frm.trigger("loan_application")
+		}
 
 		// Ignore Loan Security Assignment on cancel of loan
 		frm.ignore_doctypes_on_cancel_all = ["Loan Security Assignment", "Loan Repayment Schedule", "Sales Invoice",


### PR DESCRIPTION

<img width="1322" height="266" alt="image" src="https://github.com/user-attachments/assets/c04429a6-7e93-44cf-9d26-f6e024fb63c1" />


Loan onload always ran the loan_application autofill, even for a submitted loan. This overwrote fields like monthly repayment amount with old values from the loan application, made the form show as not saved, and blocked the update button with a cannot change after submit error.