### PR TITLE
fix: add as on date filter to Loan Outstanding Report

### DIFF
--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.js
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.js
@@ -12,6 +12,16 @@ frappe.query_reports["Loan Outstanding Report"] = {
 			"reqd": 1
 		},
 		{
+			"fieldname":"as_on_date",
+			"label": __("As on Date"),
+			"fieldtype": "Date",
+			"default": frappe.datetime.get_today(),
+			"reqd": 1,
+			on_change: function() {
+				frappe.query_report.refresh();
+			}
+		},
+		{
 			"fieldname":"applicant_type",
 			"label": __("Applicant Type"),
 			"fieldtype": "Select",

--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.json
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.json
@@ -10,7 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-08-11 11:29:39.233095",
+ "modified": "2026-09-03 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Outstanding Report",

--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
@@ -2,10 +2,14 @@ import frappe
 from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
-from frappe.utils import flt
+from frappe.utils import flt, getdate, nowdate
 
 
 def execute(filters=None):
+	filters = filters or {}
+	if not filters.get("as_on_date"):
+		frappe.throw(_("Please select an As on Date."))
+
 	columns = get_columns()
 	data = get_data(filters)
 	chart = get_chart_data(data)
@@ -146,6 +150,8 @@ def get_data(filters):
 	Loan = DocType("Loan")
 	LoanDisbursement = DocType("Loan Disbursement")
 
+	as_on_date = getdate(filters.get("as_on_date") or nowdate())
+
 	loan_disbursement_query = (
 		frappe.qb.from_(LoanDisbursement)
 		.inner_join(Loan)
@@ -172,6 +178,8 @@ def get_data(filters):
 			Loan.disbursed_amount.as_("loan_disbursed_amount"),
 		)
 		.where((Loan.docstatus == 1) & (Loan.status != "Closed"))
+		.where(LoanDisbursement.docstatus == 1)
+		.where(LoanDisbursement.disbursement_date <= as_on_date)
 	)
 
 	if filters.get("company"):
@@ -203,8 +211,12 @@ def get_data(filters):
 		r["loan"]: r.get("repayment_schedule_type") for r in disbursement_records
 	}
 
-	principal_overdue_map, interest_overdue_map = get_overdues_for_loans(loan_disbursement_keys)
-	repayment_summary_map = get_bulk_repayment_details(loan_disbursement_keys, repayment_type_by_loan)
+	principal_overdue_map, interest_overdue_map = get_overdues_for_loans(
+		loan_disbursement_keys, as_on_date
+	)
+	repayment_summary_map = get_bulk_repayment_details(
+		loan_disbursement_keys, repayment_type_by_loan, as_on_date
+	)
 	emi_summary_map = get_bulk_emi_details(disbursement_names)
 
 	report_rows = []
@@ -214,9 +226,11 @@ def get_data(filters):
 
 		repayment_summary = repayment_summary_map.get((loan, disb), {})
 		emi_summary = emi_summary_map.get(disb, {})
+		principal_paid_as_on_date = flt(repayment_summary.get("principal_amount_paid"))
+		interest_paid_as_on_date = flt(repayment_summary.get("total_interest_paid"))
 
 		if record.repayment_schedule_type == "Line of Credit" and disb:
-			pending_principal = flt(record.disbursed_amount) - flt(record.disbursement_principal_paid)
+			pending_principal = flt(record.disbursed_amount) - principal_paid_as_on_date
 		elif (
 			record.status in ("Disbursed", "Closed", "Active", "Written Off", "Settled")
 			and record.repayment_schedule_type != "Line of Credit"
@@ -225,15 +239,15 @@ def get_data(filters):
 				flt(record.total_payment)
 				+ flt(record.debit_adjustment_amount)
 				- flt(record.credit_adjustment_amount)
-				- flt(record.total_principal_paid)
-				- flt(record.total_interest_payable)
+				- principal_paid_as_on_date
+				- interest_paid_as_on_date
 			)
 		else:
 			pending_principal = (
 				flt(record.loan_disbursed_amount)
 				+ flt(record.debit_adjustment_amount)
 				- flt(record.credit_adjustment_amount)
-				- flt(record.total_principal_paid)
+				- principal_paid_as_on_date
 			)
 
 		report_rows.append(
@@ -255,7 +269,7 @@ def get_data(filters):
 	return report_rows
 
 
-def get_bulk_repayment_details(loan_disbursement_keys, repayment_type_by_loan):
+def get_bulk_repayment_details(loan_disbursement_keys, repayment_type_by_loan, as_on_date):
 	Repayment = DocType("Loan Repayment")
 	loans = list({loan for loan, _ in loan_disbursement_keys})
 	disbursements = list({disb for _, disb in loan_disbursement_keys})
@@ -273,6 +287,7 @@ def get_bulk_repayment_details(loan_disbursement_keys, repayment_type_by_loan):
 			(Repayment.docstatus == 1)
 			& (Repayment.against_loan.isin(loans))
 			& ((Repayment.loan_disbursement.isin(disbursements)) | (Repayment.loan_disbursement.isnull()))
+			& (Repayment.value_date <= as_on_date)
 		)
 		.groupby(Repayment.against_loan, Repayment.loan_disbursement)
 	).run(as_dict=True)
