### PR TITLE
fix: stop double charge debit on write off recovery payment account

### DIFF
--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2270,7 +2270,9 @@ class LoanRepayment(LoanController):
 			)
 
 		charges_paid_with_sales_invoice = sum(
-			flt(r.paid_amount) for r in self.get("repayment_details") if r.demand_type == "Charges"
+			flt(r.paid_amount)
+			for r in self.get("repayment_details")
+			if r.demand_type == "Charges" and r.sales_invoice
 		)
 		charges_paid_without_sales_invoice = flt(self.total_charges_paid, precision) - flt(
 			charges_paid_with_sales_invoice, precision

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2269,7 +2269,14 @@ class LoanRepayment(LoanController):
 				is_waiver_entry=is_waiver_entry,
 			)
 
-		if flt(self.total_charges_paid, precision) > 0 and self.repayment_type in (
+		charges_paid_with_sales_invoice = sum(
+			flt(r.paid_amount) for r in self.get("repayment_details") if r.demand_type == "Charges"
+		)
+		charges_paid_without_sales_invoice = flt(self.total_charges_paid, precision) - flt(
+			charges_paid_with_sales_invoice, precision
+		)
+
+		if charges_paid_without_sales_invoice > 0 and self.repayment_type in (
 			"Write Off Recovery",
 			"Write Off Settlement",
 		):
@@ -2277,7 +2284,7 @@ class LoanRepayment(LoanController):
 			if not against_account:
 				frappe.throw(_("Write Off Recovery Account is mandatory"))
 
-			self.add_gl_entry(self.payment_account, against_account, self.total_charges_paid, gle_map)
+			self.add_gl_entry(self.payment_account, against_account, charges_paid_without_sales_invoice, gle_map)
 
 		charge_invoices = [
 			r.sales_invoice

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1087,6 +1087,70 @@ class TestLoanRepayment(LendingTestSuite):
 		self.assertEqual(loan.total_principal_paid, 0)
 		self.assertEqual(loan.status, "Written Off")
 
+	def test_write_off_recovery_with_charges(self):
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			repayment_start_date="2024-12-01",
+			posting_date="2024-12-01",
+			rate_of_interest=25,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-12-01", repayment_start_date="2024-12-01"
+		)
+
+		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2024-12-31", company="_Test Company"
+		)
+
+		sales_invoice = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": "_Test Customer 1",
+				"company": "_Test Company",
+				"loan": loan.name,
+				"posting_date": "2024-12-31",
+				"value_date": "2024-12-31",
+				"items": [{"item_code": "Processing Fee", "qty": 1, "rate": 750}],
+			}
+		)
+		sales_invoice.submit()
+
+		amounts = calculate_amounts(loan.name, "2024-12-31", payment_type="Write Off Recovery")
+		pay_amount = (
+			flt(amounts.get("pending_principal_amount"))
+			+ flt(amounts.get("interest_amount"))
+			+ flt(amounts.get("penalty_amount"))
+			+ flt(amounts.get("total_charges_payable"))
+		)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", pay_amount, repayment_type="Write Off Recovery")
+		repayment_entry.submit()
+
+		self.assertEqual(repayment_entry.total_charges_paid, 750)
+
+		payment_account_debit = frappe.get_all(
+			"GL Entry",
+			filters={
+				"voucher_type": "Loan Repayment",
+				"voucher_no": repayment_entry.name,
+				"account": repayment_entry.payment_account,
+				"is_cancelled": 0,
+			},
+			pluck="debit",
+		)
+		self.assertEqual(flt(sum(payment_account_debit), 2), flt(repayment_entry.amount_paid, 2))
+
 	def test_pre_payment_with_partial_unbooked_interest(self):
 		set_loan_accrual_frequency("Daily")
 

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -12,6 +12,10 @@ from lending.loan_management.doctype.loan_repayment.loan_repayment import (
 	init_amounts,
 	post_bulk_payments,
 )
+from lending.loan_management.doctype.loan_write_off.loan_write_off import (
+	get_write_off_recovery_details,
+	get_write_off_waivers,
+)
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
@@ -1108,8 +1112,6 @@ class TestLoanRepayment(LendingTestSuite):
 			loan.name, loan.loan_amount, disbursement_date="2024-12-01", repayment_start_date="2024-12-01"
 		)
 
-		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
-
 		process_loan_interest_accrual_for_loans(
 			loan=loan.name, posting_date="2024-12-31", company="_Test Company"
 		)
@@ -1127,12 +1129,23 @@ class TestLoanRepayment(LendingTestSuite):
 		)
 		sales_invoice.submit()
 
