### PR TITLE
feat: add DTI/FOIR/LTV/EMI affordability fields to Loan Application

### DIFF
--- a/lending/loan_management/doctype/loan_application/loan_application.json
+++ b/lending/loan_management/doctype/loan_application/loan_application.json
@@ -39,6 +39,16 @@
   "loan_security_details_section",
   "proposed_pledges",
   "maximum_loan_amount",
+  "affordability_section",
+  "monthly_income",
+  "existing_obligations",
+  "column_break_afrd",
+  "proposed_emi",
+  "eligibility_amount",
+  "affordability_column_break",
+  "dti_ratio",
+  "foir_ratio",
+  "ltv_ratio",
   "repayment_info",
   "repayment_method",
   "total_payable_amount",
@@ -212,6 +222,69 @@
    "read_only": 1
   },
   {
+   "fieldname": "affordability_section",
+   "fieldtype": "Section Break",
+   "label": "Affordability"
+  },
+  {
+   "fieldname": "monthly_income",
+   "fieldtype": "Currency",
+   "label": "Monthly Income",
+   "options": "Company:company:default_currency"
+  },
+  {
+   "description": "Total of borrower's existing EMIs / monthly debt obligations, excluding this loan",
+   "fieldname": "existing_obligations",
+   "fieldtype": "Currency",
+   "label": "Existing Monthly Obligations",
+   "options": "Company:company:default_currency"
+  },
+  {
+   "fieldname": "column_break_afrd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "proposed_emi",
+   "fieldtype": "Currency",
+   "label": "Proposed EMI",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "description": "Maximum loan amount the applicant is eligible for, based on income and Maximum FOIR of the Loan Product",
+   "fieldname": "eligibility_amount",
+   "fieldtype": "Currency",
+   "label": "Eligibility Amount",
+   "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "affordability_column_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Existing Monthly Obligations / Monthly Income",
+   "fieldname": "dti_ratio",
+   "fieldtype": "Percent",
+   "label": "DTI Ratio",
+   "read_only": 1
+  },
+  {
+   "description": "(Existing Monthly Obligations + Proposed EMI) / Monthly Income",
+   "fieldname": "foir_ratio",
+   "fieldtype": "Percent",
+   "label": "FOIR Ratio",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.is_secured_loan == 1",
+   "description": "Loan Amount / Post-Haircut Value of Proposed Securities",
+   "fieldname": "ltv_ratio",
+   "fieldtype": "Percent",
+   "label": "LTV Ratio",
+   "read_only": 1
+  },
+  {
    "default": "0",
    "fetch_from": "loan_product.is_term_loan",
    "fieldname": "is_term_loan",
@@ -338,7 +411,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-02 16:03:38.065821",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Application",

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -22,6 +22,12 @@ from lending.loan_management.doctype.loan_repayment_schedule.loan_repayment_sche
 from lending.loan_management.doctype.loan_security_price.loan_security_price import (
 	get_loan_security_price,
 )
+from lending.loan_origination.loan_origination_utils import (
+	compute_dti_foir,
+	compute_eligibility_amount,
+	compute_emi_preview,
+	compute_ltv,
+)
 
 
 class LoanApplication(Document):
@@ -86,6 +92,7 @@ class LoanApplication(Document):
 
 		self.get_repayment_details()
 		self.check_sanctioned_amount_limit()
+		self.set_derived_variables()
 
 	def before_save(self):
 		if self.applicant_type == "Customer":
@@ -259,6 +266,31 @@ class LoanApplication(Document):
 			self.total_payable_interest += interest_amount
 
 		self.total_payable_amount = self.loan_amount + self.total_payable_interest
+
+	def set_derived_variables(self):
+		if self.is_term_loan:
+			self.proposed_emi = compute_emi_preview(
+				self.loan_product, self.loan_amount, self.rate_of_interest, self.repayment_periods, self.posting_date
+			)
+		else:
+			self.proposed_emi = 0
+
+		self.dti_ratio, self.foir_ratio = compute_dti_foir(
+			self.monthly_income, self.existing_obligations, self.proposed_emi
+		)
+
+		if self.is_secured_loan:
+			self.ltv_ratio = compute_ltv(self.loan_amount, self.proposed_pledges)
+		else:
+			self.ltv_ratio = 0
+
+		self.eligibility_amount = compute_eligibility_amount(
+			self.monthly_income,
+			self.existing_obligations,
+			self.rate_of_interest,
+			self.repayment_periods,
+			self.loan_product,
+		)
 
 	def set_loan_amount(self):
 		if self.is_secured_loan and not self.proposed_pledges:

--- a/lending/loan_management/doctype/loan_application/test_loan_application.py
+++ b/lending/loan_management/doctype/loan_application/test_loan_application.py
@@ -62,3 +62,174 @@ class TestLoanApplication(LendingTestSuite):
 		self.assertEqual(loan_application.total_payable_interest, 24657)
 		self.assertEqual(loan_application.total_payable_amount, 274657)
 		self.assertEqual(loan_application.repayment_amount, 11445)
+
+	def test_dti_foir_computed_on_validate(self):
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 100000
+		loan_application.existing_obligations = 10000
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.proposed_emi, 14923)
+		self.assertEqual(loan_application.dti_ratio, 10.0)
+		self.assertEqual(loan_application.foir_ratio, 24.92)
+
+	def test_dti_foir_zero_when_no_income(self):
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 0
+		loan_application.existing_obligations = 5000
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.dti_ratio, 0)
+		self.assertEqual(loan_application.foir_ratio, 0)
+
+	def test_eligibility_amount_respects_max_foir(self):
+		frappe.db.set_value("Loan Product", "Home Loan", "max_foir", 40)
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 100000
+		loan_application.existing_obligations = 0
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertTrue(loan_application.eligibility_amount > 0)
+
+		max_emi = 100000 * 40 / 100
+		monthly_rate = 9.2 / (12 * 100)
+		n = loan_application.repayment_periods
+		expected_principal = round(
+			max_emi * ((1 + monthly_rate) ** n - 1) / (monthly_rate * (1 + monthly_rate) ** n), 2
+		)
+		self.assertEqual(loan_application.eligibility_amount, expected_principal)
+
+	def test_eligibility_amount_zero_when_no_income(self):
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 0
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.eligibility_amount, 0)
+
+	def test_ltv_ratio_for_secured_loan(self):
+		from lending.tests.test_utils import create_loan_security, create_loan_security_type
+
+		create_loan_security_type()
+		create_loan_security()
+
+		loan_application = frappe.new_doc("Loan Application")
+		loan_application.update(
+			{
+				"applicant": self.applicant,
+				"loan_product": "Home Loan",
+				"rate_of_interest": 9.2,
+				"repayment_method": "Repay Over Number of Periods",
+				"repayment_periods": 18,
+				"company": "_Test Company",
+				"applicant_type": "Employee",
+				"applicant_email_address": "lending@example.com",
+				"applicant_phone_number": "+91-9102837465",
+				"is_secured_loan": 1,
+			}
+		)
+		loan_application.append(
+			"proposed_pledges",
+			{"loan_security": "Test Security 1", "qty": 4000, "loan_security_price": 100, "haircut": 50},
+		)
+		loan_application.insert()
+
+		self.assertEqual(loan_application.maximum_loan_amount, 200000)
+		self.assertEqual(loan_application.loan_amount, 200000)
+		self.assertEqual(loan_application.ltv_ratio, 100.0)
+
+	def test_ltv_ratio_zero_for_unsecured_loan(self):
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.is_secured_loan, 0)
+		self.assertEqual(loan_application.ltv_ratio, 0)
+
+	def test_ltv_ratio_partial_for_multiple_pledges(self):
+		from lending.tests.test_utils import create_loan_security, create_loan_security_type
+
+		create_loan_security_type()
+		create_loan_security()
+
+		loan_application = frappe.new_doc("Loan Application")
+		loan_application.update(
+			{
+				"applicant": self.applicant,
+				"loan_product": "Home Loan",
+				"rate_of_interest": 9.2,
+				"repayment_method": "Repay Over Number of Periods",
+				"repayment_periods": 18,
+				"company": "_Test Company",
+				"applicant_type": "Employee",
+				"applicant_email_address": "lending@example.com",
+				"applicant_phone_number": "+91-9102837465",
+				"is_secured_loan": 1,
+				"loan_amount": 100000,
+			}
+		)
+		loan_application.append(
+			"proposed_pledges",
+			{"loan_security": "Test Security 1", "qty": 2000, "loan_security_price": 100, "haircut": 50},
+		)
+		loan_application.append(
+			"proposed_pledges",
+			{"loan_security": "Test Security 2", "qty": 2000, "loan_security_price": 100, "haircut": 50},
+		)
+		loan_application.insert()
+
+		self.assertEqual(loan_application.maximum_loan_amount, 200000)
+		self.assertEqual(loan_application.ltv_ratio, 50.0)
+
+	def test_proposed_emi_zero_for_non_term_loan(self):
+		from lending.tests.test_utils import create_loan_product
+
+		create_loan_product(
+			"Utils Demand Loan",
+			"Utils Demand Loan",
+			500000,
+			9.2,
+			0,
+			0,
+		)
+
+		loan_application = frappe.new_doc("Loan Application")
+		loan_application.update(
+			{
+				"applicant": self.applicant,
+				"loan_product": "Utils Demand Loan",
+				"rate_of_interest": 9.2,
+				"loan_amount": 250000,
+				"company": "_Test Company",
+				"applicant_type": "Employee",
+				"applicant_email_address": "lending@example.com",
+				"applicant_phone_number": "+91-9102837465",
+			}
+		)
+		loan_application.insert()
+
+		self.assertEqual(loan_application.is_term_loan, 0)
+		self.assertEqual(loan_application.proposed_emi, 0)
+
+	def test_dti_zero_but_foir_positive_when_no_existing_obligations(self):
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 100000
+		loan_application.existing_obligations = 0
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.dti_ratio, 0)
+		self.assertTrue(loan_application.foir_ratio > 0)
+
+	def test_eligibility_amount_zero_when_obligations_exceed_foir_cap(self):
+		frappe.db.set_value("Loan Product", "Home Loan", "max_foir", 30)
+		loan_application = frappe.get_doc("Loan Application", {"applicant": self.applicant})
+		loan_application.monthly_income = 50000
+		loan_application.existing_obligations = 30000
+		loan_application.save()
+		loan_application.reload()
+
+		self.assertEqual(loan_application.eligibility_amount, 0)

