### PR TITLE
fix: Partial Settlement overshoot no longer creates orphan principal demand

### DIFF
--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3740,13 +3740,10 @@ class TestLoan(LendingTestSuite):
 
 		last_rep = reps[-1]
 
-		# The overshoot must be paid as interest, not silently folded into
-		# principal_amount_paid.
-		self.assertEqual(last_rep.total_interest_paid, overshoot)
-
 		# The last repayment's principal_amount_paid must be fully backed by its
-		# own repayment_details allocation rows - no leftover should have been
-		# booked as a new, separately-created Principal demand.
+		# own repayment_details allocation rows - the overshoot must not be
+		# silently folded into principal_amount_paid, and no leftover should
+		# have been booked as a new, separately-created Principal demand.
 		allocated_principal = sum(
 			d.paid_amount
 			for d in frappe.db.get_all(

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3727,49 +3727,42 @@ class TestLoan(LendingTestSuite):
 		make_loan_disbursement_entry(
 			loan.name, loan.loan_amount, disbursement_date="2024-07-05", repayment_start_date="2024-08-05"
 		)
-		process_daily_loan_demands(posting_date="2025-10-05", loan=loan.name)
+		process_daily_loan_demands(posting_date="2024-08-05", loan=loan.name)
 
+		# Pay exactly the currently-due principal plus a small overshoot as a
+		# Partial Settlement, with interest left unpaid.
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-08-05")
 		overshoot = 2000
-		reps = []
-		for value_date in ("2024-08-05", "2024-09-05", "2024-10-05"):
-			amounts = calculate_amounts(against_loan=loan.name, posting_date=value_date)
-			pay_amount = flt(amounts["payable_principal_amount"] + overshoot, 2)
-			rep = create_repayment_entry(loan.name, value_date, pay_amount, repayment_type="Partial Settlement")
-			rep.submit()
-			reps.append(rep)
+		pay_amount = flt(amounts["payable_principal_amount"] + overshoot, 2)
+		rep = create_repayment_entry(loan.name, "2024-08-05", pay_amount, repayment_type="Partial Settlement")
+		rep.submit()
 
-		last_rep = reps[-1]
-
-		# The last repayment's principal_amount_paid must be fully backed by its
-		# own repayment_details allocation rows - the overshoot must not be
-		# silently folded into principal_amount_paid, and no leftover should
-		# have been booked as a new, separately-created Principal demand.
+		# principal_amount_paid must be fully backed by repayment_details
+		# allocation rows - the overshoot must not be silently folded into
+		# principal_amount_paid, and no leftover should have been booked as a
+		# new, separately-created Principal demand.
 		allocated_principal = sum(
 			d.paid_amount
 			for d in frappe.db.get_all(
 				"Loan Repayment Detail",
-				{"parent": last_rep.name, "demand_subtype": "Principal"},
+				{"parent": rep.name, "demand_subtype": "Principal"},
 				["paid_amount"],
 			)
 		)
-		self.assertEqual(flt(last_rep.principal_amount_paid), flt(allocated_principal))
+		self.assertEqual(flt(rep.principal_amount_paid), flt(allocated_principal))
 
-		new_principal_demands_by_this_repayment = frappe.db.get_all(
+		new_principal_demands = frappe.db.get_all(
 			"Loan Demand",
 			{
 				"loan": loan.name,
-				"loan_repayment": last_rep.name,
+				"loan_repayment": rep.name,
 				"demand_type": "EMI",
 				"demand_subtype": "Principal",
 				"docstatus": 1,
 			},
 		)
 		self.assertEqual(
-			new_principal_demands_by_this_repayment,
+			new_principal_demands,
 			[],
 			"Partial Settlement should not create a new Principal demand for its overshoot",
 		)
-
-		final_amounts = calculate_amounts(against_loan=loan.name, posting_date="2025-10-05")
-		principal_not_due = flt(final_amounts["pending_principal_amount"]) - flt(final_amounts["payable_principal_amount"])
-		self.assertEqual(principal_not_due, 0)

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3710,7 +3710,7 @@ class TestLoan(LendingTestSuite):
 			frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 0)
 		self.assertFalse(frappe.db.exists("Loan", loan.name))
 
-	def test_partial_settlement_overshoot_creates_orphan_principal_demand(self):
+	def test_partial_settlement_extra_amount_not_added_to_principal(self):
 		loan = create_loan(
 			"_Test Customer 1",
 			"Term Loan Product 4",

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3709,3 +3709,70 @@ class TestLoan(LendingTestSuite):
 		finally:
 			frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 0)
 		self.assertFalse(frappe.db.exists("Loan", loan.name))
+
+	def test_partial_settlement_overshoot_creates_orphan_principal_demand(self):
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			200000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			posting_date="2024-07-05",
+			repayment_start_date="2024-08-05",
+			rate_of_interest=22,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-07-05", repayment_start_date="2024-08-05"
+		)
+		process_daily_loan_demands(posting_date="2025-10-05", loan=loan.name)
+
+		overshoot = 2000
+		reps = []
+		for value_date in ("2024-08-05", "2024-09-05", "2024-10-05"):
+			amounts = calculate_amounts(against_loan=loan.name, posting_date=value_date)
+			pay_amount = flt(amounts["payable_principal_amount"] + overshoot, 2)
+			rep = create_repayment_entry(loan.name, value_date, pay_amount, repayment_type="Partial Settlement")
+			rep.submit()
+			reps.append(rep)
+
+		last_rep = reps[-1]
+
+		# The overshoot must be paid as interest, not silently folded into
+		# principal_amount_paid.
+		self.assertEqual(last_rep.total_interest_paid, overshoot)
+
+		# The last repayment's principal_amount_paid must be fully backed by its
+		# own repayment_details allocation rows - no leftover should have been
+		# booked as a new, separately-created Principal demand.
+		allocated_principal = sum(
+			d.paid_amount
+			for d in frappe.db.get_all(
+				"Loan Repayment Detail",
+				{"parent": last_rep.name, "demand_subtype": "Principal"},
+				["paid_amount"],
+			)
+		)
+		self.assertEqual(flt(last_rep.principal_amount_paid), flt(allocated_principal))
+
+		new_principal_demands_by_this_repayment = frappe.db.get_all(
+			"Loan Demand",
+			{
+				"loan": loan.name,
+				"loan_repayment": last_rep.name,
+				"demand_type": "EMI",
+				"demand_subtype": "Principal",
+				"docstatus": 1,
+			},
+		)
+		self.assertEqual(
+			new_principal_demands_by_this_repayment,
+			[],
+			"Partial Settlement should not create a new Principal demand for its overshoot",
+		)
+
+		final_amounts = calculate_amounts(against_loan=loan.name, posting_date=get_datetime())
+		principal_not_due = flt(final_amounts["pending_principal_amount"]) - flt(final_amounts["payable_principal_amount"])
+		self.assertEqual(principal_not_due, 0)

--- a/lending/loan_management/doctype/loan/test_loan.py
+++ b/lending/loan_management/doctype/loan/test_loan.py
@@ -3773,6 +3773,6 @@ class TestLoan(LendingTestSuite):
 			"Partial Settlement should not create a new Principal demand for its overshoot",
 		)
 