-		# Overpay beyond principal so any waived interest/penalty is cleared
-		# too, leaving nothing to block the invoiced charge from being paid.
-		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", 102000, repayment_type="Write Off Recovery")
+		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
+
+		charge_amount = 750
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
+		waivers = get_write_off_waivers(loan.name, "2024-12-31")
+		recovery = get_write_off_recovery_details(loan.name, "2024-12-31")
+		pay_amount = (
+			flt(amounts.get("pending_principal_amount"))
+			+ flt(waivers.get("Interest Waiver")) - flt(recovery.get("total_interest"))
+			+ flt(waivers.get("Penalty Waiver")) - flt(recovery.get("total_penalty"))
+			+ flt(waivers.get("Charges Waiver")) - flt(recovery.get("total_charges"))
+		)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", pay_amount, repayment_type="Write Off Recovery")
 		repayment_entry.submit()
 
-		self.assertEqual(repayment_entry.total_charges_paid, 750)
+		self.assertEqual(repayment_entry.total_charges_paid, charge_amount)
 
 		payment_account_debit = frappe.get_all(
 			"GL Entry",
@@ -1186,10 +1199,21 @@ class TestLoanRepayment(LendingTestSuite):
 
 		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
 
-		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", 102000, repayment_type="Write Off Recovery")
+		charge_amount = 750
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
+		waivers = get_write_off_waivers(loan.name, "2024-12-31")
+		recovery = get_write_off_recovery_details(loan.name, "2024-12-31")
+		pay_amount = (
+			flt(amounts.get("pending_principal_amount"))
+			+ flt(waivers.get("Interest Waiver")) - flt(recovery.get("total_interest"))
+			+ flt(waivers.get("Penalty Waiver")) - flt(recovery.get("total_penalty"))
+			+ flt(waivers.get("Charges Waiver")) - flt(recovery.get("total_charges"))
+		)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", pay_amount, repayment_type="Write Off Recovery")
 		repayment_entry.submit()
 
-		self.assertEqual(repayment_entry.total_charges_paid, 750)
+		self.assertEqual(repayment_entry.total_charges_paid, charge_amount)
 		self.assertFalse(
 			any(d.demand_type == "Charges" for d in repayment_entry.repayment_details)
 		)

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1092,7 +1092,7 @@ class TestLoanRepayment(LendingTestSuite):
 		self.assertEqual(loan.status, "Written Off")
 
 	def test_write_off_recovery_with_charges(self):
-		"""Charge with its own sales invoice is paid off without debiting the payment account twice."""
+		"""Charge raised after write-off stays as an ordinary outstanding invoice, paid off along with principal and interest."""
 		set_loan_accrual_frequency("Daily")
 
 		loan = create_loan(
@@ -1116,6 +1116,10 @@ class TestLoanRepayment(LendingTestSuite):
 			loan=loan.name, posting_date="2024-12-31", company="_Test Company"
 		)
 
+		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
+
+		# Charge raised after write-off is never part of the write-off
+		# waiver, so it stays as an ordinary outstanding sales invoice.
 		sales_invoice = frappe.get_doc(
 			{
 				"doctype": "Sales Invoice",
@@ -1129,17 +1133,16 @@ class TestLoanRepayment(LendingTestSuite):
 		)
 		sales_invoice.submit()
 
-		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
-
 		charge_amount = 750
-		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
 		waivers = get_write_off_waivers(loan.name, "2024-12-31")
 		recovery = get_write_off_recovery_details(loan.name, "2024-12-31")
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
 		pay_amount = (
 			flt(amounts.get("pending_principal_amount"))
 			+ flt(waivers.get("Interest Waiver")) - flt(recovery.get("total_interest"))
 			+ flt(waivers.get("Penalty Waiver")) - flt(recovery.get("total_penalty"))
 			+ flt(waivers.get("Charges Waiver")) - flt(recovery.get("total_charges"))
+			+ flt(amounts.get("total_charges_payable"))
 		)
 
 		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", pay_amount, repayment_type="Write Off Recovery")
@@ -1160,7 +1163,7 @@ class TestLoanRepayment(LendingTestSuite):
 		self.assertEqual(flt(sum(payment_account_debit), 2), flt(repayment_entry.amount_paid, 2))
 
 	def test_write_off_recovery_with_waived_charges(self):
-		"""Charge waived at write-off time is paid back with no sales invoice involved."""
+		"""Charge raised before write-off is waived automatically, paid back with no invoice or repayment_details row."""
 		set_loan_accrual_frequency("Daily")
 
 		loan = create_loan(
@@ -1200,9 +1203,9 @@ class TestLoanRepayment(LendingTestSuite):
 		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
 
 		charge_amount = 750
-		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
 		waivers = get_write_off_waivers(loan.name, "2024-12-31")
 		recovery = get_write_off_recovery_details(loan.name, "2024-12-31")
+		amounts = calculate_amounts(against_loan=loan.name, posting_date="2024-12-31", payment_type="Write Off Recovery")
 		pay_amount = (
 			flt(amounts.get("pending_principal_amount"))
 			+ flt(waivers.get("Interest Waiver")) - flt(recovery.get("total_interest"))

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1088,6 +1088,7 @@ class TestLoanRepayment(LendingTestSuite):
 		self.assertEqual(loan.status, "Written Off")
 
 	def test_write_off_recovery_with_charges(self):
+		"""Charge with its own sales invoice is paid off without debiting the payment account twice."""
 		set_loan_accrual_frequency("Daily")
 
 		loan = create_loan(
@@ -1138,6 +1139,66 @@ class TestLoanRepayment(LendingTestSuite):
 		repayment_entry.submit()
 
 		self.assertEqual(repayment_entry.total_charges_paid, 750)
+
+		payment_account_debit = frappe.get_all(
+			"GL Entry",
+			filters={
+				"voucher_type": "Loan Repayment",
+				"voucher_no": repayment_entry.name,
+				"account": repayment_entry.payment_account,
+				"is_cancelled": 0,
+			},
+			pluck="debit",
+		)
+		self.assertEqual(flt(sum(payment_account_debit), 2), flt(repayment_entry.amount_paid, 2))
+
+	def test_write_off_recovery_with_waived_charges(self):
+		"""Charge waived at write-off time is paid back with no sales invoice involved."""
+		set_loan_accrual_frequency("Daily")
+
+		loan = create_loan(
+			"_Test Customer 1",
+			"Term Loan Product 4",
+			100000,
+			"Repay Over Number of Periods",
+			2,
+			"Customer",
+			repayment_start_date="2024-12-01",
+			posting_date="2024-12-01",
+			rate_of_interest=25,
+		)
+		loan.submit()
+
+		make_loan_disbursement_entry(
+			loan.name, loan.loan_amount, disbursement_date="2024-12-01", repayment_start_date="2024-12-01"
+		)
+
+		process_loan_interest_accrual_for_loans(
+			loan=loan.name, posting_date="2024-12-31", company="_Test Company"
+		)
+
+		sales_invoice = frappe.get_doc(
+			{
+				"doctype": "Sales Invoice",
+				"customer": "_Test Customer 1",
+				"company": "_Test Company",
+				"loan": loan.name,
+				"posting_date": "2024-12-31",
+				"value_date": "2024-12-31",
+				"items": [{"item_code": "Processing Fee", "qty": 1, "rate": 750}],
+			}
+		)
+		sales_invoice.submit()
+
+		create_loan_write_off(loan.name, "2024-12-31", write_off_amount=10000)
+
+		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", 102000, repayment_type="Write Off Recovery")
+		repayment_entry.submit()
+
+		self.assertEqual(repayment_entry.total_charges_paid, 750)
+		self.assertFalse(
+			any(d.demand_type == "Charges" for d in repayment_entry.repayment_details)
+		)
 
 		payment_account_debit = frappe.get_all(
 			"GL Entry",

--- a/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/test_loan_repayment.py
@@ -1127,15 +1127,9 @@ class TestLoanRepayment(LendingTestSuite):
 		)
 		sales_invoice.submit()
 
-		amounts = calculate_amounts(loan.name, "2024-12-31", payment_type="Write Off Recovery")
-		pay_amount = (
-			flt(amounts.get("pending_principal_amount"))
-			+ flt(amounts.get("interest_amount"))
-			+ flt(amounts.get("penalty_amount"))
-			+ flt(amounts.get("total_charges_payable"))
-		)
-
-		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", pay_amount, repayment_type="Write Off Recovery")
+		# Overpay beyond principal so any waived interest/penalty is cleared
+		# too, leaving nothing to block the invoiced charge from being paid.
+		repayment_entry = create_repayment_entry(loan.name, "2024-12-31", 102000, repayment_type="Write Off Recovery")
 		repayment_entry.submit()
 
 		self.assertEqual(repayment_entry.total_charges_paid, 750)


### PR DESCRIPTION
**What was wrong**
When someone pays back a written off loan (Write Off Recovery or Write Off Settlement) and that payment also covers a charge that has its own invoice (like a bounce charge), the system was taking the charge amount out of the bank account two times. This made the bank/payment account show more money collected than what the customer actually paid.

**Example**
Customer paid 14,75,000. This included a 750 charge. The correct bank entry should be 14,75,000. But the system showed 14,75,750, which is 750 too much.

<img width="5760" height="2736" alt="image" src="https://github.com/user-attachments/assets/62c9fdcb-5c32-4748-980c-eb5829b7615d" />


**What changed**
In loan_repayment.py, before posting the write off recovery charge amount to the bank account, we now check how much of that charge was already covered by its own invoice entry. Only the remaining part (if any) gets posted separately. This stops the same amount from being counted twice.