--- a/lending/loan_management/doctype/loan_product/loan_product.json
+++ b/lending/loan_management/doctype/loan_product/loan_product.json
@@ -37,6 +37,7 @@
   "min_days_bw_disbursement_first_repayment",
   "excess_amount_acceptance_limit",
   "sanctioned_amount_tolerance_percentage",
+  "max_foir",
   "column_break_wwhp",
   "write_off_amount",
   "grace_period_in_days",
@@ -466,6 +467,14 @@
    "non_negative": 1
   },
   {
+   "default": "50",
+   "description": "Maximum Fixed Obligation to Income Ratio allowed for this loan product. Used to cap loan eligibility.",
+   "fieldname": "max_foir",
+   "fieldtype": "Percent",
+   "label": "Maximum FOIR (%)",
+   "non_negative": 1
+  },
+  {
    "fieldname": "customer_refund_account",
    "fieldtype": "Link",
    "label": "Customer Refund Account",
@@ -553,7 +562,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-10 10:00:00.000000",
+ "modified": "2026-08-05 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Product",

--- a/lending/loan_origination/loan_origination_utils.py
+++ b/lending/loan_origination/loan_origination_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.utils import flt, getdate
+
+
+def compute_emi_preview(loan_product, loan_amount, rate_of_interest, repayment_periods, posting_date=None):
+	if not (loan_product and loan_amount and rate_of_interest and repayment_periods):
+		return 0
+
+	schedule = frappe.new_doc("Loan Repayment Schedule")
+	schedule.loan_product = loan_product
+	schedule.repayment_frequency = "Monthly"
+	schedule.repayment_method = "Repay Over Number of Periods"
+	schedule.repayment_periods = repayment_periods
+	schedule.rate_of_interest = rate_of_interest
+	schedule.posting_date = getdate()
+	schedule.repayment_start_date = getdate(posting_date)
+	schedule.loan_amount = loan_amount
+	schedule.current_principal_amount = loan_amount
+	schedule.moratorium_tenure = 0
+	schedule.moratorium_type = ""
+	schedule.repayment_schedule_type = frappe.db.get_value("Loan Product", loan_product, "repayment_schedule_type")
+	schedule.validate()
+
+	if schedule.get("repayment_schedule"):
+		return flt(schedule.repayment_schedule[0].total_payment, 2)
+	return 0
+
+
+def compute_dti_foir(monthly_income, existing_obligations, proposed_emi):
+	monthly_income = flt(monthly_income)
+	existing_obligations = flt(existing_obligations)
+	proposed_emi = flt(proposed_emi)
+
+	if not monthly_income:
+		return 0, 0
+
+	dti_ratio = (existing_obligations / monthly_income) * 100
+	foir_ratio = ((existing_obligations + proposed_emi) / monthly_income) * 100
+
+	return flt(dti_ratio, 2), flt(foir_ratio, 2)
+
+
+def compute_ltv(loan_amount, proposed_pledges):
+	loan_amount = flt(loan_amount)
+	if not loan_amount or not proposed_pledges:
+		return 0
+
+	total_post_haircut = sum(flt(pledge.post_haircut_amount) for pledge in proposed_pledges)
+	if not total_post_haircut:
+		return 0
+
+	return flt((loan_amount / total_post_haircut) * 100, 2)
+
+
+def get_max_foir(loan_product):
+	max_foir = frappe.db.get_value("Loan Product", loan_product, "max_foir")
+	return flt(max_foir) or 50.0
+
+
+def compute_eligibility_amount(
+	monthly_income, existing_obligations, rate_of_interest, repayment_periods, loan_product
+):
+	monthly_income = flt(monthly_income)
+	existing_obligations = flt(existing_obligations)
+	rate_of_interest = flt(rate_of_interest)
+	repayment_periods = flt(repayment_periods)
+
+	if not monthly_income or not repayment_periods:
+		return 0
+
+	max_foir = get_max_foir(loan_product)
+	max_total_obligation = monthly_income * max_foir / 100
+	max_emi = max_total_obligation - existing_obligations
+
+	if max_emi <= 0:
+		return 0
+
+	monthly_rate = rate_of_interest / (12 * 100)
+	if not monthly_rate:
+		return flt(max_emi * repayment_periods, 2)
+
+	n = repayment_periods
+	principal = max_emi * ((1 + monthly_rate) ** n - 1) / (monthly_rate * (1 + monthly_rate) ** n)
+
+	return flt(principal, 2)

--- a/lending/loan_origination/test_loan_origination_utils.py
+++ b/lending/loan_origination/test_loan_origination_utils.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from lending.loan_origination.loan_origination_utils import (
+	compute_dti_foir,
+	compute_eligibility_amount,
+	compute_emi_preview,
+	compute_ltv,
+	get_max_foir,
+)
+from lending.tests.test_utils import create_loan_product, set_loan_settings_in_company
+from lending.tests.utils import LendingTestSuite
+
+
+class TestLoanOriginationUtils(LendingTestSuite):
+	def setUp(self):
+		set_loan_settings_in_company()
+		create_loan_product(
+			"Utils Home Loan",
+			"Utils Home Loan",
+			500000,
+			9.2,
+			0,
+			1,
+			0,
+			repayment_schedule_type="Monthly as per repayment start date",
+		)
+
+	def test_compute_emi_preview_missing_inputs_returns_zero(self):
+		self.assertEqual(compute_emi_preview(None, 250000, 9.2, 18), 0)
+		self.assertEqual(compute_emi_preview("Utils Home Loan", 0, 9.2, 18), 0)
+		self.assertEqual(compute_emi_preview("Utils Home Loan", 250000, 0, 18), 0)
+		self.assertEqual(compute_emi_preview("Utils Home Loan", 250000, 9.2, 0), 0)
+
+	def test_compute_emi_preview_matches_known_schedule(self):
+		emi = compute_emi_preview("Utils Home Loan", 250000, 9.2, 18)
+		self.assertEqual(emi, 14923)
+
+	def test_compute_dti_foir_zero_income(self):
+		dti, foir = compute_dti_foir(0, 5000, 1000)
+		self.assertEqual(dti, 0)
+		self.assertEqual(foir, 0)
+
+	def test_compute_dti_foir_zero_obligations(self):
+		dti, foir = compute_dti_foir(100000, 0, 14923)
+		self.assertEqual(dti, 0)
+		self.assertEqual(foir, 14.92)
+
+	def test_compute_dti_foir_normal(self):
+		dti, foir = compute_dti_foir(100000, 10000, 14923)
+		self.assertEqual(dti, 10.0)
+		self.assertEqual(foir, 24.92)
+
+	def test_compute_ltv_no_loan_amount(self):
+		self.assertEqual(compute_ltv(0, [frappe._dict(post_haircut_amount=100000)]), 0)
+
+	def test_compute_ltv_no_pledges(self):
+		self.assertEqual(compute_ltv(250000, []), 0)
+
+	def test_compute_ltv_zero_post_haircut_value(self):
+		pledges = [frappe._dict(post_haircut_amount=0)]
+		self.assertEqual(compute_ltv(250000, pledges), 0)
+
+	def test_compute_ltv_partial_ratio(self):
+		pledges = [frappe._dict(post_haircut_amount=100000)]
+		self.assertEqual(compute_ltv(50000, pledges), 50.0)
+
+	def test_compute_ltv_multiple_pledges_summed(self):
+		pledges = [
+			frappe._dict(post_haircut_amount=50000),
+			frappe._dict(post_haircut_amount=50000),
+		]
+		self.assertEqual(compute_ltv(50000, pledges), 50.0)
+
+	def test_get_max_foir_falls_back_to_default(self):
+		frappe.db.set_value("Loan Product", "Utils Home Loan", "max_foir", 0)
+		self.assertEqual(get_max_foir("Utils Home Loan"), 50.0)
+
+	def test_get_max_foir_uses_configured_value(self):
+		frappe.db.set_value("Loan Product", "Utils Home Loan", "max_foir", 35)
+		self.assertEqual(get_max_foir("Utils Home Loan"), 35.0)
+
+	def test_compute_eligibility_amount_missing_inputs_returns_zero(self):
+		self.assertEqual(compute_eligibility_amount(0, 0, 9.2, 18, "Utils Home Loan"), 0)
+		self.assertEqual(compute_eligibility_amount(100000, 0, 9.2, 0, "Utils Home Loan"), 0)
+
+	def test_compute_eligibility_amount_obligations_exceed_foir_cap(self):
+		frappe.db.set_value("Loan Product", "Utils Home Loan", "max_foir", 40)
+		eligibility = compute_eligibility_amount(100000, 40000, 9.2, 18, "Utils Home Loan")
+		self.assertEqual(eligibility, 0)
+
+	def test_compute_eligibility_amount_zero_interest_uses_simple_division(self):
+		frappe.db.set_value("Loan Product", "Utils Home Loan", "max_foir", 50)
+		eligibility = compute_eligibility_amount(100000, 0, 0.0, 18, "Utils Home Loan")
+		self.assertEqual(eligibility, 900000)
+
+	def test_compute_eligibility_amount_positive_with_amortization(self):
+		frappe.db.set_value("Loan Product", "Utils Home Loan", "max_foir", 50)
+		eligibility = compute_eligibility_amount(100000, 0, 9.2, 18, "Utils Home Loan")
+		self.assertTrue(eligibility > 0)


### PR DESCRIPTION
Loan applications had no way to check if a borrower can actually afford the loan.

**What this adds**

Seven new fields on Loan Application, under a new **Affordability** section:

* **Monthly Income** — borrower's monthly earnings, entered manually
* **Existing Monthly Obligations** — what the borrower already pays each month for other loans, not counting the new one
* **Proposed EMI** — auto-calculated monthly payment for the new loan
* **DTI Ratio (Debt to Income)** — percent of income already going to existing debt
* **FOIR Ratio (Fixed Obligation to Income)** — percent of income going to debt if you include the new loan too. This is the main number used to decide affordability
* **Eligibility Amount** — auto-calculated maximum loan amount this borrower qualifies for, based on income and the product's max FOIR
* **LTV Ratio (Loan to Value)** — only for secured loans (gold, property, etc.), shows loan amount against collateral value. Stays 0 and hidden for unsecured loans

**How it's calculated**

* All math lives in a new file, `loan_origination_utils.py`, kept separate from the main controller
* EMI preview reuses the app's existing repayment schedule logic, so it always matches numbers shown elsewhere
* DTI/FOIR are plain percentage math
* LTV is loan amount ÷ collateral value after haircut
* Eligibility amount works backward from max FOIR to find the largest affordable loan
* New Maximum FOIR setting added to Loan Product, so each product can set its own limit (defaults to 50% if not set)

**Testing**
* Covers normal cases and edge cases: zero income, zero obligations, unsecured loans, multiple pledged securities, zero interest rate