### PR TITLE
feat: configurable advance payment handling on loan product

### DIFF
--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -22,6 +22,7 @@
   "repayment_date_on",
   "repayment_schedule_type",
   "no_interest_till_month_end",
+  "advance_payment_handling",
   "days_past_due_threshold_for_npa",
   "is_term_loan",
   "validate_normal_repayment",
@@ -217,6 +218,14 @@
    "label": "Repayment Date On",
    "mandatory_depends_on": "eval:doc.repayment_schedule_type == \"Pro-rated calendar months\"",
    "options": "\nStart of the next month\nEnd of the current month"
+  },
+  {
+   "default": "Reduce Tenure",
+   "description": "Determines how an advance payment is handled while restructuring the loan schedule. \"Reduce Tenure\" keeps the EMI fixed and reduces the number of periods, while \"Reduce EMI\" keeps the number of periods fixed and reduces the EMI.",
+   "fieldname": "advance_payment_handling",
+   "fieldtype": "Select",
+   "label": "How to Handle Advance Payments",
+   "options": "Reduce Tenure\nReduce EMI"
   },
   {
    "description": "Loans will be marked as NPA when the days past due count exceed this threshold",

--- a/lending/loan_management/doctype/loan_product/loan_product.py
+++ b/lending/loan_management/doctype/loan_product/loan_product.py
@@ -28,6 +28,7 @@ class LoanProduct(Document):
 		additional_interest_receivable: DF.Link | None
 		additional_interest_suspense: DF.Link | None
 		additional_interest_waiver: DF.Link | None
+		advance_payment_handling: DF.Literal["Reduce Tenure", "Reduce EMI"]
 		amended_from: DF.Link | None
 		bpi_recovery_method: DF.Literal["", "Upfront Deduction", "Amortized Over Tenure", "Add to First EMI", "Add to Last EMI"]
 		bpi_treatment: DF.Literal["On top of first EMI", "Adjust within the EMI amount"]

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1587,8 +1587,6 @@ class LoanRepayment(LoanController):
 			amount_paid = self.allocate_amount_against_demands(loan_status, amounts, amount_paid)
 
 		if flt(amount_paid, precision) > 0:
-			self.validate_advance_payment(amount_paid, amounts, on_submit)
-
 			pending_interest = flt(amounts.get("unaccrued_interest")) + flt(
 				amounts.get("unbooked_interest")
 			)
@@ -1763,25 +1761,6 @@ class LoanRepayment(LoanController):
 			last_principal_demand = self.get("repayment_details")[-1]
 			last_principal_demand.paid_amount += abs(self.excess_amount)
 
-	def validate_advance_payment(self, amount_paid, amounts, on_submit):
-		precision = cint(frappe.db.get_default("currency_precision")) or 2
-		if self.is_term_loan and not on_submit:
-			if self.repayment_type == "Advance Payment":
-				filters = {"loan": self.against_loan, "status": "Active", "docstatus": 1}
-
-				if self.loan_disbursement:
-					filters["loan_disbursement"] = self.loan_disbursement
-
-				monthly_repayment_amount = frappe.db.get_value(
-					"Loan Repayment Schedule",
-					filters,
-					"monthly_repayment_amount",
-				)
-
-				if (flt(amount_paid, precision) < monthly_repayment_amount) or (
-					flt(amount_paid, precision) > (2 * monthly_repayment_amount)
-				):
-					frappe.throw(_("Amount for advance payment must be between one to two EMI amount"))
 
 	def allocate_amount_against_demands(self, loan_status, amounts, amount_paid):
 		precision = cint(frappe.db.get_default("currency_precision")) or 2

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -906,6 +906,66 @@ class TestLoanRepayment(LendingTestSuite):
 
 		self.assertTrue(repayment_schedule)
 
+	def test_partial_emi_advance_payment(self):
+		frappe.db.set_value(
+			"Company",
+			"_Test Company",
+			"collection_offset_sequence_for_standard_asset",
+			"Test EMI Based Standard Loan Demand Offset Order",
+		)
+
+		frappe.db.set_value("Loan Product", "Term Loan Product 4", "advance_payment_handling", "Reduce EMI")
+
+		loan = create_loan(
+			self.applicant2,
+			"Term Loan Product 4",
+			500000,
+			"Repay Over Number of Periods",
+			12,
+			applicant_type="Customer",
+			repayment_start_date="2024-05-05",
+			posting_date="2024-04-01",
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-04-01", repayment_start_date="2024-05-05"
+		)
+		process_daily_loan_demands(posting_date="2024-05-05", loan=loan.name)
+
+		# Clear the first EMI as a scheduled repayment
+		repayment_entry = create_repayment_entry(loan.name, "2024-05-05", 47523)
+		repayment_entry.submit()
+
+		# Make an advance payment smaller than one EMI
+		repayment_entry = create_repayment_entry(
+			loan.name, "2024-05-29", 20000, repayment_type="Advance Payment"
+		)
+		repayment_entry.submit()
+
+		lrs = frappe.get_doc(
+			"Loan Repayment Schedule", {"loan": loan.name, "docstatus": 1, "status": "Active"}
+		)
+
+		# A partial advance payment neither changes the tenure nor the EMI
+		self.assertEqual(lrs.repayment_periods, 12)
+		self.assertEqual(lrs.monthly_repayment_amount, 47523)
+
+		# The paid amount is adjusted against the upcoming demand as a principal demand
+		adjusted_principal = frappe.db.get_value(
+			"Loan Demand",
+			{
+				"loan": loan.name,
+				"demand_type": "EMI",
+				"demand_subtype": "Principal",
+				"demand_date": "2024-05-29",
+				"docstatus": 1,
+			},
+			"demand_amount",
+		)
+		self.assertEqual(adjusted_principal, 20000)
+
 	def test_advance_payment_before_first_payment(self):
 		set_loan_accrual_frequency(loan_accrual_frequency="Daily")
 

--- a/lending/loan_management/doctype/loan_restructure/loan_restructure.py
+++ b/lending/loan_management/doctype/loan_restructure/loan_restructure.py
@@ -952,7 +952,7 @@ def get_restructure_details(
 		"loan_disbursement": loan_disbursement,
 	}
 
-	if repayment_type == "Advance Payment":
+	if repayment_type == "Advance Payment" and get_advance_payment_handling(loan) == "Reduce EMI":
 		loan_restructure["new_repayment_method"] = "Repay Over Number of Periods"
 		loan_restructure["new_repayment_period_in_months"] = pending_tenure
 	else:
@@ -961,6 +961,13 @@ def get_restructure_details(
 		loan_restructure["new_repayment_period_in_months"] = pending_tenure
 
 	return loan_restructure
+
+
+def get_advance_payment_handling(loan):
+	loan_product = frappe.db.get_value("Loan", loan, "loan_product")
+	return (
+		frappe.db.get_value("Loan Product", loan_product, "advance_payment_handling") or "Reduce Tenure"
+	)
 
 
 def get_pending_tenure_and_start_date(loan, posting_date, repayment_type, loan_disbursement=None):


### PR DESCRIPTION
Advance payments were previously always rescheduled the loan as "Repay Over Number of Periods" (reduce EMI). This adds a "How to Handle Advance Payments" option on Loan Product with values "Reduce Tenure" (default) and "Reduce EMI", and honours it while generating the restructure.

- Reduce EMI  -> Repay Over Number of Periods (tenure fixed, EMI reduced)
- Reduce Tenure -> Repay Fixed Amount per Period (EMI fixed, tenure reduced)

Also drops the validation that forced advance payments to be between one and two EMIs, so partial advance payments are allowed and are adjusted against the upcoming demand. Adds a test for the partial advance payment flow.

<img width="1786" height="1412" alt="image" src="https://github.com/user-attachments/assets/abb915ba-b1d0-46d3-8fd2-e8860615bf50" />
