### PR TITLE
fix: handle missing loan repayment schedule and block direct cancel while disbursement is submitted

### DIFF
--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -605,6 +605,23 @@ class LoanDisbursement(LoanController):
 				for data in schedule.repayment_schedule:
 					total_payment -= data.total_payment
 					total_interest_payable -= data.interest_amount
+			else:
+				RepaymentSchedule = frappe.qb.DocType("Repayment Schedule")
+				LoanRepaymentSchedule = frappe.qb.DocType("Loan Repayment Schedule")
+				total_payment, total_interest_payable = (
+					frappe.qb.from_(RepaymentSchedule)
+					.join(LoanRepaymentSchedule)
+					.on(RepaymentSchedule.parent == LoanRepaymentSchedule.name)
+					.select(fn.Sum(RepaymentSchedule.total_payment), fn.Sum(RepaymentSchedule.interest_amount))
+					.where(
+						(LoanRepaymentSchedule.loan == self.against_loan)
+						& (LoanRepaymentSchedule.docstatus == 1)
+						& (LoanRepaymentSchedule.loan_disbursement != self.name)
+					)
+					.run()[0]
+				)
+				total_payment = flt(total_payment)
+				total_interest_payable = flt(total_interest_payable)
 		else:
 			total_payment -= self.disbursed_amount
 

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -242,7 +242,11 @@ class LoanDisbursement(LoanController):
 			"docstatus": 1,
 			"loan_disbursement": self.name,
 		}
-		schedule = frappe.get_doc("Loan Repayment Schedule", filters)
+		schedule_name = frappe.db.get_value("Loan Repayment Schedule", filters, "name")
+		if not schedule_name:
+			return
+
+		schedule = frappe.get_doc("Loan Repayment Schedule", schedule_name)
 		schedule.reverse_interest_accruals = self.get("reverse_interest_accruals")
 		schedule.flags.ignore_links = True
 		schedule.cancel()
@@ -593,12 +597,14 @@ class LoanDisbursement(LoanController):
 		total_interest_payable = loan_details.total_interest_payable
 
 		if self.is_term_loan:
-			schedule = frappe.get_doc(
-				"Loan Repayment Schedule", {"loan_disbursement": self.name, "docstatus": 1}
+			schedule_name = frappe.db.get_value(
+				"Loan Repayment Schedule", {"loan_disbursement": self.name, "docstatus": 1}, "name"
 			)
-			for data in schedule.repayment_schedule:
-				total_payment -= data.total_payment
-				total_interest_payable -= data.interest_amount
+			if schedule_name:
+				schedule = frappe.get_doc("Loan Repayment Schedule", schedule_name)
+				for data in schedule.repayment_schedule:
+					total_payment -= data.total_payment
+					total_interest_payable -= data.interest_amount
 		else:
 			total_payment -= self.disbursed_amount
 

--- a/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -161,3 +161,45 @@ class TestLoanDisbursement(LendingTestSuite):
 
 		self.assertEqual(status_map_after.get(disbursement_1.name), "Outdated")
 		self.assertEqual(status_map_after.get(disbursement_2.name), "Active")
+
+	def test_cancel_on_loan_disbursement_with_missing_repayment_schedule(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			"2024-07-15",
+			"2024-06-25",
+			10,
+		)
+		loan.submit()
+
+		disbursement = make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-06-25",
+			repayment_start_date="2024-07-15",
+		)
+
+		schedule_name = frappe.db.get_value(
+			"Loan Repayment Schedule",
+			{"loan_disbursement": disbursement.name, "docstatus": 1},
+			"name",
+		)
+		schedule = frappe.get_doc("Loan Repayment Schedule", schedule_name)
+
+		self.assertRaises(frappe.ValidationError, schedule.cancel)
+
+		frappe.db.sql("delete from `tabRepayment Schedule` where parent=%s", schedule_name)
+		frappe.db.sql("delete from `tabLoan Repayment Schedule` where name=%s", schedule_name)
+
+		disbursement.cancel()
+
+		disbursement.load_from_db()
+		loan.reload()
+		self.assertEqual(disbursement.docstatus, 2)
+		self.assertEqual(loan.status, "Sanctioned")
+		self.assertEqual(loan.total_payment, 0)
+		self.assertEqual(loan.total_interest_payable, 0)

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -245,6 +245,8 @@ class LoanRepaymentSchedule(Document):
 			reverse_loan_interest_accruals,
 		)
 
+		self.validate_loan_disbursement_status()
+
 		precision = cint(frappe.db.get_default("currency_precision")) or 2
 
 		bpi_accrual = frappe.db.get_value(
@@ -295,6 +297,20 @@ class LoanRepaymentSchedule(Document):
 		self.ignore_linked_doctypes = ["Loan Interest Accrual", "Loan Demand"]
 
 		self.db_set("status", "Cancelled")
+
+	def validate_loan_disbursement_status(self):
+		if self.flags.ignore_links or not self.loan_disbursement:
+			return
+
+		loan_disbursement_docstatus = frappe.db.get_value(
+			"Loan Disbursement", self.loan_disbursement, "docstatus"
+		)
+		if loan_disbursement_docstatus == 1:
+			frappe.throw(
+				_(
+					"Cannot cancel Loan Repayment Schedule {0} while Loan Disbursement {1} is submitted. Cancel the Loan Disbursement first."
+				).format(frappe.bold(self.name), frappe.bold(self.loan_disbursement))
+			)
 
 	def set_repayment_period(self):
 		if self.repayment_frequency == "One Time":


### PR DESCRIPTION
fixes: https://github.com/frappe/lending/issues/1391

**Issue**
- If a submitted Loan Repayment Schedule linked to a submitted Loan Disbursement goes missing, cancelling the disbursement fails with a "not found" error. This leaves the loan in a broken state that cannot be cleaned up.

**Fix:**
1. get_values_on_cancel() and cancel_and_delete_repayment_schedule() in loan_disbursement.py now check if the schedule exists before using it. If it is missing, they skip that step instead of failing. This lets the disbursement cancel cleanly even if the schedule is gone.
2. When the schedule is missing, the loan's total payment and total interest payable are now recomputed from the loan's other remaining schedules, so these numbers stay correct after cancel instead of keeping the cancelled disbursement's amounts.
3. loan_repayment_schedule.py now blocks cancelling a Loan Repayment Schedule directly while its linked Loan Disbursement is still submitted. This was the main way a schedule could go missing while the disbursement still needed it. The disbursement must be cancelled first, which cancels the schedule as part of that normal flow.
