### PR TITLE
fix: show customer as a dropdown in loan security release

### DIFF
--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.json
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.json
@@ -31,10 +31,11 @@
   {
    "fetch_from": "loan.applicant",
    "fieldname": "applicant",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Applicant",
+   "options": "applicant_type",
    "reqd": 1,
    "search_index": 1
   },
@@ -128,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-12 08:59:16.690887",
+ "modified": "2026-09-09 11:05:00.000000",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Release",

--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.json
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.json
@@ -129,7 +129,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-09-09 11:05:00.000000",
+ "modified": "2026-09-09 11:08:04.041456",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Release",

--- a/lending/loan_management/doctype/loan_security_release/loan_security_release.py
+++ b/lending/loan_management/doctype/loan_security_release/loan_security_release.py
@@ -25,7 +25,7 @@ class LoanSecurityRelease(Document):
 		from lending.loan_management.doctype.unpledge.unpledge import Unpledge
 
 		amended_from: DF.Link | None
-		applicant: DF.Data
+		applicant: DF.DynamicLink
 		applicant_type: DF.Literal["Employee", "Member", "Customer"]
 		company: DF.Link
 		description: DF.Text | None


### PR DESCRIPTION
**Problem**
In Loan Security Release, the customer field (applicant) was a data field. Users had to type the full name by hand, which could lead to typing mistakes.
fixes: https://github.com/frappe/lending/issues/1438

**Fix**
Changed the applicant field from a data field to a dynamic link field, the same as it works in other loan doctypes (Loan, Loan Disbursement, Loan Repayment, and others). Now it shows a proper dropdown with search based on the applicant type.