### PR TITLE
fix: crash when amount paid check runs before payable amount is set

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -1027,11 +1027,12 @@ class LoanRepayment(LoanController):
 				frappe.throw(_("Incorrect repayment type, please write off the loan first"))
 
 	def validate_amount(self, amounts):
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
+
 		if not self.amount_paid:
 			frappe.throw(_("Amount paid cannot be zero"))
 
 		if self.repayment_type == "Normal Repayment":
-			precision = cint(frappe.db.get_default("currency_precision")) or 2
 			validate_repayment = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "validate_normal_repayment"
 			)
@@ -1049,7 +1050,6 @@ class LoanRepayment(LoanController):
 				frappe.throw(_("Amount paid cannot be less than payable amount for loan closure"))
 
 		if self.repayment_type in ("Interest Waiver", "Penalty Waiver", "Charges Waiver"):
-			precision = cint(frappe.db.get_default("currency_precision")) or 2
 			payable_amount = self.get_waiver_amount(amounts)
 
 			if flt(self.amount_paid, precision) > flt(payable_amount, precision):

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -958,7 +958,6 @@ class LoanRepayment(LoanController):
 				)
 
 	def validate_repayment_type(self):
-		precision = cint(frappe.db.get_default("currency_precision")) or 2
 		loan_status = frappe.db.get_value("Loan", self.against_loan, "status")
 
 		if loan_status == "Closed" and self.repayment_type not in [
@@ -1023,12 +1022,6 @@ class LoanRepayment(LoanController):
 				and not self.is_write_off_waiver
 			):
 				frappe.throw(_("Repayment type can only be Write Off Recovery or Write Off Settlement"))
-		elif self.repayment_type == "Normal Repayment":
-			validate_repayment = frappe.get_cached_value(
-				"Loan Product", self.loan_product, "validate_normal_repayment"
-			)
-			if validate_repayment and flt(self.amount_paid, precision) > flt(self.payable_amount, precision):
-				frappe.throw(_("Amount paid cannot be greater than payable amount"))
 		elif loan_status != "Settled":
 			if self.repayment_type in ("Write Off Recovery", "Write Off Settlement"):
 				frappe.throw(_("Incorrect repayment type, please write off the loan first"))
@@ -1036,6 +1029,16 @@ class LoanRepayment(LoanController):
 	def validate_amount(self, amounts):
 		if not self.amount_paid:
 			frappe.throw(_("Amount paid cannot be zero"))
+
+		if self.repayment_type == "Normal Repayment":
+			precision = cint(frappe.db.get_default("currency_precision")) or 2
+			validate_repayment = frappe.get_cached_value(
+				"Loan Product", self.loan_product, "validate_normal_repayment"
+			)
+			if validate_repayment and flt(self.amount_paid, precision) > flt(
+				amounts.get("payable_amount"), precision
+			):
+				frappe.throw(_("Amount paid cannot be greater than payable amount"))
 
 		if self.repayment_type == "Loan Closure":
 			auto_write_off_amount = frappe.get_cached_value(

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -958,6 +958,7 @@ class LoanRepayment(LoanController):
 				)
 
 	def validate_repayment_type(self):
+		precision = cint(frappe.db.get_default("currency_precision")) or 2
 		loan_status = frappe.db.get_value("Loan", self.against_loan, "status")
 
 		if loan_status == "Closed" and self.repayment_type not in [
@@ -1026,7 +1027,7 @@ class LoanRepayment(LoanController):
 			validate_repayment = frappe.get_cached_value(
 				"Loan Product", self.loan_product, "validate_normal_repayment"
 			)
-			if validate_repayment and self.amount_paid > self.payable_amount:
+			if validate_repayment and flt(self.amount_paid, precision) > flt(self.payable_amount, precision):
 				frappe.throw(_("Amount paid cannot be greater than payable amount"))
 		elif loan_status != "Settled":
 			if self.repayment_type in ("Write Off Recovery", "Write Off Settlement"):

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -2179,3 +2179,44 @@ class TestLoanRepayment(LendingTestSuite):
 
 		date_map = get_last_demand_date_map([loan.name], due_date)
 		self.assertEqual(date_map.get(loan.name), get_last_demand_date(due_date, loan=loan.name))
+
+	def test_normal_repayment_with_validate_normal_repayment(self):
+		posting_date = get_datetime("2024-04-18")
+		repayment_start_date = get_datetime("2024-05-05")
+
+		loan = create_loan(
+			self.applicant2,
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			4,
+			applicant_type="Customer",
+			repayment_start_date=repayment_start_date,
+			posting_date=posting_date,
+			rate_of_interest=10,
+		)
+		loan.submit()
+		make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date=posting_date,
+			repayment_start_date=repayment_start_date,
+		)
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date=add_months(posting_date, 1), company="_Test Company"
+		)
+		process_daily_loan_demands(loan=loan.name, posting_date=repayment_start_date)
+
+		frappe.db.set_value("Loan Product", "Term Loan Product 4", "validate_normal_repayment", 1)
+		self.addCleanup(
+			lambda: frappe.db.set_value("Loan Product", "Term Loan Product 4", "validate_normal_repayment", 0)
+		)
+
+		payable_amount = calculate_amounts(loan.name, repayment_start_date)["payable_amount"]
+
+		repayment = create_repayment_entry(
+			loan=loan.name, value_date=repayment_start_date, paid_amount=payable_amount
+		)
+		repayment.submit()
+
+		self.assertEqual(repayment.docstatus, 1)


### PR DESCRIPTION
**What is wrong**

When a Normal Repayment is saved, the code checks if the amount paid is more than the payable amount. This check used to run before the payable amount was set on the document. So the payable amount was empty at that point, and the check crashed with an error.

This happens when a loan product has "Validate Payments" turned on. One place this shows up is in payroll, when a salary slip creates a loan repayment automatically.

**What this fixes**

Moved the check to run after the payable amount is set to its real value, so it checks against correct data instead of an empty value.