### PR TITLE
fix: add missing loan permission checks across lending APIs (backport #1433)

### DIFF
--- a/lending/api.py
+++ b/lending/api.py
@@ -81,6 +81,8 @@ def get_due_details(loan: str, as_on_date: str, loan_disbursement: str | None = 
 	API to get due details for a given loan account as on a specific date
 	"""
 
+	frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
 
 	amounts = calculate_amounts(loan, as_on_date, loan_disbursement=loan_disbursement)
@@ -112,6 +114,8 @@ def apply_charge(loan: str, charge_type: str, based_on: str, percentage: float |
 		get_pending_principal_amount,
 	)
 	from lending.loan_management.utils import create_charge_master, loan_accounting_enabled
+
+	frappe.has_permission("Loan", "write", doc=loan, throw=True)
 
 	create_charge_master(charge_type)
 

--- a/lending/loan_management/doctype/loan/loan.py
+++ b/lending/loan_management/doctype/loan/loan.py
@@ -875,7 +875,7 @@ def get_sanctioned_amount_limit(applicant_type, applicant, company):
 def request_loan_closure(loan: str, posting_date: str | date | datetime | None = None, auto_close: int = 0):
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
 
-	frappe.has_permission("Loan", "write", throw=True)
+	frappe.has_permission("Loan", "write", doc=loan, throw=True)
 
 	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	if not posting_date:
@@ -926,6 +926,8 @@ def request_loan_closure(loan: str, posting_date: str | date | datetime | None =
 
 @frappe.whitelist()
 def get_loan_application(loan_application: str):
+	frappe.has_permission("Loan Application", "read", doc=loan_application, throw=True)
+
 	loan = frappe.get_doc("Loan Application", loan_application)
 	if loan:
 		return loan.as_dict()
@@ -933,7 +935,7 @@ def get_loan_application(loan_application: str):
 
 @frappe.whitelist()
 def close_unsecured_term_loan(loan: str):
-	frappe.has_permission("Loan", "write", throw=True)
+	frappe.has_permission("Loan", "write", doc=loan, throw=True)
 
 	loan_details = frappe.db.get_value(
 		"Loan", {"name": loan}, ["status", "is_term_loan", "is_secured_loan"], as_dict=1
@@ -963,6 +965,7 @@ def make_loan_disbursement(
 	is_term_loan: int | None = None,
 ):
 	frappe.has_permission("Loan Disbursement", "create", throw=True)
+	frappe.has_permission("Loan", "read", doc=loan, throw=True)
 
 	loan_doc = frappe.get_doc("Loan", loan)
 	disbursement_entry = frappe.new_doc("Loan Disbursement")
@@ -1012,6 +1015,8 @@ def make_repayment_entry(
 	loan_disbursement: str | None = None,
 	as_dict: bool = False,
 ):
+	frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 	repayment_entry = frappe.new_doc("Loan Repayment")
 	repayment_entry.against_loan = loan
 	repayment_entry.applicant_type = applicant_type
@@ -1033,6 +1038,7 @@ def make_loan_write_off(loan: str, company: str | None = None, posting_date: str
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import calculate_amounts
 
 	frappe.has_permission("Loan Write Off", "write", throw=True)
+	frappe.has_permission("Loan", "write", doc=loan, throw=True)
 
 	if not company:
 		company = frappe.get_value("Loan", loan, "company")
@@ -1083,6 +1089,8 @@ def unpledge_security(
 		security_map = json.loads(security_map)
 
 	if loan:
+		frappe.has_permission("Loan", "write", doc=loan, throw=True)
+
 		pledge_qty_map = security_map or get_pledged_security_qty(loan=loan)
 		loan_doc = frappe.get_doc("Loan", loan)
 		unpledge_request = create_loan_security_release(
@@ -1090,6 +1098,8 @@ def unpledge_security(
 		)
 	# will unpledge qty based on Loan Security Assignment
 	elif loan_security_assignment:
+		frappe.has_permission("Loan Security Assignment", "read", doc=loan_security_assignment, throw=True)
+
 		security_map = {}
 		pledge_doc = frappe.get_doc("Loan Security Assignment", loan_security_assignment)
 		for security in pledge_doc.securities:
@@ -1147,6 +1157,7 @@ def get_shortfall_applicants():
 @frappe.whitelist()
 def make_refund_jv(loan: str, amount: float = 0, reference_number: str | None = None, reference_date: str | None = None, submit: int = 0):
 	frappe.has_permission("Journal Entry", "write", throw=True)
+	frappe.has_permission("Loan", "write", doc=loan, throw=True)
 
 	loan_details = frappe.db.get_value(
 		"Loan",
@@ -1211,7 +1222,7 @@ def update_days_past_due_in_loans(
 ) -> None:
 	from lending.loan_management.doctype.loan_repayment.loan_repayment import get_unpaid_demands
 
-	frappe.has_permission("Loan", "write", throw=True)
+	frappe.has_permission("Loan", "write", doc=loan_name, throw=True)
 
 	"""Update days past due in loans"""
 	posting_date = posting_date or getdate()

--- a/lending/loan_management/doctype/loan_application/loan_application.py
+++ b/lending/loan_management/doctype/loan_application/loan_application.py
@@ -322,11 +322,15 @@ def create_loan_security_assignment(loan_application: str | None = None, loan: s
 	frappe.has_permission("Loan Security Assignment", "create", throw=True)
 
 	if loan_application:
+		frappe.has_permission("Loan Application", "read", doc=loan_application, throw=True)
+
 		loan_application_doc = frappe.get_doc("Loan Application", loan_application)
 		applicant_type, applicant, company = frappe.db.get_value("Loan Application", loan_application,
 			["applicant_type", "applicant", "company"])
 		securities = loan_application_doc.get("proposed_pledges")
 	elif loan:
+		frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 		applicant_type, applicant, company = frappe.db.get_value("Loan", loan,
 			["applicant_type", "applicant", "company"])
 	elif not applicant:
@@ -395,6 +399,8 @@ def get_proposed_pledge(securities: str | list):
 def check_duplicate_customers(
 	applicant_phone_number: str | None = None, applicant_email_address: str | None = None
 ):
+	frappe.has_permission("Customer", "read", throw=True)
+
 	# check if there are customer entries with the same email and/or phone
 	customer_doc = frappe.qb.DocType("Customer")
 

--- a/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
+++ b/lending/loan_management/doctype/loan_disbursement/loan_disbursement.py
@@ -976,6 +976,8 @@ def get_total_pledged_security_value(loan=None, applicant=None, on_shortfall_che
 
 @frappe.whitelist()
 def get_disbursal_amount(loan: str, on_current_security_price: int = 0):
+	frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 	loan_details = frappe.get_value(
 		"Loan",
 		loan,

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2964,8 +2964,9 @@ def get_bulk_due_details(loans: list[str], posting_date: str | date | datetime, 
 	if not loans:
 		return []
 
-	for loan in loans:
-		frappe.has_permission("Loan", "read", doc=loan, throw=True)
+	permitted_loans = set(frappe.get_list("Loan", filters={"name": ["in", loans]}, pluck="name"))
+	if set(loans) - permitted_loans:
+		frappe.throw(_("Not permitted to view one or more of the selected loans"), frappe.PermissionError)
 
 	loan_details = frappe.db.get_all(
 		"Loan",

--- a/lending/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/lending/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -2964,6 +2964,9 @@ def get_bulk_due_details(loans: list[str], posting_date: str | date | datetime, 
 	if not loans:
 		return []
 
+	for loan in loans:
+		frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 	loan_details = frappe.db.get_all(
 		"Loan",
 		fields=[
@@ -3085,6 +3088,8 @@ def calculate_amounts(
 	loan_disbursement: str | None = None,
 	for_update: bool = False,
 ):
+	frappe.has_permission("Loan", "read", doc=against_loan, throw=True)
+
 	amounts = init_amounts()
 
 	if with_loan_details:

--- a/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
+++ b/lending/loan_management/doctype/loan_security_assignment/loan_security_assignment.py
@@ -255,9 +255,10 @@ def update_loan_securities_values(
 
 @frappe.whitelist()
 def release_loan_security_assignment(loan_security_assignment: str):
-	if frappe.has_permission("Loan Security Assignment", "write"):
-		frappe.db.set_value(
-			"Loan Security Assignment",
-			loan_security_assignment,
-			{"status": "Released", "release_time": now_datetime()},
-		)
+	frappe.has_permission("Loan Security Assignment", "write", doc=loan_security_assignment, throw=True)
+
+	frappe.db.set_value(
+		"Loan Security Assignment",
+		loan_security_assignment,
+		{"status": "Released", "release_time": now_datetime()},
+	)

--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.py
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.py
@@ -205,6 +205,11 @@ def update_sanctioned_loan_amount_for_applicant(applicant, applicant_type):
 
 @frappe.whitelist()
 def get_pledged_security_qty(loan: str | None = None, applicant: str | None = None):
+	if loan:
+		frappe.has_permission("Loan", "read", doc=loan, throw=True)
+	else:
+		frappe.has_permission("Loan", "read", throw=True)
+
 	current_pledges = {}
 
 	unpldge_doctype = frappe.qb.DocType("Unpledge")

--- a/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
+++ b/lending/loan_management/doctype/loan_security_shortfall/loan_security_shortfall.py
@@ -69,6 +69,8 @@ def update_shortfall_status(loan, security_value, on_cancel=0):
 
 @frappe.whitelist()
 def add_security(loan: str):
+	frappe.has_permission("Loan", "read", doc=loan, throw=True)
+
 	loan_details = frappe.db.get_value(
 		"Loan", loan, ["applicant", "company", "applicant_type"], as_dict=1
 	)

--- a/lending/loan_management/doctype/loan_transfer/loan_transfer.py
+++ b/lending/loan_management/doctype/loan_transfer/loan_transfer.py
@@ -176,6 +176,8 @@ class LoanTransfer(Document):
 
 @frappe.whitelist()
 def get_loans(branch: str, applicant: str | None = None):
+	frappe.has_permission("Loan", "read", throw=True)
+
 	branch_fieldname = frappe.db.get_value(
 		"Accounting Dimension", {"document_type": "Branch"}, "fieldname"
 	)


### PR DESCRIPTION
**Problem**

Many whitelisted APIs in the lending app take a loan name (or a related document like Loan Application or Loan Security Assignment) and use it to read or change data, without checking if the calling user has access to that record. This means any logged-in user could pass any loan name and get its money details, or make a change to a loan that is not theirs.

**Fixed APIs**

- lending/api.py: get_due_details, apply_charge
- loan.py: request_loan_closure, close_unsecured_term_loan, get_loan_application, make_loan_disbursement, make_repayment_entry, make_loan_write_off, unpledge_security, make_refund_jv, update_days_past_due_in_loans
- loan_application.py: create_loan_security_assignment, check_duplicate_customers
- loan_security_shortfall.py: add_security
- loan_security_release.py: get_pledged_security_qty
- loan_security_assignment.py: release_loan_security_assignment
- loan_repayment.py: get_bulk_due_details, calculate_amounts
- loan_disbursement.py: get_disbursal_amount
- loan_transfer.py: get_loans

**Fix**

Each one now checks read or write access on the actual record before using it