### PR TITLE
fix: allow cancel of security amount Loan Refund

### DIFF
--- a/lending/loan_management/doctype/loan_refund/loan_refund.py
+++ b/lending/loan_management/doctype/loan_refund/loan_refund.py
@@ -82,12 +82,10 @@ class LoanRefund(LoanController):
 			fieldname = "refund_amount"
 			amount = self.refund_amount
 
-		refund_amount = frappe.db.get_value("Loan", self.loan, fieldname)
-
 		if cancel:
-			refund_amount -= amount
-		else:
-			refund_amount += amount
+			amount = -1 * amount
+
+		refund_amount = frappe.db.get_value("Loan", self.loan, fieldname) + amount
 
 		if self.is_excess_amount_refund:
 			if not flt(refund_amount):
@@ -97,7 +95,7 @@ class LoanRefund(LoanController):
 		elif self.is_security_amount_refund:
 			loan_security_deposit = frappe.qb.DocType("Loan Security Deposit")
 
-			if self.refund_amount > flt(security_deposit_available_amount):
+			if not cancel and self.refund_amount > flt(security_deposit_available_amount):
 				frappe.throw(_("Refund amount cannot be more than available amount"))
 
 			frappe.qb.update(loan_security_deposit).set(

--- a/lending/loan_management/doctype/loan_refund/test_loan_refund.py
+++ b/lending/loan_management/doctype/loan_refund/test_loan_refund.py
@@ -125,3 +125,56 @@ class TestLoanRefund(LendingTestSuite):
 		)
 
 		self.assertTrue(repayment_schedule, "Repayment schedule not closed after refund")
+
+	def test_security_amount_refund_cancel_restores_available_amount(self):
+		set_loan_accrual_frequency("Daily")
+
+		posting_date = "2024-04-05"
+		repayment_start_date = "2024-05-05"
+
+		loan = create_loan(
+			self.applicant2,
+			"Term Loan Product 4",
+			1000000,
+			"Repay Over Number of Periods",
+			6,
+			applicant_type="Customer",
+			repayment_start_date=repayment_start_date,
+			posting_date=posting_date,
+			rate_of_interest=23,
+		)
+
+		loan.submit()
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date=posting_date,
+			withhold_security_deposit=True,
+		)
+
+		loan_security_deposit = frappe.db.get_value(
+			"Loan Security Deposit", {"loan": loan.name, "docstatus": 1}, "name"
+		)
+		available_amount_before_refund = frappe.db.get_value(
+			"Loan Security Deposit", loan_security_deposit, "available_amount"
+		)
+
+		refund = create_loan_refund(
+			loan.name, posting_date, 50000, is_security_amount_refund=1
+		)
+
+		available_amount_after_refund = frappe.db.get_value(
+			"Loan Security Deposit", loan_security_deposit, "available_amount"
+		)
+		self.assertEqual(available_amount_after_refund, available_amount_before_refund - 50000)
+
+		refund.cancel()
+
+		available_amount_after_cancel = frappe.db.get_value(
+			"Loan Security Deposit", loan_security_deposit, "available_amount"
+		)
+		refund_amount_after_cancel = frappe.db.get_value(
+			"Loan Security Deposit", loan_security_deposit, "refund_amount"
+		)
+		self.assertEqual(available_amount_after_cancel, available_amount_before_refund)
+		self.assertEqual(refund_amount_after_cancel, 0)


### PR DESCRIPTION
**Issue**
When cancelling a submitted Loan Refund with security amount refund, the system throws an error: "Refund amount cannot be more than available amount". This blocks the cancel action even for a valid refund.

**Cause**
The same check used for submit was also running for cancel. On cancel, the code was also reducing the Loan Security Deposit's available amount instead of adding it back.

**Fix**
Skip the available amount check when cancelling.
On cancel, correctly add the refund amount back to the Loan Security Deposit's available amount, and reduce its refund amount.