### PR TITLE
fix: include unbooked and unaccrued interest in Security Deposit Adjustment payable amount

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -903,6 +903,8 @@ class LoanRepayment(LoanController):
 
 	def validate_security_deposit_amount(self, amounts):
 		if self.repayment_type == "Security Deposit Adjustment":
+			precision = cint(frappe.db.get_default("currency_precision")) or 2
+
 			available_deposit = frappe.db.get_value(
 				"Loan Security Deposit",
 				{"loan": self.against_loan, "docstatus": 1},
@@ -910,29 +912,37 @@ class LoanRepayment(LoanController):
 				for_update=True,
 			)
 
-			if flt(self.amount_paid) > flt(available_deposit):
+			if flt(self.amount_paid, precision) > flt(available_deposit, precision):
 				frappe.throw(
 					_("Amount paid ({0}) cannot be greater than available security deposit ({1})").format(
-						flt(self.amount_paid), flt(available_deposit)
+						flt(self.amount_paid, precision), flt(available_deposit, precision)
 					)
 				)
 
-			# unaccrued_interest is only computed when for_update is False, but this
-			# amounts dict was built with for_update=True, so fetch it separately.
-			unaccrued_interest = calculate_amounts(
-				self.against_loan, self.value_date, payment_type=self.repayment_type
-			).get("unaccrued_interest", 0)
-
-			total_payable_amount = (
-				flt(self.payable_amount) + flt(amounts.get("unbooked_interest", 0)) + flt(unaccrued_interest)
+			total_payable_amount = flt(
+				flt(self.payable_amount, precision) + flt(amounts.get("unbooked_interest", 0), precision),
+				precision,
 			)
 
-			if flt(self.amount_paid) > total_payable_amount and not self.loan_adjustment:
+			if flt(self.amount_paid, precision) > total_payable_amount and not self.loan_adjustment:
+				# amounts was built with for_update=True, under which unaccrued_interest
+				# (interest projected after the latest accrual) is always 0. Fetch it
+				# separately, only when needed, and write it back into amounts so
+				# allocate_amounts() also books this portion as interest, not principal.
+				amounts["unaccrued_interest"] = flt(
+					calculate_amounts(
+						self.against_loan, self.value_date, payment_type=self.repayment_type
+					).get("unaccrued_interest", 0),
+					precision,
+				)
+				total_payable_amount = flt(total_payable_amount + amounts["unaccrued_interest"], precision)
+
+			if flt(self.amount_paid, precision) > total_payable_amount and not self.loan_adjustment:
 				frappe.throw(
 					_(
 						"The amount paid ({0}) cannot be greater than the payable amount ({1}) for"
 						" Security Deposit Adjustment repayments."
-					).format(flt(self.amount_paid), total_payable_amount)
+					).format(flt(self.amount_paid, precision), total_payable_amount)
 				)
 
 	def validate_repayment_type(self):

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -916,9 +916,16 @@ class LoanRepayment(LoanController):
 						flt(self.amount_paid), flt(available_deposit)
 					)
 				)
-			total_payable_amount = flt(self.payable_amount) + flt(
-				amounts.get("unbooked_interest", 0)
-			) + flt(amounts.get("unaccrued_interest", 0))
+
+			# unaccrued_interest is only computed when for_update is False, but this
+			# amounts dict was built with for_update=True, so fetch it separately.
+			unaccrued_interest = calculate_amounts(
+				self.against_loan, self.value_date, payment_type=self.repayment_type
+			).get("unaccrued_interest", 0)
+
+			total_payable_amount = (
+				flt(self.payable_amount) + flt(amounts.get("unbooked_interest", 0)) + flt(unaccrued_interest)
+			)
 
 			if flt(self.amount_paid) > total_payable_amount and not self.loan_adjustment:
 				frappe.throw(

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -152,7 +152,7 @@ class LoanRepayment(LoanController):
 		)
 
 		self.set_missing_values(amounts)
-		self.validate_security_deposit_amount()
+		self.validate_security_deposit_amount(amounts)
 		self.validate_amount(amounts)
 		self.allocate_amounts(amounts)
 
