### PR TITLE
fix: keep advance payment EMI skip after later prepayments

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -1226,6 +1226,80 @@ class TestLoan(LendingTestSuite):
 		)
 		self.assertTrue(demands)
 
+	def test_advance_payment_then_prepayment(self):
+		# Purpose: check that an EMI skipped by an Advance Payment stays skipped even
+		# after more Pre Payments are made later. Without this, the skipped EMI can
+		# wrongly come back as due again, even though the customer already paid for it.
+		loan = create_loan(
+			self.applicant1,
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			12,
+			repayment_start_date="2025-01-05",
+			posting_date="2024-12-05",
+			rate_of_interest=10,
+		)
+
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-12-05", repayment_start_date="2025-01-05"
+		)
+		process_daily_loan_demands(posting_date="2025-01-05", loan=loan.name)
+		create_repayment_entry(loan.name, "2025-02-01", 8792.00).submit()
+		create_repayment_entry(loan.name, "2025-02-01", 10000, repayment_type="Advance Payment").submit()
+
+		active_schedule = frappe.db.get_value(
+			"Loan Repayment Schedule", {"loan": loan.name, "status": "Active", "docstatus": 1}, "name"
+		)
+		demand_generated = frappe.db.get_value(
+			"Repayment Schedule", {"parent": active_schedule, "payment_date": "2025-02-05"}, "demand_generated"
+		)
+		self.assertEqual(demand_generated, 1)
+
+		create_repayment_entry(loan.name, "2025-02-01", 20000, repayment_type="Pre Payment").submit()
+
+		active_schedule = frappe.db.get_value(
+			"Loan Repayment Schedule", {"loan": loan.name, "status": "Active", "docstatus": 1}, "name"
+		)
+		demand_generated = frappe.db.get_value(
+			"Repayment Schedule", {"parent": active_schedule, "payment_date": "2025-02-05"}, "demand_generated"
+		)
+		self.assertEqual(demand_generated, 1)
+
+		live_demands = frappe.db.get_all(
+			"Loan Demand",
+			{
+				"loan": loan.name,
+				"docstatus": 1,
+				"demand_date": "2025-02-05",
+				"demand_type": "EMI",
+			},
+		)
+		self.assertFalse(live_demands)
+
+		create_repayment_entry(loan.name, "2025-02-04", 15000, repayment_type="Pre Payment").submit()
+
+		active_schedule = frappe.db.get_value(
+			"Loan Repayment Schedule", {"loan": loan.name, "status": "Active", "docstatus": 1}, "name"
+		)
+		demand_generated = frappe.db.get_value(
+			"Repayment Schedule", {"parent": active_schedule, "payment_date": "2025-02-05"}, "demand_generated"
+		)
+		self.assertEqual(demand_generated, 1)
+
+		live_demands = frappe.db.get_all(
+			"Loan Demand",
+			{
+				"loan": loan.name,
+				"docstatus": 1,
+				"demand_date": "2025-02-05",
+				"demand_type": "EMI",
+			},
+		)
+		self.assertFalse(live_demands)
+
 	def test_interest_accrual_and_demand_on_freeze_and_unfreeze(self):
 		loan = create_loan(
 			self.applicant1,

--- a/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
+++ b/lending/loan_management/doctype/loan_repayment_schedule/loan_repayment_schedule.py
@@ -904,6 +904,11 @@ class LoanRepaymentSchedule(Document):
 					total_payment = principal_amount + interest_amount
 
 					balance_principal_amount = self.current_principal_amount - principal_amount
+					# A prior restructure (e.g. Advance Payment) may have already marked this same
+					# next_emi_date as demand_generated=1 on prev_schedule, meaning that EMI was
+					# already skipped and does not need a fresh demand. Carry that flag forward
+					# here instead of always starting at 0, otherwise this Pre Payment rebuild
+					# undoes the earlier skip and the EMI wrongly shows up as due again.
 					self.add_repayment_schedule_row(
 						next_emi_date,
 						principal_amount,
@@ -912,7 +917,7 @@ class LoanRepaymentSchedule(Document):
 						total_payment,
 						balance_principal_amount,
 						pending_prev_days,
-						0,
+						self.get_prev_schedule_demand_generated(prev_schedule, schedule_field, next_emi_date),
 						repayment_schedule_field=schedule_field,
 						principal_share_percentage=principal_share_percentage,
 						interest_share_percentage=interest_share_percentage,
@@ -929,6 +934,12 @@ class LoanRepaymentSchedule(Document):
 			additional_principal_amount,
 			pending_prev_days,
 		)
+
+	def get_prev_schedule_demand_generated(self, prev_schedule, schedule_field, payment_date):
+		for row in prev_schedule.get(schedule_field):
+			if getdate(row.payment_date) == getdate(payment_date):
+				return row.demand_generated
+		return 0
 
 	def set_repayment_start_date(self):
 		if self.repayment_schedule_type == "Pro-rated calendar months" and not self.restructure_type:


### PR DESCRIPTION
**Before:**
Customer makes an Advance Payment. This correctly marks the upcoming EMI as already paid, so no new bill is raised for it.

Right after, the customer makes a Pre Payment. This resets that EMI back to "not paid," and a fresh, full bill gets raised for it, even though it was already covered by the earlier advance payment. The customer ends up billed twice for the same EMI.

**After:**
Same steps: the Advance Payment marks the upcoming EMI as already paid. When the Pre Payment is made right after, the EMI stays correctly marked as already paid, and no new bill is raised for it.

Verified this holds even when a third payment is added right after (another Pre Payment) — the already-paid EMI stays correctly marked through the whole chain, not just after a single payment.