### PR TITLE
fix: keep loan status as Written Off after repost

### DIFF
--- a/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/loan_repayment_repost.py
@@ -218,7 +218,12 @@ class LoanRepaymentRepost(Document):
 					repayment_doc.pending_principal_amount > 0
 					and repayment_doc.principal_amount_paid >= repayment_doc.pending_principal_amount
 				):
-					frappe.db.set_value("Loan", repayment_doc.against_loan, "status", "Disbursed")
+					if repayment_doc.repayment_type not in (
+						"Write Off Recovery",
+						"Write Off Settlement",
+						"Full Settlement",
+					):
+						frappe.db.set_value("Loan", repayment_doc.against_loan, "status", "Disbursed")
 					repayment_doc.update_repayment_schedule_status(cancel=1)
 
 			LoanRepayment = DocType("Loan Repayment")

--- a/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
+++ b/lending/loan_management/doctype/loan_repayment_repost/test_loan_repayment_repost.py
@@ -300,3 +300,46 @@ class TestLoanRepaymentRepost(LendingTestSuite):
 
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Settled")
+
+	def test_loan_write_off_recovery_status_after_repost(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			2500000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			repayment_start_date="2024-11-05",
+			posting_date="2024-10-05",
+			rate_of_interest=25,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-10-05", repayment_start_date="2024-11-05"
+		)
+
+		process_daily_loan_demands(posting_date="2024-11-05", loan=loan.name)
+
+		create_loan_write_off(loan.name, "2024-11-05", write_off_amount=250000)
+
+		repayment_1 = create_repayment_entry(
+			loan.name, "2025-01-05", 750000, repayment_type="Write Off Recovery"
+		)
+		repayment_1.submit()
+
+		repayment_2 = create_repayment_entry(
+			loan.name, "2025-01-06", 1750000, repayment_type="Write Off Recovery"
+		)
+		repayment_2.submit()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Written Off")
+
+		# repayment_1 is backdated relative to repayment_2, so cancelling it
+		# triggers an auto repost that replays repayment_2. The loan must remain
+		# Written Off after the repost, not fall back to "Disbursed".
+		repayment_1.cancel()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Written Off")


### PR DESCRIPTION
**Issue:** 
When a loan was already written off, and a repost ran on it (for example, triggered by cancelling an earlier backdated repayment), the loan status could wrongly change from "Written Off" to "Disbursed". This happened even though the loan still had a Write Off Recovery, Write Off Settlement, or Full Settlement entry that should have kept it "Written Off". Once the status was wrong, posting a new Write Off Recovery/Settlement entry on that loan failed with the error "Incorrect repayment type, please write off the loan first".

**Fix:**
In the repost process, when an old entry is being replaced, the code was forcing the loan status to "Disbursed" without checking the entry type. The fix skips that forced status change for Write Off Recovery, Write Off Settlement, and Full Settlement entries, since their own logic already sets the correct status. A test was added that reproduces the original bug (fails without the fix) and confirms the loan stays "Written Off" after a repost.