@@ -901,7 +901,7 @@ class LoanRepayment(LoanController):
 
 		self.db_set("is_backdated", self.is_backdated)
 
-	def validate_security_deposit_amount(self):
+	def validate_security_deposit_amount(self, amounts):
 		if self.repayment_type == "Security Deposit Adjustment":
 			available_deposit = frappe.db.get_value(
 				"Loan Security Deposit",
@@ -911,12 +911,21 @@ class LoanRepayment(LoanController):
 			)
 
 			if flt(self.amount_paid) > flt(available_deposit):
-				frappe.throw(_("Amount paid cannot be greater than available security deposit"))
-			if flt(self.amount_paid) > flt(self.payable_amount) and not self.loan_adjustment:
+				frappe.throw(
+					_("Amount paid ({0}) cannot be greater than available security deposit ({1})").format(
+						flt(self.amount_paid), flt(available_deposit)
+					)
+				)
+			total_payable_amount = flt(self.payable_amount) + flt(
+				amounts.get("unbooked_interest", 0)
+			) + flt(amounts.get("unaccrued_interest", 0))
+
+			if flt(self.amount_paid) > total_payable_amount and not self.loan_adjustment:
 				frappe.throw(
 					_(
-						"The amount paid cannot be greater than the payable amount for Security Deposit Adjustment repayments."
-					)
+						"The amount paid ({0}) cannot be greater than the payable amount ({1}) for"
+						" Security Deposit Adjustment repayments."
+					).format(flt(self.amount_paid), total_payable_amount)
 				)
 
 	def validate_repayment_type(self):

--- a/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
@@ -178,3 +178,57 @@ class TestLoanSecurityDeposit(LendingTestSuite):
 			flt(security_deposit_after.available_amount, 2),
 			flt(security_deposit_before - amount_paid, 2),
 		)
+
+	def test_unaccrued_interest_depends_on_for_update(self):
+		# calculate_amounts() only computes unaccrued_interest (interest projected
+		# after the latest accrual) when for_update is False. LoanRepayment.validate()
+		# always calls it with for_update=True, so unaccrued_interest is 0 there even
+		# when real projected interest exists. unbooked_interest has no such gap.
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			1000000,
+			"Repay Over Number of Periods",
+			24,
+			"Customer",
+			repayment_start_date="2025-02-05",
+			posting_date="2025-01-06",
+			rate_of_interest=28,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2025-01-06",
+			repayment_start_date="2025-02-05",
+			withhold_security_deposit=1,
+		)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2025-01-20", company="_Test Company"
+		)
+
+		# posting_date is after the latest accrual, so unaccrued_interest applies.
+		posting_date = "2025-01-25"
+
+		locked_amounts = calculate_amounts(loan.name, posting_date, for_update=True)
+		unlocked_amounts = calculate_amounts(loan.name, posting_date, for_update=False)
+
+		self.assertEqual(
+			flt(locked_amounts.get("unaccrued_interest", 0), 2),
+			0,
+			"unaccrued_interest should be 0 when for_update=True",
+		)
+		self.assertGreater(
+			flt(unlocked_amounts.get("unaccrued_interest", 0), 2),
+			0,
+			"unaccrued_interest should be non-zero when for_update=False",
+		)
+		self.assertEqual(
+			flt(locked_amounts.get("unbooked_interest", 0), 2),
+			flt(unlocked_amounts.get("unbooked_interest", 0), 2),
+			"unbooked_interest should not depend on for_update",
+		)