@@ -351,7 +366,7 @@ def get_bulk_emi_details(disbursement_names):
 	return emi_summary_map
 
 
-def get_overdues_for_loans(loan_disbursement_keys):
+def get_overdues_for_loans(loan_disbursement_keys, as_on_date):
 	LoanDemand = DocType("Loan Demand")
 	disbursement_names = [disb for _, disb in loan_disbursement_keys]
 
@@ -363,7 +378,11 @@ def get_overdues_for_loans(loan_disbursement_keys):
 			LoanDemand.demand_subtype,
 			fn.Sum(LoanDemand.outstanding_amount).as_("outstanding"),
 		)
-		.where((LoanDemand.docstatus == 1) & (LoanDemand.loan_disbursement.isin(disbursement_names)))
+		.where(
+			(LoanDemand.docstatus == 1)
+			& (LoanDemand.loan_disbursement.isin(disbursement_names))
+			& (LoanDemand.demand_date <= as_on_date)
+		)
 		.groupby(LoanDemand.loan, LoanDemand.loan_disbursement, LoanDemand.demand_subtype)
 	).run(as_dict=True)
 

--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
@@ -171,13 +171,11 @@ def get_data(filters):
 			Loan.repayment_schedule_type,
 			Loan.days_past_due,
 			Loan.total_payment,
-			Loan.debit_adjustment_amount,
-			Loan.credit_adjustment_amount,
 			Loan.total_principal_paid,
 			Loan.total_interest_payable,
 			Loan.disbursed_amount.as_("loan_disbursed_amount"),
 		)
-		.where((Loan.docstatus == 1) & (Loan.status != "Closed"))
+		.where(Loan.docstatus == 1)
 		.where(LoanDisbursement.docstatus == 1)
 		.where(LoanDisbursement.disbursement_date <= as_on_date)
 	)
@@ -218,6 +216,7 @@ def get_data(filters):
 		loan_disbursement_keys, repayment_type_by_loan, as_on_date
 	)
 	emi_summary_map = get_bulk_emi_details(disbursement_names)
+	adjustment_map = get_bulk_balance_adjustments(loan_disbursement_keys, as_on_date)
 
 	report_rows = []
 	for record in disbursement_records:
@@ -226,8 +225,11 @@ def get_data(filters):
 
 		repayment_summary = repayment_summary_map.get((loan, disb), {})
 		emi_summary = emi_summary_map.get(disb, {})
+		adjustments = adjustment_map.get(loan, {})
 		principal_paid_as_on_date = flt(repayment_summary.get("principal_amount_paid"))
 		interest_paid_as_on_date = flt(repayment_summary.get("total_interest_paid"))
+		debit_adjustment_as_on_date = flt(adjustments.get("debit_adjustment_amount"))
+		credit_adjustment_as_on_date = flt(adjustments.get("credit_adjustment_amount"))
 
 		if record.repayment_schedule_type == "Line of Credit" and disb:
 			pending_principal = flt(record.disbursed_amount) - principal_paid_as_on_date
@@ -237,16 +239,16 @@ def get_data(filters):
 		):
 			pending_principal = (
 				flt(record.total_payment)
-				+ flt(record.debit_adjustment_amount)
-				- flt(record.credit_adjustment_amount)
+				+ debit_adjustment_as_on_date
+				- credit_adjustment_as_on_date
 				- principal_paid_as_on_date
 				- interest_paid_as_on_date
 			)
 		else:
 			pending_principal = (
 				flt(record.loan_disbursed_amount)
-				+ flt(record.debit_adjustment_amount)
-				- flt(record.credit_adjustment_amount)
+				+ debit_adjustment_as_on_date
+				- credit_adjustment_as_on_date
 				- principal_paid_as_on_date
 			)
 
