### PR TITLE
fix: allow creating loan repayment directly when it fails to create during payroll

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -852,6 +852,11 @@ class LoanRepayment(LoanController):
 			elif not self.repay_from_salary and self.payroll_payable_account:
 				self.repay_from_salary = 1
 
+			if self.repay_from_salary and self.is_new():
+				self.process_payroll_accounting_entry_based_on_employee = frappe.db.get_single_value(
+					"Payroll Settings", "process_payroll_accounting_entry_based_on_employee"
+				)
+
 		if self.repayment_type in ("Full Settlement", "Write Off Settlement", "Charges Waiver"):
 			self.total_charges_payable = amounts.get("total_charges_payable")
 

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2089,7 +2089,13 @@ class LoanRepayment(LoanController):
 			merge_entries = False
 
 		if gle_map:
+			previous_flag = frappe.flags.party_not_required
+			if self.get("repay_from_salary") and not self.get("process_payroll_accounting_entry_based_on_employee"):
+				frappe.flags.party_not_required = True
+
 			super().make_gl_entries(gle_map, merge_entries=merge_entries, cancel=cancel, adv_adj=adv_adj)
+
+			frappe.flags.party_not_required = previous_flag
 
 	def get_gl_map(self):
 		if not loan_accounting_enabled(self.company):


### PR DESCRIPTION
**Issue**

Sometimes, while running payroll, the loan repayment for an employee fails to get created because of some validation error on the Loan Repayment side. Since payroll has already been generated and the Bank Entry is already submitted, the user does not want to cancel the whole Payroll Entry just to fix one employee's loan deduction. In this case, the user needs to create the Loan Repayment separately, only for that one loan, without touching payroll again.

But when trying to create that single Loan Repayment directly, it was failing again with: "Supplier is required against Payable account"

This happens because, for a loan that repays from salary, the Loan Repayment uses the payroll payable account, which is a Payable type account. Frappe checks for a Supplier on this kind of account by default. This entry is not a supplier bill, so it does not have a Supplier, and it should not need one here. This was already fixed on the HRMS side, but only inside the payroll flow, so it worked only when the repayment was created automatically through payroll. It did not help when the user tried to create the repayment separately, like in this case.

**Fix**

This check is now handled inside Loan Repayment itself, so it also works when someone creates and submits the repayment directly, without going through payroll. It only skips the Supplier check when the loan is set to repay from salary and payroll accounting is not tracked per employee, same condition already used on the HRMS side. Everything else stays the same as before.