--- a/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
@@ -8,6 +8,9 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import calcul
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
+from lending.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+	process_loan_interest_accrual_for_loans,
+)
 from lending.tests.test_utils import (
 	create_loan,
 	create_repayment_entry,
@@ -15,6 +18,7 @@ from lending.tests.test_utils import (
 	init_loan_products,
 	make_loan_disbursement_entry,
 	master_init,
+	set_loan_accrual_frequency,
 )
 from lending.tests.utils import LendingTestSuite
 
@@ -118,3 +122,59 @@ class TestLoanSecurityDeposit(LendingTestSuite):
 
 		self.assertEqual(flt(security_deposit.allocated_amount, 2), 0)
 		self.assertEqual(flt(security_deposit.available_amount, 2), flt(repayment_doc.amount_paid, 2))
+
+	def test_security_deposit_adjustment_with_unbooked_interest(self):
+		# Accrued interest not yet billed (unbooked_interest) should still count
+		# as payable for a Security Deposit Adjustment.
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			1000000,
+			"Repay Over Number of Periods",
+			24,
+			"Customer",
+			repayment_start_date="2025-02-05",
+			posting_date="2025-01-06",
+			rate_of_interest=28,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2025-01-06",
+			repayment_start_date="2025-02-05",
+			withhold_security_deposit=1,
+		)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2025-01-20", company="_Test Company"
+		)
+
+		amounts = calculate_amounts(loan.name, "2025-01-21", for_update=True)
+		payable_amount = flt(amounts.get("payable_amount", 0), 2)
+		unbooked_interest = flt(amounts.get("unbooked_interest", 0), 2)
+		self.assertGreater(unbooked_interest, 0, "No unbooked interest accrued for test loan")
+
+		security_deposit_before = frappe.db.get_value(
+			"Loan Security Deposit", {"loan": loan.name, "docstatus": 1}, "available_amount"
+		)
+
+		amount_paid = flt(payable_amount + unbooked_interest, 2)
+		repayment = create_repayment_entry(
+			loan.name, "2025-01-21", amount_paid, repayment_type="Security Deposit Adjustment"
+		)
+		repayment.submit()
+
+		self.assertEqual(repayment.docstatus, 1, "Repayment should submit")
+
+		security_deposit_after = frappe.get_doc(
+			"Loan Security Deposit", {"loan": loan.name, "docstatus": 1}
+		)
+		self.assertEqual(flt(security_deposit_after.allocated_amount, 2), amount_paid)
+		self.assertEqual(
+			flt(security_deposit_after.available_amount, 2),
+			flt(security_deposit_before - amount_paid, 2),
+		)

--- a/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
@@ -232,3 +232,63 @@ class TestLoanSecurityDeposit(LendingTestSuite):
 			flt(unlocked_amounts.get("unbooked_interest", 0), 2),
 			"unbooked_interest should not depend on for_update",
 		)
+
+	def test_security_deposit_adjustment_books_unaccrued_interest_as_interest(self):
+		# An adjustment amount that only fits within payable_amount + unbooked_interest
+		# + unaccrued_interest must still be booked as interest, not principal or excess.
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			1000000,
+			"Repay Over Number of Periods",
+			24,
+			"Customer",
+			repayment_start_date="2025-02-05",
+			posting_date="2025-01-06",
+			rate_of_interest=28,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2025-01-06",
+			repayment_start_date="2025-02-05",
+			withhold_security_deposit=1,
+		)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2025-01-20", company="_Test Company"
+		)
+
+		# posting_date is after the latest accrual, so unaccrued_interest applies.
+		posting_date = "2025-01-25"
+		unlocked_amounts = calculate_amounts(loan.name, posting_date, for_update=False)
+		payable_amount = flt(unlocked_amounts.get("payable_amount", 0), 2)
+		unbooked_interest = flt(unlocked_amounts.get("unbooked_interest", 0), 2)
+		unaccrued_interest = flt(unlocked_amounts.get("unaccrued_interest", 0), 2)
+		self.assertGreater(unaccrued_interest, 0, "No unaccrued interest projected for test loan")
+
+		pending_principal_before = frappe.db.get_value("Loan", loan.name, "total_principal_paid") or 0
+
+		amount_paid = flt(payable_amount + unbooked_interest + unaccrued_interest, 2)
+		repayment = create_repayment_entry(
+			loan.name, posting_date, amount_paid, repayment_type="Security Deposit Adjustment"
+		)
+		repayment.submit()
+
+		self.assertEqual(
+			flt(repayment.unbooked_interest_paid, 2),
+			flt(unbooked_interest + unaccrued_interest, 2),
+			"unaccrued_interest portion should be booked as interest",
+		)
+		self.assertEqual(flt(repayment.excess_amount, 2), 0, "No excess amount expected")
+
+		pending_principal_after = frappe.db.get_value("Loan", loan.name, "total_principal_paid") or 0
+		self.assertEqual(
+			pending_principal_after,
+			pending_principal_before,
+			"unaccrued_interest portion should not be booked as principal",
+		)