@@ -334,6 +336,38 @@ def get_bulk_repayment_details(loan_disbursement_keys, repayment_type_by_loan, a
 		repayment_summary_map[(loan, disb)] = combined_totals
 
 	return repayment_summary_map
+
+
+def get_bulk_balance_adjustments(loan_disbursement_keys, as_on_date):
+	LoanBalanceAdjustment = DocType("Loan Balance Adjustment")
+	loans = list({loan for loan, _ in loan_disbursement_keys})
+
+	raw_adjustment_data = (
+		frappe.qb.from_(LoanBalanceAdjustment)
+		.select(
+			LoanBalanceAdjustment.loan,
+			LoanBalanceAdjustment.adjustment_type,
+			fn.Sum(LoanBalanceAdjustment.amount).as_("amount"),
+		)
+		.where(
+			(LoanBalanceAdjustment.docstatus == 1)
+			& (LoanBalanceAdjustment.loan.isin(loans))
+			& (LoanBalanceAdjustment.posting_date <= as_on_date)
+		)
+		.groupby(LoanBalanceAdjustment.loan, LoanBalanceAdjustment.adjustment_type)
+	).run(as_dict=True)
+
+	adjustment_map = {}
+	for row in raw_adjustment_data:
+		totals = adjustment_map.setdefault(
+			row["loan"], {"debit_adjustment_amount": 0.0, "credit_adjustment_amount": 0.0}
+		)
+		if row["adjustment_type"] == "Debit Adjustment":
+			totals["debit_adjustment_amount"] = flt(row["amount"])
+		elif row["adjustment_type"] == "Credit Adjustment":
+			totals["credit_adjustment_amount"] = flt(row["amount"])
+
+	return adjustment_map
 
 
 def get_bulk_emi_details(disbursement_names):

--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
@@ -4,6 +4,10 @@ from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
 from frappe.utils import flt, getdate, nowdate
 
+from lending.loan_management.doctype.loan_repayment.loan_repayment import (
+	get_pending_principal_amount,
+)
+
 
 def execute(filters=None):
 	filters = filters or {}
@@ -233,23 +237,18 @@ def get_data(filters):
 
 		if record.repayment_schedule_type == "Line of Credit" and disb:
 			pending_principal = flt(record.disbursed_amount) - principal_paid_as_on_date
-		elif (
-			record.status in ("Disbursed", "Closed", "Active", "Written Off", "Settled")
-			and record.repayment_schedule_type != "Line of Credit"
-		):
-			pending_principal = (
-				flt(record.total_payment)
-				+ debit_adjustment_as_on_date
-				- credit_adjustment_as_on_date
-				- principal_paid_as_on_date
-				- interest_paid_as_on_date
-			)
 		else:
-			pending_principal = (
-				flt(record.loan_disbursed_amount)
-				+ debit_adjustment_as_on_date
-				- credit_adjustment_as_on_date
-				- principal_paid_as_on_date
+			pending_principal = get_pending_principal_amount(
+				frappe._dict(
+					status=record.status,
+					repayment_schedule_type=record.repayment_schedule_type,
+					disbursed_amount=record.loan_disbursed_amount,
+					total_payment=record.total_payment,
+					debit_adjustment_amount=debit_adjustment_as_on_date,
+					credit_adjustment_amount=credit_adjustment_as_on_date,
+					total_principal_paid=principal_paid_as_on_date,
+					total_interest_payable=interest_paid_as_on_date,
+				)
 			)
 
 		report_rows.append(
@@ -410,7 +409,7 @@ def get_overdues_for_loans(loan_disbursement_keys, as_on_date):
 			LoanDemand.loan.as_("loan"),
 			LoanDemand.loan_disbursement.as_("loan_disbursement"),
 			LoanDemand.demand_subtype,
-			fn.Sum(LoanDemand.outstanding_amount).as_("outstanding"),
+			fn.Sum(LoanDemand.demand_amount).as_("demanded"),
 		)
 		.where(
 			(LoanDemand.docstatus == 1)
@@ -420,14 +419,49 @@ def get_overdues_for_loans(loan_disbursement_keys, as_on_date):
 		.groupby(LoanDemand.loan, LoanDemand.loan_disbursement, LoanDemand.demand_subtype)
 	).run(as_dict=True)
 
+	RepaymentDetail = DocType("Loan Repayment Detail")
+	Repayment = DocType("Loan Repayment")
+
+	raw_paid_data = (
+		frappe.qb.from_(RepaymentDetail)
+		.inner_join(Repayment)
+		.on(Repayment.name == RepaymentDetail.parent)
+		.inner_join(LoanDemand)
+		.on(LoanDemand.name == RepaymentDetail.loan_demand)
+		.select(
+			LoanDemand.loan.as_("loan"),
+			LoanDemand.loan_disbursement.as_("loan_disbursement"),
+			RepaymentDetail.demand_subtype,
+			fn.Sum(RepaymentDetail.paid_amount).as_("paid"),
+		)
+		.where(
+			(Repayment.docstatus == 1)
+			& (LoanDemand.loan_disbursement.isin(disbursement_names))
+			& (LoanDemand.demand_date <= as_on_date)
+			& (Repayment.value_date <= as_on_date)
+		)
+		.groupby(LoanDemand.loan, LoanDemand.loan_disbursement, RepaymentDetail.demand_subtype)
+	).run(as_dict=True)
+
+	demanded_map = {}
+	for row in raw_demand_data:
+		key = (row["loan"], row["loan_disbursement"], row["demand_subtype"])
+		demanded_map[key] = flt(row["demanded"])
+
+	paid_map = {}
+	for row in raw_paid_data:
+		key = (row["loan"], row["loan_disbursement"], row["demand_subtype"])
+		paid_map[key] = flt(row["paid"])
+
 	principal_overdue_map = {}
 	interest_overdue_map = {}
 
-	for row in raw_demand_data:
-		key = (row["loan"], row["loan_disbursement"])
-		if row["demand_subtype"] == "Principal":
-			principal_overdue_map[key] = flt(row["outstanding"])
-		elif row["demand_subtype"] == "Interest":
-			interest_overdue_map[key] = flt(row["outstanding"])
+	for key, demanded in demanded_map.items():
+		loan, loan_disbursement, demand_subtype = key
+		outstanding = demanded - paid_map.get(key, 0.0)
+		if demand_subtype == "Principal":
+			principal_overdue_map[(loan, loan_disbursement)] = outstanding
+		elif demand_subtype == "Interest":
+			interest_overdue_map[(loan, loan_disbursement)] = outstanding
 
 	return principal_overdue_map, interest_overdue_map

--- a/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/loan_outstanding_report.py
@@ -221,6 +221,9 @@ def get_data(filters):
 	)
 	emi_summary_map = get_bulk_emi_details(disbursement_names)
 	adjustment_map = get_bulk_balance_adjustments(loan_disbursement_keys, as_on_date)
+	disbursed_as_on_date_map = get_disbursed_amount_as_on_date(
+		[loan for loan, _ in loan_disbursement_keys], as_on_date
+	)
 
 	report_rows = []
 	for record in disbursement_records:
@@ -231,23 +234,26 @@ def get_data(filters):
 		emi_summary = emi_summary_map.get(disb, {})
 		adjustments = adjustment_map.get(loan, {})
 		principal_paid_as_on_date = flt(repayment_summary.get("principal_amount_paid"))
-		interest_paid_as_on_date = flt(repayment_summary.get("total_interest_paid"))
 		debit_adjustment_as_on_date = flt(adjustments.get("debit_adjustment_amount"))
 		credit_adjustment_as_on_date = flt(adjustments.get("credit_adjustment_amount"))
 
 		if record.repayment_schedule_type == "Line of Credit" and disb:
 			pending_principal = flt(record.disbursed_amount) - principal_paid_as_on_date
 		else:
+			disbursed_as_on_date = flt(disbursed_as_on_date_map.get(loan))
+			was_fully_disbursed_as_on_date = disbursed_as_on_date >= flt(record.loan_amount)
+			status_for_formula = record.status if was_fully_disbursed_as_on_date else "Partially Disbursed"
+
 			pending_principal = get_pending_principal_amount(
 				frappe._dict(
-					status=record.status,
+					status=status_for_formula,
 					repayment_schedule_type=record.repayment_schedule_type,
-					disbursed_amount=record.loan_disbursed_amount,
+					disbursed_amount=disbursed_as_on_date,
 					total_payment=record.total_payment,
 					debit_adjustment_amount=debit_adjustment_as_on_date,
 					credit_adjustment_amount=credit_adjustment_as_on_date,
 					total_principal_paid=principal_paid_as_on_date,
-					total_interest_payable=interest_paid_as_on_date,
+					total_interest_payable=record.total_interest_payable,
 				)
 			)
 
@@ -369,6 +375,23 @@ def get_bulk_balance_adjustments(loan_disbursement_keys, as_on_date):
 	return adjustment_map
 
 
+def get_disbursed_amount_as_on_date(loans, as_on_date):
+	LoanDisbursement = DocType("Loan Disbursement")
+
+	raw_data = (
+		frappe.qb.from_(LoanDisbursement)
+		.select(LoanDisbursement.against_loan.as_("loan"), fn.Sum(LoanDisbursement.disbursed_amount))
+		.where(
+			(LoanDisbursement.docstatus == 1)
+			& (LoanDisbursement.against_loan.isin(loans))
+			& (LoanDisbursement.disbursement_date <= as_on_date)
+		)
+		.groupby(LoanDisbursement.against_loan)
+	).run()
+
+	return {row[0]: flt(row[1]) for row in raw_data}
+
+
 def get_bulk_emi_details(disbursement_names):
 	RepaymentSchedule = DocType("Loan Repayment Schedule")
 	raw_emi_data = (
@@ -406,62 +429,70 @@ def get_overdues_for_loans(loan_disbursement_keys, as_on_date):
 	raw_demand_data = (
 		frappe.qb.from_(LoanDemand)
 		.select(
+			LoanDemand.name.as_("demand"),
 			LoanDemand.loan.as_("loan"),
 			LoanDemand.loan_disbursement.as_("loan_disbursement"),
 			LoanDemand.demand_subtype,
-			fn.Sum(LoanDemand.demand_amount).as_("demanded"),
+			LoanDemand.demand_amount,
+			LoanDemand.paid_amount,
 		)
 		.where(
 			(LoanDemand.docstatus == 1)
 			& (LoanDemand.loan_disbursement.isin(disbursement_names))
 			& (LoanDemand.demand_date <= as_on_date)
 		)
-		.groupby(LoanDemand.loan, LoanDemand.loan_disbursement, LoanDemand.demand_subtype)
 	).run(as_dict=True)
 
-	RepaymentDetail = DocType("Loan Repayment Detail")
-	Repayment = DocType("Loan Repayment")
+	demand_names = [row["demand"] for row in raw_demand_data]
 
-	raw_paid_data = (
-		frappe.qb.from_(RepaymentDetail)
-		.inner_join(Repayment)
-		.on(Repayment.name == RepaymentDetail.parent)
-		.inner_join(LoanDemand)
-		.on(LoanDemand.name == RepaymentDetail.loan_demand)
-		.select(
-			LoanDemand.loan.as_("loan"),
-			LoanDemand.loan_disbursement.as_("loan_disbursement"),
-			RepaymentDetail.demand_subtype,
-			fn.Sum(RepaymentDetail.paid_amount).as_("paid"),
-		)
-		.where(
-			(Repayment.docstatus == 1)
-			& (LoanDemand.loan_disbursement.isin(disbursement_names))
-			& (LoanDemand.demand_date <= as_on_date)
-			& (Repayment.value_date <= as_on_date)
-		)
-		.groupby(LoanDemand.loan, LoanDemand.loan_disbursement, RepaymentDetail.demand_subtype)
-	).run(as_dict=True)
+	demands_with_repayment_detail = set()
+	paid_via_repayment_detail = {}
+	if demand_names:
+		RepaymentDetail = DocType("Loan Repayment Detail")
+		Repayment = DocType("Loan Repayment")
 
-	demanded_map = {}
-	for row in raw_demand_data:
-		key = (row["loan"], row["loan_disbursement"], row["demand_subtype"])
-		demanded_map[key] = flt(row["demanded"])
+		all_repayment_detail_demands = (
+			frappe.qb.from_(RepaymentDetail)
+			.select(RepaymentDetail.loan_demand)
+			.where(RepaymentDetail.loan_demand.isin(demand_names))
+			.distinct()
+		).run()
+		demands_with_repayment_detail = {row[0] for row in all_repayment_detail_demands}
 
-	paid_map = {}
-	for row in raw_paid_data:
-		key = (row["loan"], row["loan_disbursement"], row["demand_subtype"])
-		paid_map[key] = flt(row["paid"])
+		raw_paid_data = (
+			frappe.qb.from_(RepaymentDetail)
+			.inner_join(Repayment)
+			.on(Repayment.name == RepaymentDetail.parent)
+			.select(
+				RepaymentDetail.loan_demand.as_("demand"),
+				fn.Sum(RepaymentDetail.paid_amount).as_("paid"),
+			)
+			.where(
+				(Repayment.docstatus == 1)
+				& (RepaymentDetail.loan_demand.isin(demand_names))
+				& (Repayment.value_date <= as_on_date)
+			)
+			.groupby(RepaymentDetail.loan_demand)
+		).run(as_dict=True)
+
+		paid_via_repayment_detail = {row["demand"]: flt(row["paid"]) for row in raw_paid_data}
 
 	principal_overdue_map = {}
 	interest_overdue_map = {}
 
-	for key, demanded in demanded_map.items():
-		loan, loan_disbursement, demand_subtype = key
-		outstanding = demanded - paid_map.get(key, 0.0)
-		if demand_subtype == "Principal":
-			principal_overdue_map[(loan, loan_disbursement)] = outstanding
-		elif demand_subtype == "Interest":
-			interest_overdue_map[(loan, loan_disbursement)] = outstanding
+	for row in raw_demand_data:
+		key = (row["loan"], row["loan_disbursement"])
+		if row["demand"] in demands_with_repayment_detail:
+			paid = paid_via_repayment_detail.get(row["demand"], 0.0)
+		else:
+			# Some demands are created already fully paid, with no Loan
+			# Repayment Detail allocation, and never get one later.
+			paid = flt(row["paid_amount"])
+
+		outstanding = flt(row["demand_amount"]) - paid
+		if row["demand_subtype"] == "Principal":
+			principal_overdue_map[key] = principal_overdue_map.get(key, 0.0) + outstanding
+		elif row["demand_subtype"] == "Interest":
+			interest_overdue_map[key] = interest_overdue_map.get(key, 0.0) + outstanding
 
 	return principal_overdue_map, interest_overdue_map

--- a/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
@@ -18,7 +18,7 @@ from lending.tests.utils import LendingTestSuite
 
 
 class TestLoanOutstandingReport(LendingTestSuite):
-	def test_loan_outstanding_report_returns_expected_row_and_chart(self):
+	def make_loan_and_disbursement(self):
 		loan = create_loan(
 			"_Test Loan Customer",
 			"Term Loan Product 4",
@@ -37,17 +37,23 @@ class TestLoanOutstandingReport(LendingTestSuite):
 			disbursement_date="2024-01-05",
 			repayment_start_date="2024-02-05",
 		)
+		return loan, disb
 
-		report = execute(
+	def run_report(self, loan, disb, as_on_date):
+		_, data, _, chart = execute(
 			{
 				"company": "_Test Company",
 				"loan": loan.name,
 				"loan_disbursement": disb.name,
-				"as_on_date": "2024-12-31",
+				"as_on_date": as_on_date,
 			}
 		)
-		columns, data, _, chart = report
-		self.assertEqual(columns[0].get("fieldname"), "loan")
+		return data, chart
+
+	def test_loan_outstanding_report_returns_expected_row_and_chart(self):
+		loan, disb = self.make_loan_and_disbursement()
+
+		data, chart = self.run_report(loan, disb, "2024-12-31")
 		self.assertTrue(data)
 		expected_data = {
 			"loan": loan.name,
@@ -63,134 +69,52 @@ class TestLoanOutstandingReport(LendingTestSuite):
 	def test_loan_outstanding_report_requires_as_on_date(self):
 		self.assertRaises(frappe.ValidationError, execute, {"company": "_Test Company"})
 
-	def test_loan_outstanding_report_excludes_disbursement_after_as_on_date(self):
-		loan = create_loan(
-			"_Test Loan Customer",
-			"Term Loan Product 4",
-			110000,
-			"Repay Over Number of Periods",
-			6,
-			"Customer",
-			repayment_start_date="2024-02-05",
-			posting_date="2024-01-05",
-			rate_of_interest=10,
-		)
-		loan.submit()
-		disb = make_loan_disbursement_entry(
-			loan.name,
-			loan.loan_amount,
-			disbursement_date="2024-01-05",
-			repayment_start_date="2024-02-05",
-		)
+	def test_loan_outstanding_report_reflects_as_on_date_snapshot(self):
+		loan, disb = self.make_loan_and_disbursement()
 
-		# as_on_date before the disbursement date: the loan should not appear yet
-		_, data, _, _ = execute(
-			{
-				"company": "_Test Company",
-				"loan": loan.name,
-				"loan_disbursement": disb.name,
-				"as_on_date": "2024-01-04",
-			}
-		)
+		data, _ = self.run_report(loan, disb, "2024-01-04")
 		self.assertFalse(data)
 
-		# as_on_date on/after the disbursement date: the loan should appear
-		_, data, _, _ = execute(
-			{
-				"company": "_Test Company",
-				"loan": loan.name,
-				"loan_disbursement": disb.name,
-				"as_on_date": "2024-01-05",
-			}
-		)
-		self.assertTrue(data)
-
-	def test_loan_outstanding_report_ignores_repayments_after_as_on_date(self):
-		loan = create_loan(
-			"_Test Loan Customer",
-			"Term Loan Product 4",
-			110000,
-			"Repay Over Number of Periods",
-			6,
-			"Customer",
-			repayment_start_date="2024-02-05",
-			posting_date="2024-01-05",
-			rate_of_interest=10,
-		)
-		loan.submit()
-		disb = make_loan_disbursement_entry(
-			loan.name,
-			loan.loan_amount,
-			disbursement_date="2024-01-05",
-			repayment_start_date="2024-02-05",
-		)
-
-		repayment = create_repayment_entry(loan.name, "2024-03-01", 20000)
-		repayment.submit()
-
-		filters_before_repayment = {
-			"company": "_Test Company",
-			"loan": loan.name,
-			"loan_disbursement": disb.name,
-			"as_on_date": "2024-02-15",
-		}
-		filters_after_repayment = {
-			**filters_before_repayment,
-			"as_on_date": "2024-12-31",
-		}
-
-		_, data_before, _, _ = execute(filters_before_repayment)
-		_, data_after, _, _ = execute(filters_after_repayment)
-
+		create_repayment_entry(loan.name, "2024-03-01", 20000).submit()
+		data_before, _ = self.run_report(loan, disb, "2024-02-15")
+		data_after, _ = self.run_report(loan, disb, "2024-12-31")
 		self.assertEqual(data_before[0].get("principal_amount_paid"), 0)
-		self.assertGreater(data_after[0].get("pending_principal_amount"), 0)
 		self.assertGreater(
 			data_before[0].get("pending_principal_amount"),
 			data_after[0].get("pending_principal_amount"),
 		)
 
 	def test_loan_outstanding_report_shows_loan_closed_after_as_on_date(self):
-		loan = create_loan(
-			"_Test Loan Customer",
-			"Term Loan Product 4",
-			110000,
-			"Repay Over Number of Periods",
-			6,
-			"Customer",
-			repayment_start_date="2024-02-05",
-			posting_date="2024-01-05",
-			rate_of_interest=10,
-		)
-		loan.submit()
-		disb = make_loan_disbursement_entry(
-			loan.name,
-			loan.loan_amount,
-			disbursement_date="2024-01-05",
-			repayment_start_date="2024-02-05",
-		)
+		loan, disb = self.make_loan_and_disbursement()
 
 		process_daily_loan_demands(posting_date="2024-07-05", loan=loan.name)
-
 		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2024-07-05")[
 			"payable_amount"
 		]
 		create_repayment_entry(loan.name, "2024-07-05", payable_amount).submit()
-
 		loan.load_from_db()
 		self.assertEqual(loan.status, "Closed")
 
-		# as_on_date before the closing repayment: the loan was still outstanding then,
-		# so it must still show up even though its current status is "Closed".
-		_, data, _, _ = execute(
-			{
-				"company": "_Test Company",
-				"loan": loan.name,
-				"loan_disbursement": disb.name,
-				"as_on_date": "2024-03-01",
-			}
-		)
+		data, _ = self.run_report(loan, disb, "2024-03-01")
 		self.assertTrue(data, "Loan should still appear for a date before it was closed")
 		self.assertGreater(data[0].get("pending_principal_amount"), 0)
+
+	def test_loan_outstanding_report_overdue_ignores_later_repayment(self):
+		loan, disb = self.make_loan_and_disbursement()
+
+		process_daily_loan_demands(posting_date="2024-03-01", loan=loan.name)
+
+		data_overdue, _ = self.run_report(loan, disb, "2024-03-01")
+		overdue_before_payment = data_overdue[0].get("principal_overdue")
+		self.assertGreater(overdue_before_payment, 0)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2024-06-01")[
+			"payable_amount"
+		]
+		create_repayment_entry(loan.name, "2024-06-01", payable_amount).submit()
+
+		data_after, _ = self.run_report(loan, disb, "2024-03-01")
+		self.assertEqual(data_after[0].get("principal_overdue"), overdue_before_payment)
 
 	def test_loan_outstanding_report_defines_columns(self):
 		columns = get_columns()

--- a/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
@@ -1,9 +1,15 @@
+import frappe
+
 from lending.loan_management.report.loan_outstanding_report.loan_outstanding_report import (
 	execute,
 	get_chart_data,
 	get_columns,
 )
-from lending.tests.test_utils import create_loan, make_loan_disbursement_entry
+from lending.tests.test_utils import (
+	create_loan,
+	create_repayment_entry,
+	make_loan_disbursement_entry,
+)
 from lending.tests.utils import LendingTestSuite
 
 
@@ -29,7 +35,12 @@ class TestLoanOutstandingReport(LendingTestSuite):
 		)
 
 		report = execute(
-			{"company": "_Test Company", "loan": loan.name, "loan_disbursement": disb.name}
+			{
+				"company": "_Test Company",
+				"loan": loan.name,
+				"loan_disbursement": disb.name,
+				"as_on_date": "2024-12-31",
+			}
 		)
 		columns, data, _, chart = report
 		self.assertEqual(columns[0].get("fieldname"), "loan")
@@ -44,6 +55,95 @@ class TestLoanOutstandingReport(LendingTestSuite):
 			self.assertEqual(data[0].get(key), value)
 		self.assertGreaterEqual(data[0].get("pending_principal_amount") or 0, 0)
 		self.assertIn("data", chart)
+
+	def test_loan_outstanding_report_requires_as_on_date(self):
+		self.assertRaises(frappe.ValidationError, execute, {"company": "_Test Company"})
+
+	def test_loan_outstanding_report_excludes_disbursement_after_as_on_date(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			110000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+		disb = make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+		)
+
+		# as_on_date before the disbursement date: the loan should not appear yet
+		_, data, _, _ = execute(
+			{
+				"company": "_Test Company",
+				"loan": loan.name,
+				"loan_disbursement": disb.name,
+				"as_on_date": "2024-01-04",
+			}
+		)
+		self.assertFalse(data)
+
+		# as_on_date on/after the disbursement date: the loan should appear
+		_, data, _, _ = execute(
+			{
+				"company": "_Test Company",
+				"loan": loan.name,
+				"loan_disbursement": disb.name,
+				"as_on_date": "2024-01-05",
+			}
+		)
+		self.assertTrue(data)
+
+	def test_loan_outstanding_report_ignores_repayments_after_as_on_date(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			110000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+		disb = make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+		)
+
+		repayment = create_repayment_entry(loan.name, "2024-03-01", 20000)
+		repayment.submit()
+
+		filters_before_repayment = {
+			"company": "_Test Company",
+			"loan": loan.name,
+			"loan_disbursement": disb.name,
+			"as_on_date": "2024-02-15",
+		}
+		filters_after_repayment = {
+			**filters_before_repayment,
+			"as_on_date": "2024-12-31",
+		}
+
+		_, data_before, _, _ = execute(filters_before_repayment)
+		_, data_after, _, _ = execute(filters_after_repayment)
+
+		self.assertEqual(data_before[0].get("principal_amount_paid"), 0)
+		self.assertGreater(data_after[0].get("pending_principal_amount"), 0)
+		self.assertGreater(
+			data_before[0].get("pending_principal_amount"),
+			data_after[0].get("pending_principal_amount"),
+		)
 
 	def test_loan_outstanding_report_defines_columns(self):
 		columns = get_columns()

--- a/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
@@ -1,5 +1,9 @@
 import frappe
 
+from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
+from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
+	process_daily_loan_demands,
+)
 from lending.loan_management.report.loan_outstanding_report.loan_outstanding_report import (
 	execute,
 	get_chart_data,
@@ -144,6 +148,49 @@ class TestLoanOutstandingReport(LendingTestSuite):
 			data_before[0].get("pending_principal_amount"),
 			data_after[0].get("pending_principal_amount"),
 		)