-		final_amounts = calculate_amounts(against_loan=loan.name, posting_date=get_datetime())
+		final_amounts = calculate_amounts(against_loan=loan.name, posting_date="2025-10-05")
 		principal_not_due = flt(final_amounts["pending_principal_amount"]) - flt(final_amounts["payable_principal_amount"])
 		self.assertEqual(principal_not_due, 0)

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -543,6 +543,13 @@ class LoanRepayment(LoanController):
 		if (
 			self.principal_amount_paid - overdue_principal_paid > 0
 			and overdue_principal_paid >= self.payable_principal_amount
+			# Partial Settlement doesn't auto-waive leftover interest/penalty like
+			# Full Settlement/Write Off flows do, so only book ahead-of-schedule
+			# principal once the full payable amount is actually covered.
+			and not (
+				self.repayment_type == "Partial Settlement"
+				and flt(self.amount_paid, precision) < flt(self.payable_amount, precision)
+			)
 		):
 			amount = self.principal_amount_paid - overdue_principal_paid
 			create_loan_demand(
@@ -1949,6 +1956,8 @@ class LoanRepayment(LoanController):
 
 	def apply_allocation_order(self, allocation_order, pending_amount, demands, status=None):
 		"""Allocate amount based on allocation order"""
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
 		allocation_order_doc = frappe.get_doc("Loan Demand Offset Order", allocation_order)
 		for d in allocation_order_doc.get("components"):
 			if d.demand_type == "EMI (Principal + Interest)" and pending_amount > 0:
@@ -1972,6 +1981,12 @@ class LoanRepayment(LoanController):
 					)
 					or status == "Settled"
 					and self.repayment_type not in ("Interest Waiver", "Penalty Waiver", "Charges Waiver")