--- a/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
+++ b/lending/loan_management/doctype/loan_security_deposit/test_loan_security_deposit.py
@@ -179,60 +179,6 @@ class TestLoanSecurityDeposit(LendingTestSuite):
 			flt(security_deposit_before - amount_paid, 2),
 		)
 
-	def test_unaccrued_interest_depends_on_for_update(self):
-		# calculate_amounts() only computes unaccrued_interest (interest projected
-		# after the latest accrual) when for_update is False. LoanRepayment.validate()
-		# always calls it with for_update=True, so unaccrued_interest is 0 there even
-		# when real projected interest exists. unbooked_interest has no such gap.
-		set_loan_accrual_frequency("Daily")
-
-		loan = create_loan(
-			"_Test Customer 1",
-			"Term Loan Product 4",
-			1000000,
-			"Repay Over Number of Periods",
-			24,
-			"Customer",
-			repayment_start_date="2025-02-05",
-			posting_date="2025-01-06",
-			rate_of_interest=28,
-		)
-		loan.submit()
-
-		make_loan_disbursement_entry(
-			loan.name,
-			loan.loan_amount,
-			disbursement_date="2025-01-06",
-			repayment_start_date="2025-02-05",
-			withhold_security_deposit=1,
-		)
-
-		process_loan_interest_accrual_for_loans(
-			loan=loan.name, posting_date="2025-01-20", company="_Test Company"
-		)
-
-		# posting_date is after the latest accrual, so unaccrued_interest applies.
-		posting_date = "2025-01-25"
-
-		locked_amounts = calculate_amounts(loan.name, posting_date, for_update=True)
-		unlocked_amounts = calculate_amounts(loan.name, posting_date, for_update=False)
-
-		self.assertEqual(
-			flt(locked_amounts.get("unaccrued_interest", 0), 2),
-			0,
-			"unaccrued_interest should be 0 when for_update=True",
-		)
-		self.assertGreater(
-			flt(unlocked_amounts.get("unaccrued_interest", 0), 2),
-			0,
-			"unaccrued_interest should be non-zero when for_update=False",
-		)
-		self.assertEqual(
-			flt(locked_amounts.get("unbooked_interest", 0), 2),
-			flt(unlocked_amounts.get("unbooked_interest", 0), 2),
-			"unbooked_interest should not depend on for_update",
-		)
-
 	def test_security_deposit_adjustment_books_unaccrued_interest_as_interest(self):
 		# An adjustment amount that only fits within payable_amount + unbooked_interest
 		# + unaccrued_interest must still be booked as interest, not principal or excess.


### PR DESCRIPTION
**Summary**

validate_security_deposit_amount() checked amount_paid only against payable_amount, which is the sum of outstanding Loan Demand rows (principal, interest, penalty, charges). Interest that had already accrued (via Loan Interest Accrual) but was not yet raised as a Loan Demand was excluded from this check, so a Security Deposit Adjustment could be rejected even when that interest was real and collectible.

Example: a loan had payable_amount = 0 (no outstanding Loan Demand) but unbooked_interest ≈ 800, backed by submitted Loan Interest Accrual records. A Security Deposit Adjustment for that amount failed with "amount paid cannot be greater than the payable amount." The same amount submitted as a Pre Payment succeeded and correctly applied to unbooked_interest_paid, confirming the interest was genuinely owed.

**Fix**

validate_security_deposit_amount() now includes unbooked_interest (accrued but not yet demanded) and unaccrued_interest (projected up to the posting date) in the payable amount check, matching how foreclosure, interest waiver, and write-off already treat this interest as payable.

Two related issues surfaced while testing this:
- unaccrued_interest is only computed by calculate_amounts() when for_update is False, but repayment submission always calls it with for_update=True. It is now recomputed separately, only when needed, and written back into the shared amounts so allocation books it as interest instead of principal or excess.
- The comparisons in this method used raw floats with no rounding, which could reject a valid amount due to floating point drift. Comparisons now use explicit currency precision.