+
+	def test_loan_outstanding_report_shows_loan_closed_after_as_on_date(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			110000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+		disb = make_loan_disbursement_entry(
+			loan.name,
+			loan.loan_amount,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+		)
+
+		process_daily_loan_demands(posting_date="2024-07-05", loan=loan.name)
+
+		payable_amount = calculate_amounts(against_loan=loan.name, posting_date="2024-07-05")[
+			"payable_amount"
+		]
+		create_repayment_entry(loan.name, "2024-07-05", payable_amount).submit()
+
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Closed")
+
+		# as_on_date before the closing repayment: the loan was still outstanding then,
+		# so it must still show up even though its current status is "Closed".
+		_, data, _, _ = execute(
+			{
+				"company": "_Test Company",
+				"loan": loan.name,
+				"loan_disbursement": disb.name,
+				"as_on_date": "2024-03-01",
+			}
+		)
+		self.assertTrue(data, "Loan should still appear for a date before it was closed")
+		self.assertGreater(data[0].get("pending_principal_amount"), 0)
 
 	def test_loan_outstanding_report_defines_columns(self):
 		columns = get_columns()

--- a/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
+++ b/lending/loan_management/report/loan_outstanding_report/test_loan_outstanding_report.py
@@ -1,6 +1,11 @@
 import frappe
+from frappe.utils import nowdate
 
-from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
+from lending.loan_management.doctype.loan_demand.loan_demand import create_loan_demand
+from lending.loan_management.doctype.loan_repayment.loan_repayment import (
+	calculate_amounts,
+	get_pending_principal_amount,
+)
 from lending.loan_management.doctype.process_loan_demand.process_loan_demand import (
 	process_daily_loan_demands,
 )
@@ -115,6 +120,70 @@ class TestLoanOutstandingReport(LendingTestSuite):
 
 		data_after, _ = self.run_report(loan, disb, "2024-03-01")
 		self.assertEqual(data_after[0].get("principal_overdue"), overdue_before_payment)
+
+	def test_loan_outstanding_report_uses_disbursed_status_as_on_date(self):
+		loan = create_loan(
+			"_Test Loan Customer",
+			"Term Loan Product 4",
+			110000,
+			"Repay Over Number of Periods",
+			6,
+			"Customer",
+			repayment_start_date="2024-02-05",
+			posting_date="2024-01-05",
+			rate_of_interest=10,
+		)
+		loan.submit()
+		disb = make_loan_disbursement_entry(
+			loan.name,
+			55000,
+			disbursement_date="2024-01-05",
+			repayment_start_date="2024-02-05",
+		)
+
+		# Only half the loan is out as of this date: outstanding should be
+		# bounded by what was actually disbursed, not the full EMI schedule.
+		data, _ = self.run_report(loan, disb, "2024-01-10")
+		self.assertLessEqual(data[0].get("pending_principal_amount"), 55000)
+
+		make_loan_disbursement_entry(
+			loan.name,
+			55000,
+			disbursement_date="2024-02-10",
+			repayment_start_date="2024-03-05",
+		)
+		loan.load_from_db()
+		self.assertEqual(loan.status, "Disbursed")
+
+		# Loan is now fully Disbursed, but the same earlier as_on_date must
+		# still reflect that only the first tranche was out at that time.
+		data, _ = self.run_report(loan, disb, "2024-01-10")
+		self.assertLessEqual(data[0].get("pending_principal_amount"), 55000)
+
+	def test_loan_outstanding_report_ignores_demand_paid_at_creation(self):
+		loan, disb = self.make_loan_and_disbursement()
+
+		# A demand created already fully paid (e.g. interest booked as part of
+		# a repayment, with no separate Loan Repayment Detail allocation).
+		create_loan_demand(
+			loan.name,
+			"2024-02-05",
+			"Normal",
+			"Interest",
+			500,
+			loan_disbursement=disb.name,
+			paid_amount=500,
+		)
+
+		data, _ = self.run_report(loan, disb, "2024-02-10")
+		self.assertEqual(data[0].get("interest_overdue"), 0)
+
+	def test_loan_outstanding_report_matches_live_calculation_for_today(self):
+		loan, disb = self.make_loan_and_disbursement()
+
+		data, _ = self.run_report(loan, disb, nowdate())
+		loan.load_from_db()
+		self.assertEqual(data[0].get("pending_principal_amount"), get_pending_principal_amount(loan))
 
 	def test_loan_outstanding_report_defines_columns(self):
 		columns = get_columns()


### PR DESCRIPTION
**Before**

The Loan Outstanding Report only ever showed live numbers as of today. There was no way to see what a loan's outstanding balance looked like on a past date. On top of that, once we added the date filter, we found the report was mixing "as of a date" numbers with fields that only ever hold today's value, so the date filter looked like it worked but quietly gave wrong numbers in several cases:

- A loan that is closed or written off today would disappear from the report entirely, even for a date when it still had money outstanding.
- A repayment or balance adjustment made after the chosen date could still reduce the outstanding amount shown for an earlier date.
- Overdue amounts could later drop to zero once a demand was paid, even when checking a date before that payment happened.
- A loan that was only partly disbursed on the chosen date could show the full loan schedule amount as outstanding, because the report used today's status to decide which formula to use.
- Some paid demands (booked without a normal repayment entry) were wrongly shown as fully overdue.
- Draft or cancelled disbursements could show up in the report by mistake.

**What changed**

- Added a required "As on Date" filter to the report.
- Principal outstanding, principal paid, interest paid, and overdue amounts are now calculated using only the disbursements, repayments, and demands that existed on or before the chosen date, not today's running totals.
- A loan's status on the chosen date is worked out from what was actually disbursed by then, instead of using today's status, so the right formula is picked.
- Reused the existing `get_pending_principal_amount` calculation instead of writing a new one, so the report matches the same logic used elsewhere in the app.
- Fixed a few small existing bugs found while doing this: draft/cancelled disbursements no longer show up, and paid-at-creation demands are no longer counted as overdue.
- Added tests covering each of these cases.