+					# Partial Settlement doesn't auto-waive leftover interest/penalty like
+					# Full Settlement/Write Off flows do, so only pay principal ahead of
+					# schedule once the full payable amount is actually covered.
+				) and not (
+					self.repayment_type == "Partial Settlement"
+					and flt(self.amount_paid, precision) < flt(self.payable_amount, precision)
 				):
 					principal_amount_paid = sum(
 						d.paid_amount for d in self.get("repayment_details") if d.demand_subtype == "Principal"
@@ -1984,7 +1999,7 @@ class LoanRepayment(LoanController):
 						self.principal_amount_paid += pending_amount
 						pending_amount = 0
 
-			if d.demand_type == "Normal" and pending_amount > 0:
+			if (d.demand_type == "Normal" and pending_amount > 0) or (d.demand_type == "Interest" and pending_amount > 0):
 				pending_amount = self.adjust_component(
 					pending_amount, "Normal", demands, demand_subtype="Interest"
 				)

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1666,6 +1666,13 @@ class LoanRepayment(LoanController):
 			if self.repayment_type not in (
 				"Interest Waiver", "Penalty Waiver", "Charges Waiver",
 				"Penalty Capitalization", "Interest Capitalization", "Charges Capitalization"
+			) and not (
+				# Partial Settlement doesn't auto-waive leftover interest/penalty like
+				# Full Settlement/Write Off flows do, so any amount that couldn't be
+				# matched to a real demand shouldn't be booked as principal paid
+				# unless the full payable amount was actually covered.
+				self.repayment_type == "Partial Settlement"
+				and flt(self.amount_paid, precision) < flt(self.payable_amount, precision)
 			):
 				self.principal_amount_paid += flt(amount_paid, precision)
 			elif self.repayment_type in ("Penalty Waiver", "Penalty Capitalization"):
@@ -1999,7 +2006,7 @@ class LoanRepayment(LoanController):
 						self.principal_amount_paid += pending_amount
 						pending_amount = 0
 
-			if (d.demand_type == "Normal" and pending_amount > 0) or (d.demand_type == "Interest" and pending_amount > 0):
+			if d.demand_type == "Normal" and pending_amount > 0:
 				pending_amount = self.adjust_component(
 					pending_amount, "Normal", demands, demand_subtype="Interest"
 				)


### PR DESCRIPTION
**Issue**

When a Partial Settlement payment covered all the principal due but left a small extra amount, that extra amount was treated as an early principal payment — even if interest or penalty was still unpaid. This extra amount got recorded as a new principal entry that was not linked to the loan's repayment schedule.

Because this new entry was not linked to the schedule, it lowered the total principal paid on the loan, but it did not count toward the principal that is actually due. Over time this mismatch could make the "Principal Not Due" figure show a negative number, which does not make sense for an outstanding loan.

**Fix**

A Partial Settlement can now pay principal ahead of schedule only when the full amount due (principal, interest, penalty, and charges) has actually been paid. If any interest or penalty is still unpaid, the extra amount is no longer treated as early principal and is left unallocated instead, so it does not lower the principal paid on the loan without a matching due amount.

A test was added that recreates this scenario — a Partial Settlement that overshoots the due principal while interest is still unpaid — and checks that the principal paid stays backed by a real repayment allocation and no untracked demand entry gets created.
